### PR TITLE
Phase 3: Intelligence — query expansion, MMR, contradiction detection

### DIFF
--- a/src/contradiction.ts
+++ b/src/contradiction.ts
@@ -1,0 +1,172 @@
+/**
+ * Contradiction detection — finds and resolves conflicting memories.
+ *
+ * When a new memory is saved, searches for existing memories on the same
+ * topic. Uses the local LLM to classify the relationship:
+ *   - same: identical fact, no action
+ *   - update: new supersedes old, decay old confidence
+ *   - contradiction: direct conflict, decay old confidence more aggressively
+ */
+
+import type { Store, SearchResult } from "./store.ts";
+import { embed } from "./embedder.ts";
+import { generate } from "./llm.ts";
+
+const OVERLAP_THRESHOLD = 0.7; // minimum vector similarity to consider overlapping
+const UPDATE_DECAY = 0.15;     // confidence reduction for superseded memories
+const CONTRADICTION_DECAY = 0.25;
+const CONFIDENCE_FLOOR = 0.2;
+
+const SYSTEM_PROMPT = `You classify the relationship between two memories. Given an existing memory and a new memory, respond with exactly one word:
+
+- same: they express the same fact or decision
+- update: the new memory supersedes or refines the old one
+- contradiction: they directly conflict
+- unrelated: different topics
+
+Respond with ONLY the classification word, nothing else.`;
+
+type Relationship = "same" | "update" | "contradiction" | "unrelated";
+
+/**
+ * Check a new memory against existing memories for contradictions.
+ * Returns the number of memories whose confidence was decayed.
+ */
+export async function checkContradictions(
+  store: Store,
+  newTitle: string,
+  newContent: string,
+  newDocId: number,
+): Promise<{ decayed: number; relationships: Array<{ docId: number; title: string; relationship: Relationship }> }> {
+  const relationships: Array<{ docId: number; title: string; relationship: Relationship }> = [];
+  let decayed = 0;
+
+  // Find overlapping memories via vector similarity
+  let overlapping: SearchResult[] = [];
+  try {
+    const queryEmb = await embed(`title: ${newTitle} | text: ${newContent}`);
+    overlapping = store.searchVector(queryEmb, 5);
+  } catch {
+    return { decayed: 0, relationships: [] };
+  }
+
+  // Filter to genuinely overlapping results (exclude self)
+  const candidates = overlapping.filter(
+    (r) => r.doc_id !== newDocId && r.score >= OVERLAP_THRESHOLD,
+  );
+
+  if (candidates.length === 0) {
+    return { decayed: 0, relationships: [] };
+  }
+
+  // Classify each relationship via LLM
+  for (const candidate of candidates) {
+    try {
+      const prompt = `Existing memory:\nTitle: ${candidate.title}\nContent: ${candidate.content.slice(0, 500)}\n\nNew memory:\nTitle: ${newTitle}\nContent: ${newContent.slice(0, 500)}`;
+
+      const response = await generate(SYSTEM_PROMPT, prompt, 10);
+      const classification = response.trim().toLowerCase() as Relationship;
+
+      if (!["same", "update", "contradiction", "unrelated"].includes(classification)) {
+        continue;
+      }
+
+      relationships.push({
+        docId: candidate.doc_id,
+        title: candidate.title,
+        relationship: classification,
+      });
+
+      // Apply confidence decay
+      if (classification === "update") {
+        const doc = store.get(candidate.doc_id);
+        if (doc) {
+          const newConfidence = Math.max(CONFIDENCE_FLOOR, doc.confidence - UPDATE_DECAY);
+          store.db.run(
+            "UPDATE documents SET confidence = ?, updated_at = datetime('now') WHERE id = ?",
+            [newConfidence, candidate.doc_id],
+          );
+          store.addRelation(newDocId, candidate.doc_id, "supersedes", 0.8);
+          decayed++;
+        }
+      } else if (classification === "contradiction") {
+        const doc = store.get(candidate.doc_id);
+        if (doc) {
+          const newConfidence = Math.max(CONFIDENCE_FLOOR, doc.confidence - CONTRADICTION_DECAY);
+          store.db.run(
+            "UPDATE documents SET confidence = ?, updated_at = datetime('now') WHERE id = ?",
+            [newConfidence, candidate.doc_id],
+          );
+          store.addRelation(newDocId, candidate.doc_id, "contradicts", 0.9);
+          decayed++;
+        }
+      } else if (classification === "same") {
+        store.addRelation(newDocId, candidate.doc_id, "related", 1.0);
+      }
+    } catch {
+      // LLM classification failed for this candidate — skip
+      continue;
+    }
+  }
+
+  return { decayed, relationships };
+}
+
+// ── Confidence Decay ────────────────────────────────────────────────────────
+
+const HALF_LIVES: Record<string, number | null> = {
+  decision: null,
+  preference: null,
+  antipattern: null,
+  observation: 90,
+  research: 90,
+  project: 120,
+  handoff: 30,
+  note: 60,
+};
+
+/**
+ * Apply time-based confidence decay to all documents.
+ * Documents with access activity decay slower (access reinforcement).
+ * Returns the number of documents whose confidence was updated.
+ */
+export function applyConfidenceDecay(store: Store): number {
+  let updated = 0;
+
+  for (const [contentType, halfLife] of Object.entries(HALF_LIVES)) {
+    if (halfLife === null) continue;
+
+    // Get documents of this type that haven't been invalidated
+    const docs = store.db.query<any, [string]>(`
+      SELECT id, confidence, access_count, pinned,
+             CAST(julianday('now') - julianday(updated_at) AS REAL) AS age_days
+      FROM documents
+      WHERE content_type = ?
+        AND invalidated_at IS NULL
+        AND pinned = 0
+    `).all(contentType);
+
+    for (const doc of docs) {
+      // Access reinforcement: each access extends effective half-life
+      // More accesses = slower decay (up to 3x half-life extension)
+      const accessMultiplier = Math.min(3.0, 1.0 + doc.access_count * 0.1);
+      const effectiveHalfLife = halfLife * accessMultiplier;
+
+      // Exponential decay: confidence * 2^(-age/halflife)
+      const decayFactor = Math.pow(2, -doc.age_days / effectiveHalfLife);
+      const baseConfidence = store.defaultConfidence(contentType as any);
+      const decayedConfidence = Math.max(CONFIDENCE_FLOOR, baseConfidence * decayFactor);
+
+      // Only update if confidence changed meaningfully
+      if (Math.abs(decayedConfidence - doc.confidence) > 0.01) {
+        store.db.run(
+          "UPDATE documents SET confidence = ? WHERE id = ?",
+          [decayedConfidence, doc.id],
+        );
+        updated++;
+      }
+    }
+  }
+
+  return updated;
+}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -281,6 +281,104 @@ server.tool(
   },
 );
 
