### PR TITLE
Phase 5: Polish — tests, type checking, documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,34 +5,40 @@ Universal long-term memory layer for AI agents via MCP.
 ## Stack
 
 - **Runtime:** Bun (use `bun` not `node`, `bun test` not `jest`, `bun:sqlite` not `better-sqlite3`)
-- **Storage:** SQLite + FTS5 + sqlite-vec (single-file vault at `~/.mnemon/default.sqlite`)
+- **Storage:** SQLite + FTS5 + in-process vector store (single-file vault at `~/.mnemon/default.sqlite`)
 - **Embedding:** EmbeddingGemma-300M (GGUF, 768d, auto-downloaded via node-llama-cpp)
-- **MCP:** @modelcontextprotocol/sdk (stdio transport)
+- **LLM:** QMD-query-expansion-1.7B (GGUF, for observation extraction + query expansion)
+- **MCP:** @modelcontextprotocol/sdk (stdio + Streamable HTTP transports)
 
 ## Key files
 
 ```
-src/store.ts      # SQLite storage layer — content, documents, FTS5, vectors, relations
-src/embedder.ts   # EmbeddingGemma-300M via node-llama-cpp, fragment-level embedding
-src/search.ts     # BM25 + vector + RRF fusion + composite scoring
-src/mcp.ts        # MCP server — 10 tools (retrieval, mutation, lifecycle)
-src/index.ts      # CLI dispatcher (serve, status, search, save, setup)
-bin/mnemon        # CLI entry point
+src/store.ts                    # SQLite storage — content, documents, FTS5, relations
+src/vecstore.ts                 # In-process vector store — brute-force cosine over Float32Arrays
+src/embedder.ts                 # EmbeddingGemma-300M via node-llama-cpp
+src/llm.ts                     # QMD-1.7B for extraction + expansion
+src/search.ts                  # BM25 + vector + RRF fusion + MMR + composite scoring
+src/contradiction.ts           # Contradiction detection + confidence decay
+src/mcp.ts                     # MCP server (stdio) — 13 tools
+src/server.ts                  # Remote HTTP server (Streamable HTTP for Claude.ai/iOS)
+src/sync.ts                    # S3 vault sync (push/pull)
+src/index.ts                   # CLI dispatcher
+src/hooks/framework.ts         # Hook framework — stdin/stdout, dedup, noise filtering
+src/hooks/context-surfacing.ts # UserPromptSubmit — search + inject context
+src/hooks/session-extractor.ts # Stop — extract observations from transcript
+src/hooks/handoff-generator.ts # Stop — session summary for continuity
+bin/mnemon                     # CLI entry point
 ```
 
 ## Commands
 
 ```bash
-bun run src/index.ts serve      # Start MCP server (stdio)
-bun run src/index.ts status     # Vault health
-bun run src/index.ts search <q> # Search memories
-bun run src/index.ts save <title> <content>  # Save a memory
-bun run src/index.ts setup claude-code       # Configure Claude Code integration
-bun test                        # Run tests
+bun run src/index.ts serve          # MCP server (stdio)
+bun run src/index.ts serve-remote   # HTTP server (Streamable HTTP)
+bun run src/index.ts status         # Vault health
+bun run src/index.ts search <q>     # Search memories
+bun run src/index.ts save <t> <c>   # Save a memory
+bun run src/index.ts setup <target> # Configure (claude-code, cursor, gemini, hooks)
+bun run src/index.ts sync <push|pull>  # S3 vault sync
+bun test                            # Run tests (50 tests)
 ```
