### PR TITLE
fix: resolve HuggingFace model URI before loading embedder

### DIFF
--- a/src/embedder.ts
+++ b/src/embedder.ts
@@ -7,6 +7,7 @@
 
 import {
   getLlama,
+  resolveModelFile,
   type Llama,
   type LlamaModel,
   type LlamaEmbeddingContext,
@@ -32,7 +33,8 @@ async function ensureModel(): Promise<LlamaEmbeddingContext> {
   if (!_initPromise) {
     _initPromise = (async () => {
       _llama = await getLlama();
-      _model = await _llama.loadModel({ modelPath: MODEL_URI });
+      const modelPath = await resolveModelFile(MODEL_URI);
+      _model = await _llama.loadModel({ modelPath });
       _ctx = await _model.createEmbeddingContext({
         contextSize: 2048,
       });


### PR DESCRIPTION
## Summary
- `loadModel()` was receiving the raw `hf:` URI instead of a resolved local path, causing all vector embeddings to silently fail
- Added `resolveModelFile()` call to download/resolve the GGUF model before passing to `loadModel()`
- Rebuilt vectors for all 9 existing memories (18 vectors total)

## Test plan
- [x] `bun test` — 62/62 pass
- [x] Manual embed test returns dim: 768
- [x] `mnemon status` shows vectors > 0 after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)