+// ── Profile Tools ───────────────────────────────────────────────────────────
+
+server.tool(
+  "profile_get",
+  "Get a synthesized user profile from stored preferences and decisions. Shows what mnemon knows about the user's habits, preferences, and key decisions.",
+  {},
+  async () => {
+    const preferences = store.timeline(50, "preference" as any);
+    const decisions = store.timeline(50, "decision" as any);
+
+    if (preferences.length === 0 && decisions.length === 0) {
+      return {
+        content: [{ type: "text" as const, text: "No profile data yet. Preferences and decisions will be collected automatically over time." }],
+      };
+    }
+
+    const sections: string[] = [];
+
+    if (preferences.length > 0) {
+      sections.push("## Preferences\n" +
+        preferences.map((p: any) => `- **${p.title}**: ${p.doc.slice(0, 200)}`).join("\n"));
+    }
+
+    if (decisions.length > 0) {
+      sections.push("## Key Decisions\n" +
+        decisions.map((d: any) => `- **${d.title}**: ${d.doc.slice(0, 200)}`).join("\n"));
+    }
+
+    return {
+      content: [{ type: "text" as const, text: sections.join("\n\n") }],
+    };
+  },
+);
+
+server.tool(
+  "profile_update",
+  "Manually add a fact to the user profile. Saved as a preference memory.",
+  {
+    title: z.string().describe("Short title for the preference"),
+    content: z.string().describe("Description of the preference or habit"),
+  },
+  async ({ title, content }) => {
+    const docId = store.save({
+      title,
+      content,
+      content_type: "preference",
+      source_client: "mcp-profile",
+    });
+
+    const doc = store.get(docId);
+    if (doc) {
+      embedDocument(store, doc.hash, title, content).catch(() => {});
+    }
+
+    return {
+      content: [{ type: "text" as const, text: `Profile updated — saved preference #${docId}: "${title}"` }],
+    };
+  },
+);
+
+// ── Contradiction Check Tool ────────────────────────────────────────────────
+
+server.tool(
+  "memory_check_contradictions",
+  "Check a memory for contradictions against existing memories. Uses vector similarity + LLM classification to find conflicts.",
+  {
+    id: z.number().describe("Document ID to check"),
+  },
+  async ({ id }) => {
+    const doc = store.get(id);
+    if (!doc) {
+      return {
+        content: [{ type: "text" as const, text: `Memory #${id} not found.` }],
+      };
+    }
+
+    const { checkContradictions } = await import("./contradiction.ts");
+    const result = await checkContradictions(store, doc.title, (doc as any).doc, id);
+
+    if (result.relationships.length === 0) {
+      return {
+        content: [{ type: "text" as const, text: `No contradictions found for memory #${id}.` }],
+      };
+    }
+
+    const lines = result.relationships
+      .map((r) => `- #${r.docId} "${r.title}" → **${r.relationship}**`)
+      .join("\n");
+
+    return {
+      content: [{
+        type: "text" as const,
+        text: `Contradiction check for #${id} "${doc.title}":\n${lines}\n\n${result.decayed} memories had their confidence decayed.`,
+      }],
+    };
+  },
+);
+
 // ── Start Server ────────────────────────────────────────────────────────────
 
 async function main() {

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,5 +1,6 @@
 /**
- * Search pipeline — BM25 + vector + RRF fusion + composite scoring.
+ * Search pipeline — BM25 + vector + query expansion + RRF fusion +
+ * composite scoring + MMR diversity filtering.
  */
 
 import type { Store, SearchResult, ContentType } from "./store.ts";
@@ -12,6 +13,7 @@ export interface SearchOptions {
   limit?: number;
   contentType?: ContentType;
   useVector?: boolean;
+  useExpansion?: boolean;
 }
 
 export interface ScoredResult extends SearchResult {
@@ -23,17 +25,13 @@ export interface ScoredResult extends SearchResult {
 
 const RRF_K = 60;
 
-function rrfFuse(
-  ...resultSets: SearchResult[][]
-): SearchResult[] {
+function rrfFuse(...resultSets: SearchResult[][]): SearchResult[] {
   const scores = new Map<number, { score: number; result: SearchResult }>();
 
   for (const results of resultSets) {
     for (let rank = 0; rank < results.length; rank++) {
       const r = results[rank]!;
       const rrfScore = 1 / (RRF_K + rank + 1);
-
-      // Top-rank bonuses (from ClawMem)
       const bonus = rank === 0 ? 0.05 : rank <= 2 ? 0.02 : 0;
 
       const existing = scores.get(r.doc_id);
@@ -58,8 +56,6 @@ function rrfFuse(
 function computeRecency(createdAt: string): number {
   const ageMs = Date.now() - new Date(createdAt).getTime();
   const ageDays = ageMs / (1000 * 60 * 60 * 24);
-
-  // Exponential decay: half-life of 30 days
   return Math.exp(-0.693 * ageDays / 30);
 }
 
@@ -77,28 +73,122 @@ function compositeScore(result: SearchResult): ScoredResult {
   };
 }
 
-// ── Main Search Function ────────────────────────────────────────────────────
+// ── MMR Diversity Filtering ─────────────────────────────────────────────────
+
+function bigrams(text: string): Set<string> {
+  const tokens = text.toLowerCase().split(/\s+/);
+  const bg = new Set<string>();
+  for (let i = 0; i < tokens.length - 1; i++) {
+    bg.add(`${tokens[i]} ${tokens[i + 1]}`);
+  }
+  return bg;
+}
+
+function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1;
+  let intersection = 0;
+  for (const item of a) {
+    if (b.has(item)) intersection++;
+  }
+  const union = a.size + b.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+const MMR_THRESHOLD = 0.6;
+
+function mmrFilter(results: ScoredResult[]): ScoredResult[] {
+  if (results.length <= 1) return results;
+
+  const selected: ScoredResult[] = [results[0]!];
+  const selectedBigrams: Set<string>[] = [bigrams(results[0]!.content)];
+
+  for (let i = 1; i < results.length; i++) {
+    const candidate = results[i]!;
+    const candidateBg = bigrams(candidate.content);
+
+    const tooSimilar = selectedBigrams.some(
+      (bg) => jaccardSimilarity(candidateBg, bg) > MMR_THRESHOLD,
+    );
+
+    if (!tooSimilar) {
+      selected.push(candidate);
+      selectedBigrams.push(candidateBg);
+    } else {
+      // Demote rather than remove — reduce score by 50%
+      selected.push({ ...candidate, composite_score: candidate.composite_score * 0.5 });
+      selectedBigrams.push(candidateBg);
+    }
+  }
+
+  return selected.sort((a, b) => b.composite_score - a.composite_score);
+}
+
+// ── Query Expansion ─────────────────────────────────────────────────────────
 
 /**
- * Hybrid search: BM25 + vector + RRF fusion + composite scoring.
- * Falls back to BM25-only if useVector is false (remote mode).
+ * Expand a query into lexical/semantic variants using the local LLM.
+ * Falls back to the original query if expansion fails.
  */
+async function expandQuery(query: string): Promise<string[]> {
+  try {
+    const { generate } = await import("./llm.ts");
+    const response = await generate(
+      "Generate 3 alternative search queries for the given query. Output one per line, no numbering or bullets. Keep them short and diverse — include synonyms, related concepts, and different phrasings.",
+      query,
+      200,
+    );
+
+    const expansions = response
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.length > 3 && l.length < 200);
+
+    return expansions.slice(0, 3);
+  } catch {
+    return [];
+  }
+}
+
+// ── Main Search Function ────────────────────────────────────────────────────
+
 export async function search(
   store: Store,
   opts: SearchOptions,
 ): Promise<ScoredResult[]> {
   const limit = opts.limit ?? 10;
   const useVector = opts.useVector ?? true;
+  const useExpansion = opts.useExpansion ?? false;
 
   // BM25 search
   const bm25Results = store.searchBM25(opts.query, limit * 2);
 
+  // Skip expansion if BM25 already has a strong signal
+  const strongBm25 =
+    bm25Results.length > 0 &&
+    bm25Results[0]!.score >= 0.85 &&
+    (bm25Results.length < 2 || bm25Results[0]!.score - bm25Results[1]!.score >= 0.15);
+
+  // Query expansion (optional, skip if strong BM25 match)
+  let expansionResults: SearchResult[] = [];
+  if (useExpansion && !strongBm25) {
+    const expanded = await expandQuery(opts.query);
+    for (const eq of expanded) {
+      const results = store.searchBM25(eq, limit);
+      expansionResults.push(...results);
+    }
+  }
+
   if (!useVector) {
-    // BM25-only mode (remote server, no GPU)
-    return bm25Results
-      .map(compositeScore)
-      .sort((a, b) => b.composite_score - a.composite_score)
-      .slice(0, limit);
+    const allBm25 = expansionResults.length > 0
+      ? rrfFuse(bm25Results, expansionResults)
+      : bm25Results;
+
+    return mmrFilter(
+      allBm25
+        .map(compositeScore)
+        .sort((a, b) => b.composite_score - a.composite_score)
+        .slice(0, limit),
+    );
   }
 
   // Vector search
@@ -107,25 +197,27 @@ export async function search(
     const queryEmbedding = await embed(`query: ${opts.query}`);
     vectorResults = store.searchVector(queryEmbedding, limit * 2);
   } catch (err) {
-    // Vector search may fail if no embeddings exist yet
     console.error("Vector search failed, using BM25 only:", err);
   }
 
-  // Fuse results
-  const fused =
-    vectorResults.length > 0
-      ? rrfFuse(bm25Results, vectorResults)
-      : bm25Results;
+  // Fuse all result sets
+  const resultSets = [bm25Results];
+  if (vectorResults.length > 0) resultSets.push(vectorResults);
+  if (expansionResults.length > 0) resultSets.push(expansionResults);
 
-  // Apply composite scoring
+  const fused = resultSets.length > 1 ? rrfFuse(...resultSets) : bm25Results;
+
+  // Composite scoring + MMR
   const scored = fused
     .map(compositeScore)
     .sort((a, b) => b.composite_score - a.composite_score);
 
-  // Filter by content type if specified
   const filtered = opts.contentType
     ? scored.filter((r) => r.content_type === opts.contentType)
     : scored;
 
-  return filtered.slice(0, limit);
+  return mmrFilter(filtered.slice(0, limit));
 }
+
+// Exported for testing
+export { bigrams, jaccardSimilarity, mmrFilter, computeRecency, rrfFuse };

--- a/src/store.ts
+++ b/src/store.ts
@@ -224,7 +224,7 @@ export class Store {
     const hash = sha256(opts.content);
     const contentType = opts.content_type ?? "note";
     const memoryType = opts.memory_type ?? MEMORY_TYPE_MAP[contentType] ?? "semantic";
-    const confidence = opts.confidence ?? this._defaultConfidence(contentType);
+    const confidence = opts.confidence ?? this.defaultConfidence(contentType);
 
     // Upsert content (idempotent)
     this.db.run(
@@ -552,7 +552,7 @@ export class Store {
     return { archived: dryRun ? 0 : candidates.length, candidates };
   }
 
-  private _defaultConfidence(contentType: ContentType): number {
+  defaultConfidence(contentType: ContentType): number {
     const defaults: Record<ContentType, number> = {
       decision: 0.85,
       preference: 0.80,

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,0 +1,173 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { Store } from "../src/store.ts";
+import {
+  bigrams,
+  jaccardSimilarity,
+  mmrFilter,
+  computeRecency,
+  rrfFuse,
+  type ScoredResult,
+} from "../src/search.ts";
+import { applyConfidenceDecay } from "../src/contradiction.ts";
+import { unlinkSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const TEST_DB = join(import.meta.dir, "search-test.sqlite");
+const TEST_VEC = join(import.meta.dir, "search-test.vec");
+
+// ── MMR Tests ────────────────────────────────────────────────────────────────
+
+test("bigrams: extracts word pairs", () => {
+  const bg = bigrams("the quick brown fox");
+  expect(bg.size).toBe(3);
+  expect(bg.has("the quick")).toBe(true);
+  expect(bg.has("quick brown")).toBe(true);
+  expect(bg.has("brown fox")).toBe(true);
+});
+
+test("jaccardSimilarity: identical sets", () => {
+  const a = new Set(["a b", "b c"]);
+  expect(jaccardSimilarity(a, a)).toBeCloseTo(1.0);
+});
+
+test("jaccardSimilarity: disjoint sets", () => {
+  const a = new Set(["a b"]);
+  const b = new Set(["c d"]);
+  expect(jaccardSimilarity(a, b)).toBe(0);
+});
+
+test("jaccardSimilarity: partial overlap", () => {
+  const a = new Set(["a b", "b c", "c d"]);
+  const b = new Set(["a b", "b c", "d e"]);
+  expect(jaccardSimilarity(a, b)).toBeCloseTo(0.5);
+});
+
+test("mmrFilter: demotes similar results", () => {
+  const results: ScoredResult[] = [
+    makeScoredResult(1, "Use SQLite for database storage layer", 0.9),
+    makeScoredResult(2, "Use SQLite for database storage implementation", 0.85), // very similar
+    makeScoredResult(3, "Deploy to EC2 using systemd services", 0.7), // different topic
+  ];
+
+  const filtered = mmrFilter(results);
+  // Result 2 should be demoted due to similarity with result 1
+  const result2 = filtered.find((r) => r.doc_id === 2)!;
+  expect(result2.composite_score).toBeLessThan(0.85);
+  // Result 3 should keep its score (different topic)
+  const result3 = filtered.find((r) => r.doc_id === 3)!;
+  expect(result3.composite_score).toBe(0.7);
+});
+
+// ── RRF Tests ────────────────────────────────────────────────────────────────
+
+test("rrfFuse: merges multiple result sets", () => {
+  const set1 = [
+    makeSearchResult(1, 0.9),
+    makeSearchResult(2, 0.5),
+  ];
+  const set2 = [
+    makeSearchResult(2, 0.8), // appears in both
+    makeSearchResult(3, 0.6),
+  ];
+
+  const fused = rrfFuse(set1, set2);
+  // Doc 2 appears in both sets, should have highest fused score
+  expect(fused[0]!.doc_id).toBe(2);
+  expect(fused.length).toBe(3);
+});
+
+// ── Recency Tests ────────────────────────────────────────────────────────────
+
+test("computeRecency: recent = high score", () => {
+  const recent = computeRecency(new Date().toISOString());
+  expect(recent).toBeGreaterThan(0.95);
+});
+
+test("computeRecency: old = low score", () => {
+  const old = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
+  const score = computeRecency(old);
+  expect(score).toBeLessThan(0.2);
+});
+
+// ── Confidence Decay Tests ──────────────────────────────────────────────────
+
+let store: Store;
+
+beforeEach(() => {
+  for (const f of [TEST_DB, TEST_VEC, TEST_DB + "-wal", TEST_DB + "-shm"]) {
+    if (existsSync(f)) unlinkSync(f);
+  }
+  store = new Store(TEST_DB);
+});
+
+afterEach(() => {
+  store.close();
+  for (const f of [TEST_DB, TEST_VEC, TEST_DB + "-wal", TEST_DB + "-shm"]) {
+    if (existsSync(f)) unlinkSync(f);
+  }
+});
+
+test("confidence decay: decisions never decay", () => {
+  store.save({ title: "Architecture decision", content: "Use microservices.", content_type: "decision" });
+
+  // Simulate aging the document
+  store.db.run("UPDATE documents SET updated_at = datetime('now', '-365 days')");
+
+  const decayed = applyConfidenceDecay(store);
+  expect(decayed).toBe(0); // decisions don't decay
+});
+
+test("confidence decay: notes decay over time", () => {
+  const id = store.save({ title: "Temporary note", content: "Some note.", content_type: "note" });
+
+  // Simulate aging
+  store.db.run("UPDATE documents SET updated_at = datetime('now', '-120 days')");
+
+  const decayed = applyConfidenceDecay(store);
+  expect(decayed).toBe(1);
+
+  const doc = store.get(id);
+  expect(doc!.confidence).toBeLessThan(0.5); // decayed from 0.5
+});
+
+test("confidence decay: pinned documents exempt", () => {
+  const id = store.save({ title: "Pinned note", content: "Important.", content_type: "note" });
+  store.pin(id);
+
+  store.db.run("UPDATE documents SET updated_at = datetime('now', '-120 days') WHERE id = ?", [id]);
+
+  const decayed = applyConfidenceDecay(store);
+  expect(decayed).toBe(0); // pinned = exempt
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSearchResult(docId: number, score: number): any {
+  return {
+    doc_id: docId,
+    title: `Doc ${docId}`,
+    content: `Content for document ${docId}`,
+    content_type: "note",
+    memory_type: "semantic",
+    confidence: 0.5,
+    created_at: new Date().toISOString(),
+    score,
+    source: "bm25",
+  };
+}
+
+function makeScoredResult(docId: number, content: string, score: number): ScoredResult {
+  return {
+    doc_id: docId,
+    title: `Doc ${docId}`,
+    content,
+    content_type: "note" as any,
+    memory_type: "semantic" as any,
+    confidence: 0.5,
+    created_at: new Date().toISOString(),
+    score,
+    source: "fused",
+    composite_score: score,
+    recency_score: 1.0,
+  };
+}


### PR DESCRIPTION
## Summary
- Query expansion via local QMD 1.7B — generates alternative search queries, skips when BM25 has strong signal
- MMR diversity filtering — Jaccard bigram similarity > 0.6 demotes near-duplicates by 50%
- Contradiction detection — vector overlap + LLM classification (same/update/contradiction), auto-decays confidence on superseded/contradicted memories
- Confidence decay — exponential by content type half-life, access reinforcement (up to 3x), decisions/preferences never decay
- Profile tools — profile_get, profile_update, memory_check_contradictions
- 11 new tests (32 total passing)

Depends on: PR #2 (Phase 2)

## Test plan
- [x] `bun test` — 32/32 passing
- [ ] Manual: verify MMR deduplicates similar search results
- [ ] Manual: verify contradiction detection decays old memory confidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)