-
-## Architecture
-
-Hybrid local + remote. Phase 1 is local-only (stdio MCP).
-- Local: GGUF models on Metal, Claude Code hooks for auto-capture, hybrid search
-- Remote (Phase 4): Streamable HTTP on EC2, BM25-only, S3 vault sync

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Bun](https://img.shields.io/badge/bun-1.3+-blue.svg)]()
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-37_passing-brightgreen.svg)]()
+[![Tests](https://img.shields.io/badge/tests-50_passing-brightgreen.svg)]()
 [![CI](https://github.com/cipher813/mnemon/actions/workflows/ci.yml/badge.svg)](https://github.com/cipher813/mnemon/actions/workflows/ci.yml)
 
 # mnemon (μνήμων)
@@ -91,6 +91,9 @@ Or manually add to your MCP config:
 | `memory_status` | Vault health stats |
 | `memory_sweep` | Archive stale memories past their half-life |
 | `memory_rebuild` | Re-embed all documents (after model upgrade) |
+| `memory_check_contradictions` | Check a memory for conflicts with existing memories |
+| `profile_get` | Synthesized user profile from preferences + decisions |
+| `profile_update` | Add a preference to the user profile |
 
 ## Memory types
 
@@ -147,13 +150,27 @@ MNEMON_S3_BUCKET=my-bucket bun run src/index.ts sync pull
 
 ## Architecture
 
-**Phase 1 (current):** Local MCP server via stdio. SQLite + FTS5 for keyword search, in-process brute-force cosine for vector search. EmbeddingGemma-300M for embeddings via node-llama-cpp on Metal.
+**Phase 1:** Local MCP server via stdio. SQLite + FTS5 for keyword search, in-process brute-force cosine for vector search. EmbeddingGemma-300M for embeddings via node-llama-cpp on Metal.
 
-**Phase 2 (planned):** Claude Code hooks for automatic memory capture — context surfacing on every prompt, session extraction on exit, handoff generation. 90% of memory happens without agent intervention.
+**Phase 2:** Claude Code hooks for automatic memory capture — context surfacing on every prompt, session extraction on exit, handoff generation. 90% of memory happens without agent intervention.
 
-**Phase 3 (planned):** Query expansion, cross-encoder reranking, contradiction detection, confidence decay.
+**Phase 3:** Query expansion via local LLM, MMR diversity filtering, contradiction detection with confidence decay, user profile tools.
 
-**Phase 4 (current):** Remote Streamable HTTP server for Claude.ai web + iOS access. S3 vault sync between local and remote. Bearer token auth.
+**Phase 4:** Remote Streamable HTTP server for Claude.ai web + iOS access. S3 vault sync between local and remote. Bearer token auth.
+
+**Phase 5:** Test coverage (50 tests), type checking, documentation.
+
+## Claude Code hooks
+
+mnemon automatically captures memories via Claude Code hooks — no manual intervention needed:
+
+| Hook | Event | What it does |
+|------|-------|-------------|
+| Context surfacing | UserPromptSubmit (8s) | Searches vault, injects relevant memories as XML context |
+| Session extractor | Stop (30s) | Extracts observations from transcript via local 1.7B LLM |
+| Handoff generator | Stop (30s) | Generates session summary for continuity |
+
+Install with: `bun run src/index.ts setup hooks`
 
 ## Stack
 

--- a/src/search.ts
+++ b/src/search.ts
@@ -183,12 +183,15 @@ export async function search(
       ? rrfFuse(bm25Results, expansionResults)
       : bm25Results;
 
-    return mmrFilter(
-      allBm25
-        .map(compositeScore)
-        .sort((a, b) => b.composite_score - a.composite_score)
-        .slice(0, limit),
-    );
+    const scored = allBm25
+      .map(compositeScore)
+      .sort((a, b) => b.composite_score - a.composite_score);
+
+    const filtered = opts.contentType
+      ? scored.filter((r) => r.content_type === opts.contentType)
+      : scored;
+
+    return mmrFilter(filtered.slice(0, limit));
   }
 
   // Vector search

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,0 +1,167 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { Store } from "../src/store.ts";
+import { search } from "../src/search.ts";
+import { VecStore } from "../src/vecstore.ts";
+import { unlinkSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const TEST_DB = join(import.meta.dir, "integration-test.sqlite");
+const TEST_VEC = join(import.meta.dir, "integration-test.vec");
+
+let store: Store;
+
+beforeEach(() => {
+  for (const f of [TEST_DB, TEST_VEC, TEST_DB + "-wal", TEST_DB + "-shm"]) {
+    if (existsSync(f)) unlinkSync(f);
+  }
+  store = new Store(TEST_DB);
+});
+
+afterEach(() => {
+  store.close();
+  for (const f of [TEST_DB, TEST_VEC, TEST_DB + "-wal", TEST_DB + "-shm"]) {
+    if (existsSync(f)) unlinkSync(f);
+  }
+});
+
+// ── Search Pipeline Integration ─────────────────────────────────────────────
+
+test("search: BM25-only mode returns results", async () => {
+  store.save({ title: "SQLite decision", content: "We use SQLite for the storage layer because it is zero-dependency.", content_type: "decision" });
+  store.save({ title: "Redis caching", content: "Redis handles ephemeral caching for hot data.", content_type: "observation" });
+
+  const results = await search(store, { query: "SQLite storage", useVector: false });
+  expect(results.length).toBeGreaterThan(0);
+  expect(results[0]!.title).toBe("SQLite decision");
+  expect(results[0]!.composite_score).toBeGreaterThan(0);
+  expect(results[0]!.recency_score).toBeGreaterThan(0.9); // just created
+});
+
+test("search: filters by content_type", async () => {
+  store.save({ title: "A decision", content: "Decided something important.", content_type: "decision" });
+  store.save({ title: "A note", content: "Just a note about decisions.", content_type: "note" });
+
+  const results = await search(store, { query: "decision", contentType: "decision", useVector: false });
+  expect(results.every((r) => r.content_type === "decision")).toBe(true);
+});
+
+test("search: empty query returns empty", async () => {
+  store.save({ title: "Something", content: "Content here." });
+  const results = await search(store, { query: "", useVector: false });
+  expect(results.length).toBe(0);
+});
+
+test("search: respects limit", async () => {
+  for (let i = 0; i < 10; i++) {
+    store.save({ title: `Memory ${i}`, content: `Content about topic alpha number ${i}.` });
+  }
+
+  const results = await search(store, { query: "topic alpha", limit: 3, useVector: false });
+  expect(results.length).toBeLessThanOrEqual(3);
+});
+
+// ── Store Edge Cases ────────────────────────────────────────────────────────
+
+test("store: multiple content types have correct default confidence", () => {
+  const decision = store.save({ title: "D", content: "Decision content.", content_type: "decision" });
+  const note = store.save({ title: "N", content: "Note content.", content_type: "note" });
+  const handoff = store.save({ title: "H", content: "Handoff content.", content_type: "handoff" });
+
+  expect(store.get(decision)!.confidence).toBe(0.85);
+  expect(store.get(note)!.confidence).toBe(0.5);
+  expect(store.get(handoff)!.confidence).toBe(0.6);
+});
+
+test("store: getByPath retrieves by path", () => {
+  store.save({ title: "Path test", content: "Content.", path: "test/path-123", collection: "default" });
+
+  const doc = store.getByPath("test/path-123", "default");
+  expect(doc).not.toBeNull();
+  expect(doc!.title).toBe("Path test");
+});
+
+test("store: getByPath returns null for missing", () => {
+  const doc = store.getByPath("nonexistent/path");
+  expect(doc).toBeNull();
+});
+
+test("store: sweep with no stale docs returns empty", () => {
+  store.save({ title: "Fresh", content: "Just created.", content_type: "note" });
+  const result = store.sweep(true);
+  expect(result.candidates.length).toBe(0);
+});
+
+test("store: forget removes from BM25 search", () => {
+  const id = store.save({ title: "Forgettable", content: "This will be forgotten." });
+
+  // Should be searchable
+  let results = store.searchBM25("forgettable");
+  expect(results.length).toBe(1);
+
+  store.forget(id);
+
+  // Should no longer appear in search
+  results = store.searchBM25("forgettable");
+  expect(results.length).toBe(0);
+});
+
+// ── VecStore Edge Cases ─────────────────────────────────────────────────────
+
+test("vecstore: overwrite replaces vector", () => {
+  const vec = new VecStore(TEST_VEC, 4);
+  vec.set("a_0", new Float32Array([1, 0, 0, 0]));
+  vec.set("a_0", new Float32Array([0, 1, 0, 0])); // overwrite
+
+  const results = vec.search(new Float32Array([0, 1, 0, 0]), 1);
+  expect(results[0]!.id).toBe("a_0");
+  expect(results[0]!.similarity).toBeCloseTo(1.0);
+});
+
+test("vecstore: k larger than store size returns all", () => {
+  const vec = new VecStore(TEST_VEC, 4);
+  vec.set("a_0", new Float32Array([1, 0, 0, 0]));
+  vec.set("b_0", new Float32Array([0, 1, 0, 0]));
+
+  const results = vec.search(new Float32Array([1, 0, 0, 0]), 100);
+  expect(results.length).toBe(2);
+});
+
+// ── Context Surfacing Format ────────────────────────────────────────────────
+
+test("context surfacing: builds valid XML-like format", async () => {
+  // Test that the context builder produces the right format
+  // by checking the structural elements
+  store.save({ title: "Known fact", content: "The system uses SQLite for storage.", content_type: "decision" });
+
+  const results = await search(store, { query: "SQLite storage", useVector: false });
+  expect(results.length).toBeGreaterThan(0);
+
+  // Verify result shape for context building
+  const r = results[0]!;
+  expect(r).toHaveProperty("title");
+  expect(r).toHaveProperty("content");
+  expect(r).toHaveProperty("content_type");
+  expect(r).toHaveProperty("composite_score");
+  expect(r).toHaveProperty("recency_score");
+  expect(r).toHaveProperty("confidence");
+});
+
+// ── Relations Integration ───────────────────────────────────────────────────
+
+test("relations: bidirectional graph traversal", () => {
+  const id1 = store.save({ title: "Parent", content: "Parent fact." });
+  const id2 = store.save({ title: "Child", content: "Child fact." });
+  const id3 = store.save({ title: "Sibling", content: "Sibling fact." });
+
+  store.addRelation(id1, id2, "causes");
+  store.addRelation(id1, id3, "related");
+
+  // From parent, find both children
+  const fromParent = store.getRelated(id1);
+  expect(fromParent.length).toBe(2);
+
+  // From child, find parent
+  const fromChild = store.getRelated(id2);
+  expect(fromChild.length).toBe(1);
+  expect(fromChild[0]!.title).toBe("Parent");
+});


### PR DESCRIPTION
## Summary
- 13 new integration tests (50 total, 115 assertions)
- Fixed content_type filter bug in BM25-only search path
- Zero type errors (tsc --noEmit clean)
- README: test badge updated, hooks table, all 13 tools listed, all phases documented
- CLAUDE.md: complete 14-file reference

Depends on: PR #4 (Phase 4)

## Test plan
- [x] `bun test` — 50/50 passing
- [x] `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)