### PR TITLE
Add 90% test coverage + README refresh with badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,30 @@
 # mnemon
 
-Universal long-term memory layer for AI agents via [MCP](https://modelcontextprotocol.io).
+[![Python](https://img.shields.io/badge/python-3.10+-blue.svg)]()
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Tests](https://img.shields.io/badge/tests-253_passing-brightgreen.svg)]()
+[![Coverage](https://img.shields.io/badge/coverage-90%25-brightgreen.svg)]()
+[![MCP](https://img.shields.io/badge/MCP-compatible-blueviolet.svg)](https://modelcontextprotocol.io)
+[![PyPI](https://img.shields.io/pypi/v/mnemon.svg)](https://pypi.org/project/mnemon/)
+
+> Universal long-term memory layer for AI agents via [MCP](https://modelcontextprotocol.io).
 
 mnemon gives AI agents persistent, searchable memory that survives across sessions. It stores memories in a local SQLite vault with hybrid BM25 + vector search, automatic confidence decay, contradiction detection, and the Model Context Protocol for seamless integration with Claude Code, Cursor, and other MCP clients.
+
+## Table of Contents
+
+- [Install](#install)
+- [Quick Start](#quick-start)
+- [MCP Tools](#mcp-tools)
+- [Memory Types](#memory-types)
+- [Claude Code Hooks](#claude-code-hooks)
+- [Remote Server](#remote-server)
+- [S3 Vault Sync](#s3-vault-sync)
+- [Architecture](#architecture)
+- [Configuration](#configuration)
+- [Development](#development)
+
+---
 
 ## Install
 
@@ -47,12 +69,12 @@ Once configured, mnemon works automatically:
 - **Session extraction**: decisions, preferences, and observations are saved at session end
 - **Handoff generation**: session summaries maintain continuity across sessions
 
-You can also interact with memories directly via MCP tools:
+You can also interact with memories directly via MCP tools or CLI:
 
 ```bash
-# CLI usage
 mnemon search "deployment architecture"
 mnemon save "DB migration plan" "Migrate from PostgreSQL to DynamoDB in Q3"
+mnemon forget 42
 mnemon status
 ```
 
@@ -128,14 +150,14 @@ For use with Claude.ai web or iOS (any Streamable HTTP MCP client):
 # Start remote server
 mnemon serve-remote
 
-# With authentication
+# With authentication (at proxy/infra level)
 MNEMON_TOKEN=your-secret-token mnemon serve-remote
 
 # Custom port
 PORT=9000 mnemon serve-remote
 ```
 
-The remote server exposes the same MCP tools as stdio mode at `http://localhost:8502/mcp`, with a health check at `/health`.
+The remote server exposes the same MCP tools as stdio mode via FastMCP's native Streamable HTTP transport at `http://localhost:8502/mcp`.
 
 ## S3 Vault Sync
 
@@ -169,7 +191,7 @@ Requires the AWS CLI (`aws`) on your PATH with valid credentials.
 - **Search**: Hybrid BM25 + vector (384d, bge-small-en-v1.5 via FastEmbed) fused with Reciprocal Rank Fusion
 - **Scoring**: Composite score = 0.5 * relevance + 0.25 * recency + 0.25 * confidence
 - **Diversity**: MMR filtering (Jaccard bigram similarity > 0.6 demoted by 50%)
-- **Intelligence** (optional): Local 1.7B LLM for query expansion, contradiction detection, session extraction
+- **Intelligence** (optional): Local 1.7B LLM (QMD-query-expansion) for query expansion, contradiction detection, session extraction — zero API cost
 - **Transport**: MCP stdio (local) and Streamable HTTP (remote)
 
 ## Configuration
@@ -187,11 +209,11 @@ Requires the AWS CLI (`aws`) on your PATH with valid credentials.
 # Install with dev dependencies
 pip install -e ".[dev]"
 
-# Run tests
+# Run tests (253 tests)
 pytest
 
-# Run tests with verbose output
-pytest -v
+# Run tests with coverage
+pytest --cov=mnemon --cov-report=term-missing
 
 # Run a specific test file
 pytest tests/test_store.py -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ llm = [
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
+    "pytest-cov>=5.0",
     "httpx>=0.27",
 ]
 all = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,377 @@
+"""Tests for CLI command dispatcher."""
+
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from mnemon import __version__
+from mnemon.cli import main, _print_usage
+
+
+class TestVersionAndHelp:
+    def test_version_flag(self, capsys):
+        with patch("sys.argv", ["mnemon", "--version"]):
+            main()
+        out = capsys.readouterr().out
+        assert f"mnemon v{__version__}" in out
+
+    def test_version_short_flag(self, capsys):
+        with patch("sys.argv", ["mnemon", "-v"]):
+            main()
+        out = capsys.readouterr().out
+        assert f"mnemon v{__version__}" in out
+
+    def test_help_flag(self, capsys):
+        with patch("sys.argv", ["mnemon", "--help"]):
+            main()
+        out = capsys.readouterr().out
+        assert "Usage:" in out
+        assert "mnemon serve" in out
+
+    def test_help_short_flag(self, capsys):
+        with patch("sys.argv", ["mnemon", "-h"]):
+            main()
+        out = capsys.readouterr().out
+        assert "Usage:" in out
+
+    def test_no_args_prints_usage(self, capsys):
+        with patch("sys.argv", ["mnemon"]):
+            main()
+        out = capsys.readouterr().out
+        assert "Usage:" in out
+
+    def test_print_usage_contains_all_commands(self, capsys):
+        _print_usage()
+        out = capsys.readouterr().out
+        for cmd in ["serve", "serve-remote", "status", "search", "save",
+                     "forget", "setup", "sync push", "sync pull",
+                     "--version", "--help"]:
+            assert cmd in out
+
+    def test_print_usage_contains_env_vars(self, capsys):
+        _print_usage()
+        out = capsys.readouterr().out
+        assert "MNEMON_VAULT_DIR" in out
+        assert "MNEMON_TOKEN" in out
+        assert "MNEMON_S3_BUCKET" in out
+
+
+class TestServe:
+    @patch("mnemon.server.run_stdio")
+    def test_serve_calls_run_stdio(self, mock_run):
+        with patch("sys.argv", ["mnemon", "serve"]):
+            main()
+        mock_run.assert_called_once()
+
+    @patch("mnemon.server_remote.run_remote")
+    def test_serve_remote_calls_run_remote(self, mock_run):
+        with patch("sys.argv", ["mnemon", "serve-remote"]):
+            main()
+        mock_run.assert_called_once()
+
+
+class TestStatus:
+    @patch("mnemon.store.Store")
+    def test_status_prints_vault_stats(self, MockStore, capsys):
+        mock_store = MagicMock()
+        mock_store.status.return_value = {
+            "vault_path": "/home/user/.mnemon/default.sqlite",
+            "total_documents": 42,
+            "total_vectors": 40,
+            "pinned": 3,
+            "invalidated": 1,
+            "by_type": [
+                {"content_type": "note", "count": 30},
+                {"content_type": "decision", "count": 12},
+            ],
+        }
+        MockStore.return_value = mock_store
+
+        with patch("sys.argv", ["mnemon", "status"]):
+            main()
+
+        out = capsys.readouterr().out
+        assert "Vault: /home/user/.mnemon/default.sqlite" in out
+        assert "Total memories: 42" in out
+        assert "Vectors: 40" in out
+        assert "Pinned: 3" in out
+        assert "Invalidated: 1" in out
+        assert "note: 30" in out
+        assert "decision: 12" in out
+        mock_store.close.assert_called_once()
+
+
+class TestSearch:
+    @patch("mnemon.search.search")
+    @patch("mnemon.store.Store")
+    def test_search_with_results(self, MockStore, mock_search, capsys):
+        mock_store = MagicMock()
+        MockStore.return_value = mock_store
+
+        result = MagicMock()
+        result.content = "Some memory content here"
+        result.content_type = "note"
+        result.title = "My Note"
+        result.composite_score = 0.875
+        mock_search.return_value = [result]
+
+        with patch("sys.argv", ["mnemon", "search", "test", "query"]):
+            main()
+
+        out = capsys.readouterr().out
+        assert "[note] My Note (score: 0.875)" in out
+        assert "Some memory content here" in out
+        mock_search.assert_called_once_with(mock_store, "test query", limit=10)
+        mock_store.close.assert_called_once()
+
+    @patch("mnemon.search.search")
+    @patch("mnemon.store.Store")
+    def test_search_no_results(self, MockStore, mock_search, capsys):
+        MockStore.return_value = MagicMock()
+        mock_search.return_value = []
+
+        with patch("sys.argv", ["mnemon", "search", "nothing"]):
+            main()
+
+        out = capsys.readouterr().out
+        assert "No memories found." in out
+
+    def test_search_without_query_exits(self, capsys):
+        with patch("sys.argv", ["mnemon", "search"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "Usage: mnemon search <query>" in err
+
+    @patch("mnemon.search.search")
+    @patch("mnemon.store.Store")
+    def test_search_long_content_truncated(self, MockStore, mock_search, capsys):
+        mock_store = MagicMock()
+        MockStore.return_value = mock_store
+
+        result = MagicMock()
+        result.content = "x" * 300
+        result.content_type = "note"
+        result.title = "Long"
+        result.composite_score = 0.5
+        mock_search.return_value = [result]
+
+        with patch("sys.argv", ["mnemon", "search", "long"]):
+            main()
+
+        out = capsys.readouterr().out
+        assert "..." in out
+        # Content should be truncated to 200 chars
+        assert "x" * 200 in out
+
+
+class TestSave:
+    @patch("mnemon.store.Store")
+    def test_save_with_title_and_content(self, MockStore, capsys):
+        mock_store = MagicMock()
+        mock_store.save.return_value = 7
+        MockStore.return_value = mock_store
+
+        with patch("sys.argv", ["mnemon", "save", "My Title", "some", "content"]):
+            main()
+
+        out = capsys.readouterr().out
+        assert 'Saved memory #7: "My Title"' in out
+        mock_store.save.assert_called_once_with(
+            title="My Title", content="some content", source_client="cli"
+        )
+        mock_store.close.assert_called_once()
+
+    def test_save_without_enough_args_exits(self, capsys):
+        with patch("sys.argv", ["mnemon", "save", "titleonly"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "Usage: mnemon save <title> <content>" in err
+
+    def test_save_no_args_exits(self, capsys):
+        with patch("sys.argv", ["mnemon", "save"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1
+
+
+class TestForget:
+    @patch("mnemon.store.Store")
+    def test_forget_found(self, MockStore, capsys):
+        mock_store = MagicMock()
+        mock_store.forget.return_value = True
+        MockStore.return_value = mock_store
+
+        with patch("sys.argv", ["mnemon", "forget", "42"]):
+            main()
+
+        out = capsys.readouterr().out
+        assert "Forgot memory #42." in out
+        mock_store.forget.assert_called_once_with(42)
+        mock_store.close.assert_called_once()
+
+    @patch("mnemon.store.Store")
+    def test_forget_not_found_exits(self, MockStore, capsys):
+        mock_store = MagicMock()
+        mock_store.forget.return_value = False
+        MockStore.return_value = mock_store
+
+        with patch("sys.argv", ["mnemon", "forget", "999"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "Memory #999 not found or already forgotten." in err
+
+    def test_forget_without_id_exits(self, capsys):
+        with patch("sys.argv", ["mnemon", "forget"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "Usage: mnemon forget <id>" in err
+
+    def test_forget_non_numeric_id_exits(self, capsys):
+        with patch("sys.argv", ["mnemon", "forget", "abc"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "Usage: mnemon forget <id>" in err
+
+
+class TestSync:
+    @patch("mnemon.sync.push")
+    def test_sync_push_calls_push(self, mock_push, capsys):
+        mock_push.return_value = {"pushed": ["vault.sqlite"], "errors": []}
+
+        with patch("sys.argv", ["mnemon", "sync", "push"]):
+            main()
+
+        mock_push.assert_called_once()
+        out = capsys.readouterr().out
+        assert "Pushed:" in out
+        assert "vault.sqlite" in out
+
+    @patch("mnemon.sync.push")
+    def test_sync_push_shows_errors(self, mock_push, capsys):
+        mock_push.return_value = {
+            "pushed": [],
+            "errors": ["S3 bucket not found"],
+        }
+
+        with patch("sys.argv", ["mnemon", "sync", "push"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "Errors:" in err
+        assert "S3 bucket not found" in err
+
+    @patch("mnemon.sync.push")
+    def test_sync_push_nothing_to_push(self, mock_push, capsys):
+        mock_push.return_value = {"pushed": [], "errors": []}
+
+        with patch("sys.argv", ["mnemon", "sync", "push"]):
+            main()
+
+        out = capsys.readouterr().out
+        assert "No vault files found to push." in out
+
+    @patch("mnemon.sync.pull")
+    def test_sync_pull_calls_pull(self, mock_pull, capsys):
+        mock_pull.return_value = {"pulled": ["vault.sqlite"], "errors": []}
+
+        with patch("sys.argv", ["mnemon", "sync", "pull"]):
+            main()
+
+        mock_pull.assert_called_once()
+        out = capsys.readouterr().out
+        assert "Pulled:" in out
+        assert "vault.sqlite" in out
+
+    @patch("mnemon.sync.pull")
+    def test_sync_pull_shows_errors(self, mock_pull, capsys):
+        mock_pull.return_value = {
+            "pulled": [],
+            "errors": ["Access denied"],
+        }
+
+        with patch("sys.argv", ["mnemon", "sync", "pull"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "Access denied" in err
+
+    @patch("mnemon.sync.pull")
+    def test_sync_pull_nothing_on_s3(self, mock_pull, capsys):
+        mock_pull.return_value = {"pulled": [], "errors": []}
+
+        with patch("sys.argv", ["mnemon", "sync", "pull"]):
+            main()
+
+        out = capsys.readouterr().out
+        assert "No vault files found on S3." in out
+
+    def test_sync_without_subcommand_exits(self, capsys):
+        with patch("sys.argv", ["mnemon", "sync"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1
+        combined = capsys.readouterr()
+        assert "Usage: mnemon sync <push|pull>" in combined.err
+        # Env var help lines go to stdout (no file=sys.stderr)
+        assert "MNEMON_S3_BUCKET" in combined.out
+
+    def test_sync_invalid_subcommand_exits(self, capsys):
+        with patch("sys.argv", ["mnemon", "sync", "bogus"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1
+
+
+class TestSetup:
+    @patch("mnemon.setup.run_setup")
+    def test_setup_calls_run_setup(self, mock_run, capsys):
+        mock_run.return_value = "Configured claude-code successfully."
+
+        with patch("sys.argv", ["mnemon", "setup", "claude-code"]):
+            main()
+
+        mock_run.assert_called_once_with("claude-code")
+        out = capsys.readouterr().out
+        assert "Configured claude-code successfully." in out
+
+    def test_setup_without_target_exits(self, capsys):
+        with patch("sys.argv", ["mnemon", "setup"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "Usage: mnemon setup" in err
+
+
+class TestUnknownCommand:
+    def test_unknown_command_exits(self, capsys):
+        with patch("sys.argv", ["mnemon", "foobar"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "Unknown command: foobar" in err
+        out = capsys.readouterr().out
+        # Usage is printed to stdout by _print_usage
+
+    def test_unknown_command_prints_usage(self, capsys):
+        with patch("sys.argv", ["mnemon", "badcmd"]):
+            with pytest.raises(SystemExit):
+                main()
+        # _print_usage prints to stdout
+        combined = capsys.readouterr()
+        assert "Unknown command: badcmd" in combined.err
+        assert "Usage:" in combined.out

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -1,0 +1,174 @@
+"""Tests for the embedding pipeline — fragmentize, embed, embed_batch, embed_document."""
+
+import numpy as np
+import pytest
+from unittest.mock import MagicMock, patch
+
+import mnemon.embedder
+
+
+@pytest.fixture(autouse=True)
+def reset_model_singleton():
+    """Reset the singleton model before each test."""
+    mnemon.embedder._model = None
+    yield
+    mnemon.embedder._model = None
+
+
+# ── fragmentize ───────────────────────────────────────────────────────────────
+
+
+class TestFragmentize:
+    def test_short_content_only_seq_zero(self):
+        frags = mnemon.embedder.fragmentize("My Title", "Short content here.")
+        assert len(frags) == 1
+        assert frags[0]["seq"] == 0
+        assert "title: My Title" in frags[0]["text"]
+        assert "Short content here." in frags[0]["text"]
+
+    def test_markdown_headers_create_sections(self):
+        content = (
+            "Introduction paragraph that is long enough to pass the 50 char filter easily.\n"
+            "## Section One\n"
+            "Content for section one that is definitely longer than fifty characters.\n"
+            "## Section Two\n"
+            "Content for section two that is also longer than fifty characters easily."
+        )
+        frags = mnemon.embedder.fragmentize("Doc", content)
+        # seq=0 (full) + sections that pass the 50-char filter
+        assert frags[0]["seq"] == 0
+        section_frags = [f for f in frags if f["seq"] > 0]
+        assert len(section_frags) >= 2
+        assert all("title: Doc | section:" in f["text"] for f in section_frags)
+
+    def test_max_five_sections(self):
+        sections = "\n".join(
+            f"## Section {i}\n{'X' * 60}" for i in range(10)
+        )
+        frags = mnemon.embedder.fragmentize("Many Sections", sections)
+        section_frags = [f for f in frags if f["seq"] > 0]
+        assert len(section_frags) <= 5
+
+    def test_short_sections_filtered(self):
+        content = (
+            "## Short\nTiny.\n"
+            "## Long Section\n" + "Y" * 100
+        )
+        frags = mnemon.embedder.fragmentize("Title", content)
+        section_frags = [f for f in frags if f["seq"] > 0]
+        # "Short\nTiny." is under 50 chars, should be filtered
+        assert len(section_frags) == 1
+        assert "Long Section" in section_frags[0]["text"]
+
+    def test_full_text_truncated_to_2000_chars(self):
+        long_content = "A" * 5000
+        frags = mnemon.embedder.fragmentize("Title", long_content)
+        assert len(frags[0]["text"]) <= 2000
+
+    def test_section_text_truncated_to_1000_chars(self):
+        content = "## Big Section\n" + "Z" * 2000
+        frags = mnemon.embedder.fragmentize("Title", content)
+        section_frags = [f for f in frags if f["seq"] > 0]
+        assert len(section_frags) == 1
+        # "title: Title | section: " prefix + 1000 chars max
+        assert len(section_frags[0]["text"]) <= len("title: Title | section: ") + 1000 + 20
+
+
+# ── embed ─────────────────────────────────────────────────────────────────────
+
+
+class TestEmbed:
+    def test_returns_float32_array(self):
+        mock_model = MagicMock()
+        mock_model.embed.return_value = iter([np.random.randn(384)])
+        with patch("mnemon.embedder._get_model", return_value=mock_model):
+            result = mnemon.embedder.embed("hello world")
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == np.float32
+        assert result.shape == (384,)
+
+    def test_calls_model_with_list(self):
+        mock_model = MagicMock()
+        mock_model.embed.return_value = iter([np.random.randn(384)])
+        with patch("mnemon.embedder._get_model", return_value=mock_model):
+            mnemon.embedder.embed("test text")
+        mock_model.embed.assert_called_once_with(["test text"])
+
+
+# ── embed_batch ───────────────────────────────────────────────────────────────
+
+
+class TestEmbedBatch:
+    def test_returns_list_of_arrays(self):
+        mock_model = MagicMock()
+        mock_model.embed.return_value = iter([np.random.randn(384) for _ in range(3)])
+        with patch("mnemon.embedder._get_model", return_value=mock_model):
+            results = mnemon.embedder.embed_batch(["a", "b", "c"])
+        assert len(results) == 3
+        for arr in results:
+            assert isinstance(arr, np.ndarray)
+            assert arr.dtype == np.float32
+            assert arr.shape == (384,)
+
+    def test_calls_model_with_all_texts(self):
+        mock_model = MagicMock()
+        mock_model.embed.return_value = iter([np.random.randn(384), np.random.randn(384)])
+        with patch("mnemon.embedder._get_model", return_value=mock_model):
+            mnemon.embedder.embed_batch(["text1", "text2"])
+        mock_model.embed.assert_called_once_with(["text1", "text2"])
+
+
+# ── embed_document ────────────────────────────────────────────────────────────
+
+
+class TestEmbedDocument:
+    def test_saves_embeddings_and_flushes(self):
+        mock_store = MagicMock()
+        fake_emb = np.zeros(384, dtype=np.float32)
+        with patch("mnemon.embedder.embed", return_value=fake_emb) as mock_embed:
+            count = mnemon.embedder.embed_document(mock_store, "hash123", "Title", "Short content.")
+        # Only seq=0 fragment for short content
+        assert count == 1
+        mock_store.save_embedding.assert_called_once_with("hash123", 0, fake_emb)
+        mock_store.flush_vectors.assert_called_once()
+
+    def test_multiple_fragments_all_saved(self):
+        mock_store = MagicMock()
+        fake_emb = np.zeros(384, dtype=np.float32)
+        content = "## Section A\n" + "A" * 100 + "\n## Section B\n" + "B" * 100
+        with patch("mnemon.embedder.embed", return_value=fake_emb):
+            count = mnemon.embedder.embed_document(mock_store, "hash456", "Doc", content)
+        # seq=0 + 2 sections
+        assert count == 3
+        assert mock_store.save_embedding.call_count == 3
+        mock_store.flush_vectors.assert_called_once()
+
+    def test_embed_called_per_fragment(self):
+        mock_store = MagicMock()
+        fake_emb = np.zeros(384, dtype=np.float32)
+        with patch("mnemon.embedder.embed", return_value=fake_emb) as mock_embed:
+            mnemon.embedder.embed_document(mock_store, "h", "T", "Short.")
+        assert mock_embed.call_count == 1
+        # Verify the text passed to embed contains the title
+        call_text = mock_embed.call_args[0][0]
+        assert "title: T" in call_text
+
+
+# ── _get_model singleton ─────────────────────────────────────────────────────
+
+
+class TestGetModel:
+    def test_lazy_loads_model(self):
+        mock_model = MagicMock()
+        mock_fastembed = MagicMock()
+        mock_fastembed.TextEmbedding.return_value = mock_model
+        with patch.dict("sys.modules", {"fastembed": mock_fastembed}):
+            result = mnemon.embedder._get_model()
+        assert result is mock_model
+        mock_fastembed.TextEmbedding.assert_called_once_with(model_name="BAAI/bge-small-en-v1.5")
+
+    def test_singleton_returns_same_instance(self):
+        fake_model = MagicMock()
+        mnemon.embedder._model = fake_model
+        result = mnemon.embedder._get_model()
+        assert result is fake_model

--- a/tests/test_hooks_extended.py
+++ b/tests/test_hooks_extended.py
@@ -1,0 +1,577 @@
+"""Extended tests for hook framework, context surfacing, session extractor, and handoff generator."""
+
+import json
+import sys
+import time
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mnemon.hooks.framework import is_duplicate, read_stdin, read_transcript, write_output
+
+
+# ── framework.py: is_duplicate ────────────────────────────────────────────────
+
+
+class TestIsDuplicate:
+    def test_first_call_is_not_duplicate(self, tmp_path):
+        dedup_file = tmp_path / "dedup.json"
+        with patch("mnemon.hooks.framework._dedup_path", return_value=dedup_file):
+            assert is_duplicate("hello world") is False
+
+    def test_second_call_is_duplicate(self, tmp_path):
+        dedup_file = tmp_path / "dedup.json"
+        with patch("mnemon.hooks.framework._dedup_path", return_value=dedup_file):
+            is_duplicate("hello world")
+            assert is_duplicate("hello world") is True
+
+    def test_different_text_is_not_duplicate(self, tmp_path):
+        dedup_file = tmp_path / "dedup.json"
+        with patch("mnemon.hooks.framework._dedup_path", return_value=dedup_file):
+            is_duplicate("hello world")
+            assert is_duplicate("goodbye world") is False
+
+    def test_expired_entry_is_not_duplicate(self, tmp_path):
+        dedup_file = tmp_path / "dedup.json"
+        with patch("mnemon.hooks.framework._dedup_path", return_value=dedup_file):
+            is_duplicate("hello world")
+            # Manually backdate the entry beyond the 600s window
+            entries = json.loads(dedup_file.read_text())
+            entries[0]["timestamp"] = time.time() - 700
+            dedup_file.write_text(json.dumps(entries))
+            assert is_duplicate("hello world") is False
+
+    def test_corrupt_dedup_file_handled(self, tmp_path):
+        dedup_file = tmp_path / "dedup.json"
+        dedup_file.parent.mkdir(parents=True, exist_ok=True)
+        dedup_file.write_text("not valid json!!!")
+        with patch("mnemon.hooks.framework._dedup_path", return_value=dedup_file):
+            assert is_duplicate("hello world") is False
+
+    def test_creates_parent_directory(self, tmp_path):
+        dedup_file = tmp_path / "subdir" / "dedup.json"
+        with patch("mnemon.hooks.framework._dedup_path", return_value=dedup_file):
+            is_duplicate("hello world")
+            assert dedup_file.exists()
+
+
+# ── framework.py: read_stdin ──────────────────────────────────────────────────
+
+
+class TestReadStdin:
+    def test_reads_json_from_stdin(self):
+        payload = {"prompt": "test prompt", "key": 42}
+        with patch("sys.stdin", StringIO(json.dumps(payload))):
+            result = read_stdin()
+        assert result == payload
+
+    def test_reads_empty_object(self):
+        with patch("sys.stdin", StringIO("{}")):
+            result = read_stdin()
+        assert result == {}
+
+
+# ── framework.py: write_output ────────────────────────────────────────────────
+
+
+class TestWriteOutput:
+    def test_writes_json_to_stdout(self):
+        buf = StringIO()
+        with patch("sys.stdout", buf):
+            write_output({"result": "ok"})
+        assert json.loads(buf.getvalue()) == {"result": "ok"}
+
+    def test_flushes_stdout(self):
+        mock_stdout = MagicMock()
+        with patch("sys.stdout", mock_stdout):
+            write_output({"a": 1})
+        mock_stdout.flush.assert_called_once()
+
+
+# ── framework.py: read_transcript ─────────────────────────────────────────────
+
+
+class TestReadTranscript:
+    def test_returns_empty_for_none_path(self):
+        assert read_transcript(None) == ""
+        assert read_transcript("") == ""
+
+    def test_returns_empty_for_missing_file(self):
+        assert read_transcript("/nonexistent/path/transcript.jsonl") == ""
+
+    def test_reads_user_and_assistant_messages(self, tmp_path):
+        transcript = tmp_path / "transcript.jsonl"
+        lines = [
+            json.dumps({"role": "user", "content": "How does X work?"}),
+            json.dumps({"role": "assistant", "content": "X works by doing Y."}),
+        ]
+        transcript.write_text("\n".join(lines))
+        result = read_transcript(str(transcript))
+        assert "[user]: How does X work?" in result
+        assert "[assistant]: X works by doing Y." in result
+
+    def test_filters_non_user_assistant_roles(self, tmp_path):
+        transcript = tmp_path / "transcript.jsonl"
+        lines = [
+            json.dumps({"role": "system", "content": "You are helpful."}),
+            json.dumps({"role": "user", "content": "Hello"}),
+        ]
+        transcript.write_text("\n".join(lines))
+        result = read_transcript(str(transcript))
+        assert "system" not in result.lower() or "[user]" in result
+        assert "[user]: Hello" in result
+        assert "You are helpful" not in result
+
+    def test_handles_list_content(self, tmp_path):
+        transcript = tmp_path / "transcript.jsonl"
+        msg = {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "First part."},
+                {"type": "text", "text": "Second part."},
+                {"type": "image", "data": "binary"},
+            ],
+        }
+        transcript.write_text(json.dumps(msg))
+        result = read_transcript(str(transcript))
+        assert "First part." in result
+        assert "Second part." in result
+        assert "binary" not in result
+
+    def test_respects_max_chars_budget(self, tmp_path):
+        transcript = tmp_path / "transcript.jsonl"
+        lines = [
+            json.dumps({"role": "user", "content": "A" * 500})
+            for _ in range(20)
+        ]
+        transcript.write_text("\n".join(lines))
+        result = read_transcript(str(transcript), max_chars=1000)
+        # Should have stopped reading before exhausting all messages
+        assert len(result) < 1500 + 200  # some overhead for role prefixes
+
+    def test_skips_malformed_json_lines(self, tmp_path):
+        transcript = tmp_path / "transcript.jsonl"
+        lines = [
+            "not json at all",
+            json.dumps({"role": "user", "content": "Valid line"}),
+        ]
+        transcript.write_text("\n".join(lines))
+        result = read_transcript(str(transcript))
+        assert "[user]: Valid line" in result
+
+    def test_reads_from_end_most_recent_first(self, tmp_path):
+        transcript = tmp_path / "transcript.jsonl"
+        lines = [
+            json.dumps({"role": "user", "content": "First message"}),
+            json.dumps({"role": "user", "content": "Second message"}),
+        ]
+        transcript.write_text("\n".join(lines))
+        result = read_transcript(str(transcript), max_chars=30)
+        # With a budget of 30 chars, should pick up the last message first
+        assert "Second message" in result
+
+
+# ── context_surfacing.py: build_context ───────────────────────────────────────
+
+
+def _make_result(score, content_type="observation", title="Test", content="Test content"):
+    r = MagicMock()
+    r.composite_score = score
+    r.content_type = content_type
+    r.title = title
+    r.content = content
+    return r
+
+
+class TestBuildContext:
+    def test_empty_results_returns_empty(self):
+        from mnemon.hooks.context_surfacing import build_context
+
+        assert build_context([]) == ""
+        assert build_context(None) == ""
+
+    def test_hot_result_includes_300_char_snippet(self):
+        from mnemon.hooks.context_surfacing import build_context
+
+        long_content = "A" * 500
+        r = _make_result(0.20, "decision", "Big Decision", long_content)
+        ctx = build_context([r])
+        assert "<mnemon-context>" in ctx
+        assert "[decision] Big Decision:" in ctx
+        assert "A" * 300 in ctx
+        assert "..." in ctx
+
+    def test_hot_result_short_content_no_ellipsis(self):
+        from mnemon.hooks.context_surfacing import build_context
+
+        r = _make_result(0.20, "note", "Short", "Brief content")
+        ctx = build_context([r])
+        # Content is under 300 chars so no ellipsis
+        assert "Brief content" in ctx
+        # The entry should not end with "..."
+        lines = ctx.split("\n")
+        content_line = [l for l in lines if "Short" in l][0]
+        assert not content_line.endswith("...")
+
+    def test_warm_result_includes_150_char_snippet(self):
+        from mnemon.hooks.context_surfacing import build_context
+
+        long_content = "B" * 300
+        r = _make_result(0.12, "preference", "My Pref", long_content)
+        ctx = build_context([r])
+        assert "[preference] My Pref:" in ctx
+        assert "B" * 150 in ctx
+        # Should not include full 300 chars
+        assert "B" * 200 not in ctx
+
+    def test_cold_result_title_only(self):
+        from mnemon.hooks.context_surfacing import build_context
+
+        r = _make_result(0.05, "observation", "Cold Fact", "Lots of detail here")
+        ctx = build_context([r])
+        assert "[observation] Cold Fact" in ctx
+        assert "Lots of detail" not in ctx
+
+    def test_respects_char_budget(self):
+        from mnemon.hooks.context_surfacing import build_context, CHAR_BUDGET
+
+        results = [
+            _make_result(0.20, "note", f"Item {i}", "X" * 400)
+            for i in range(50)
+        ]
+        ctx = build_context(results)
+        # Total context should be within budget (plus the wrapper lines)
+        inner_lines = [l for l in ctx.split("\n") if l.startswith("[")]
+        inner_text = "\n".join(inner_lines)
+        assert len(inner_text) <= CHAR_BUDGET + 100
+
+    def test_wraps_in_mnemon_context_tags(self):
+        from mnemon.hooks.context_surfacing import build_context
+
+        r = _make_result(0.20, "note", "Title", "Content")
+        ctx = build_context([r])
+        assert ctx.startswith("<mnemon-context>")
+        assert ctx.endswith("</mnemon-context>")
+        assert "Relevant memories from previous sessions:" in ctx
+
+    def test_mixed_tiers(self):
+        from mnemon.hooks.context_surfacing import build_context
+
+        results = [
+            _make_result(0.20, "decision", "Hot", "Hot content here"),
+            _make_result(0.12, "preference", "Warm", "Warm content here"),
+            _make_result(0.05, "observation", "Cold", "Cold content here"),
+        ]
+        ctx = build_context(results)
+        assert "[decision] Hot: Hot content here" in ctx
+        assert "[preference] Warm: Warm content here..." in ctx
+        assert "[observation] Cold" in ctx
+        assert "Cold content here" not in ctx.split("[observation] Cold")[-1].split("\n")[0]
+
+
+# ── context_surfacing.py: main ────────────────────────────────────────────────
+
+
+class TestContextSurfacingMain:
+    def test_full_pipeline(self):
+        from mnemon.hooks.context_surfacing import main
+
+        mock_store = MagicMock()
+        mock_result = _make_result(0.20, "note", "Pipeline", "It works via Step Functions")
+        with patch("mnemon.hooks.framework.read_stdin", return_value={"prompt": "how does the pipeline work?"}), \
+             patch("mnemon.hooks.framework.is_noise", return_value=False), \
+             patch("mnemon.hooks.framework.is_duplicate", return_value=False), \
+             patch("mnemon.hooks.framework.write_output") as mock_write, \
+             patch("mnemon.store.Store", return_value=mock_store), \
+             patch("mnemon.search.search", return_value=[mock_result]):
+            main()
+        mock_write.assert_called_once()
+        output = mock_write.call_args[0][0]
+        assert "additionalContext" in output["hookSpecificOutput"]
+        assert "Pipeline" in output["hookSpecificOutput"]["additionalContext"]
+
+    def test_skips_noise(self):
+        from mnemon.hooks.context_surfacing import main
+
+        with patch("mnemon.hooks.framework.read_stdin", return_value={"prompt": "hi"}), \
+             patch("mnemon.hooks.framework.is_noise", return_value=True), \
+             patch("mnemon.hooks.framework.write_output") as mock_write:
+            main()
+        mock_write.assert_not_called()
+
+    def test_skips_duplicate(self):
+        from mnemon.hooks.context_surfacing import main
+
+        with patch("mnemon.hooks.framework.read_stdin", return_value={"prompt": "how does the pipeline work?"}), \
+             patch("mnemon.hooks.framework.is_noise", return_value=False), \
+             patch("mnemon.hooks.framework.is_duplicate", return_value=True), \
+             patch("mnemon.hooks.framework.write_output") as mock_write:
+            main()
+        mock_write.assert_not_called()
+
+    def test_no_results_no_output(self):
+        from mnemon.hooks.context_surfacing import main
+
+        mock_store = MagicMock()
+        with patch("mnemon.hooks.framework.read_stdin", return_value={"prompt": "something obscure"}), \
+             patch("mnemon.hooks.framework.is_noise", return_value=False), \
+             patch("mnemon.hooks.framework.is_duplicate", return_value=False), \
+             patch("mnemon.hooks.framework.write_output") as mock_write, \
+             patch("mnemon.store.Store", return_value=mock_store), \
+             patch("mnemon.search.search", return_value=[]):
+            main()
+        mock_write.assert_not_called()
+
+
+# ── session_extractor.py: extract_with_llm ───────────────────────────────────
+
+
+class TestExtractWithLLM:
+    def test_returns_none_when_llm_unavailable(self):
+        from mnemon.hooks.session_extractor import extract_with_llm
+
+        with patch("mnemon.llm.is_available", return_value=False), \
+             patch("mnemon.llm.generate"):
+            result = extract_with_llm("some transcript")
+        assert result is None
+
+    def test_returns_empty_list_for_none_tag(self):
+        from mnemon.hooks.session_extractor import extract_with_llm
+
+        with patch("mnemon.llm.is_available", return_value=True), \
+             patch("mnemon.llm.generate", return_value="<none/>"):
+            result = extract_with_llm("some transcript")
+        assert result == []
+
+    def test_returns_parsed_observations(self):
+        from mnemon.hooks.session_extractor import extract_with_llm
+
+        llm_response = (
+            "<observation>\n"
+            "  <type>decision</type>\n"
+            "  <title>Use PostgreSQL</title>\n"
+            "  <content>Chose PostgreSQL for JSON support.</content>\n"
+            "</observation>"
+        )
+        with patch("mnemon.llm.is_available", return_value=True), \
+             patch("mnemon.llm.generate", return_value=llm_response):
+            result = extract_with_llm("some transcript")
+        assert len(result) == 1
+        assert result[0]["title"] == "Use PostgreSQL"
+
+    def test_returns_none_on_exception(self):
+        from mnemon.hooks.session_extractor import extract_with_llm
+
+        with patch("mnemon.llm.is_available", side_effect=Exception("boom")):
+            result = extract_with_llm("some transcript")
+        assert result is None
+
+
+# ── session_extractor.py: is_duplicate (vector dedup) ─────────────────────────
+
+
+class TestSessionExtractorIsDuplicate:
+    def test_not_duplicate_when_low_similarity(self):
+        from mnemon.hooks.session_extractor import is_duplicate as vec_is_dup
+
+        mock_store = MagicMock()
+        low_result = MagicMock()
+        low_result.score = 0.80
+        mock_store.search_vector.return_value = [low_result]
+        with patch("mnemon.embedder.embed", return_value="fake_emb"):
+            assert vec_is_dup(mock_store, "title", "content") is False
+
+    def test_duplicate_when_high_similarity(self):
+        from mnemon.hooks.session_extractor import is_duplicate as vec_is_dup
+
+        mock_store = MagicMock()
+        high_result = MagicMock()
+        high_result.score = 0.95
+        mock_store.search_vector.return_value = [high_result]
+        with patch("mnemon.embedder.embed", return_value="fake_emb"):
+            assert vec_is_dup(mock_store, "title", "content") is True
+
+    def test_returns_false_on_exception(self):
+        from mnemon.hooks.session_extractor import is_duplicate as vec_is_dup
+
+        mock_store = MagicMock()
+        with patch("mnemon.embedder.embed", side_effect=Exception("no model")):
+            assert vec_is_dup(mock_store, "title", "content") is False
+
+    def test_no_results_not_duplicate(self):
+        from mnemon.hooks.session_extractor import is_duplicate as vec_is_dup
+
+        mock_store = MagicMock()
+        mock_store.search_vector.return_value = []
+        with patch("mnemon.embedder.embed", return_value="fake_emb"):
+            assert vec_is_dup(mock_store, "title", "content") is False
+
+
+# ── session_extractor.py: main ────────────────────────────────────────────────
+
+
+class TestSessionExtractorMain:
+    def test_skips_short_transcript(self):
+        from mnemon.hooks.session_extractor import main
+
+        with patch("mnemon.hooks.framework.read_stdin", return_value={"transcript_path": "/tmp/t.jsonl"}), \
+             patch("mnemon.hooks.framework.read_transcript", return_value="short"):
+            main()
+
+    def test_falls_back_to_regex(self):
+        from mnemon.hooks import session_extractor
+        from mnemon.hooks.session_extractor import main
+
+        mock_store = MagicMock()
+        mock_store.save.return_value = "doc-123"
+        mock_store.get.return_value = MagicMock(hash="abc123")
+        with patch("mnemon.hooks.framework.read_stdin", return_value={"transcript_path": "/tmp/t.jsonl"}), \
+             patch("mnemon.hooks.framework.read_transcript", return_value="A" * 200), \
+             patch.object(session_extractor, "extract_with_llm", return_value=None), \
+             patch.object(session_extractor, "extract_with_regex", return_value=[{"type": "decision", "title": "Use Redis", "content": "Chose Redis for caching."}]) as mock_regex, \
+             patch.object(session_extractor, "is_duplicate", return_value=False), \
+             patch("mnemon.store.Store", return_value=mock_store), \
+             patch("mnemon.embedder.embed_document"):
+            main()
+        mock_regex.assert_called_once()
+        mock_store.save.assert_called_once()
+
+    def test_skips_duplicate_observations(self):
+        from mnemon.hooks import session_extractor
+        from mnemon.hooks.session_extractor import main
+
+        mock_store = MagicMock()
+        with patch("mnemon.hooks.framework.read_stdin", return_value={"transcript_path": "/tmp/t.jsonl"}), \
+             patch("mnemon.hooks.framework.read_transcript", return_value="A" * 200), \
+             patch.object(session_extractor, "extract_with_llm", return_value=[{"type": "decision", "title": "Dup", "content": "Already saved."}]), \
+             patch.object(session_extractor, "is_duplicate", return_value=True), \
+             patch("mnemon.store.Store", return_value=mock_store):
+            main()
+        mock_store.save.assert_not_called()
+
+    def test_no_observations_exits_early(self):
+        from mnemon.hooks import session_extractor
+        from mnemon.hooks.session_extractor import main
+
+        with patch("mnemon.hooks.framework.read_stdin", return_value={"transcript_path": "/tmp/t.jsonl"}), \
+             patch("mnemon.hooks.framework.read_transcript", return_value="A" * 200), \
+             patch.object(session_extractor, "extract_with_llm", return_value=[]), \
+             patch("mnemon.store.Store") as mock_store_cls:
+            main()
+        mock_store_cls.assert_not_called()
+
+
+# ── handoff_generator.py: generate_with_llm ──────────────────────────────────
+
+
+class TestGenerateWithLLM:
+    def test_returns_none_when_llm_unavailable(self):
+        from mnemon.hooks.handoff_generator import generate_with_llm
+
+        with patch("mnemon.llm.is_available", return_value=False), \
+             patch("mnemon.llm.generate"):
+            result = generate_with_llm("some transcript")
+        assert result is None
+
+    def test_returns_skip_for_none_tag(self):
+        from mnemon.hooks.handoff_generator import generate_with_llm
+
+        with patch("mnemon.llm.is_available", return_value=True), \
+             patch("mnemon.llm.generate", return_value="<none/>"):
+            result = generate_with_llm("some transcript")
+        assert result == {"skip": True}
+
+    def test_returns_parsed_handoff(self):
+        from mnemon.hooks.handoff_generator import generate_with_llm
+
+        llm_response = (
+            "<handoff>\n"
+            "  <title>Fixed auth bug</title>\n"
+            "  <summary>- Fixed JWT validation\n- Added tests</summary>\n"
+            "</handoff>"
+        )
+        with patch("mnemon.llm.is_available", return_value=True), \
+             patch("mnemon.llm.generate", return_value=llm_response):
+            result = generate_with_llm("some transcript")
+        assert result["title"] == "Fixed auth bug"
+        assert "JWT" in result["summary"]
+
+    def test_returns_none_on_exception(self):
+        from mnemon.hooks.handoff_generator import generate_with_llm
+
+        with patch("mnemon.llm.is_available", side_effect=Exception("boom")):
+            result = generate_with_llm("some transcript")
+        assert result is None
+
+    def test_returns_none_for_unparseable_response(self):
+        from mnemon.hooks.handoff_generator import generate_with_llm
+
+        with patch("mnemon.llm.is_available", return_value=True), \
+             patch("mnemon.llm.generate", return_value="just some text"):
+            result = generate_with_llm("some transcript")
+        assert result is None
+
+
+# ── handoff_generator.py: main ────────────────────────────────────────────────
+
+
+class TestHandoffGeneratorMain:
+    def test_skips_short_transcript(self):
+        from mnemon.hooks.handoff_generator import main
+
+        with patch("mnemon.hooks.framework.read_stdin", return_value={"transcript_path": "/tmp/t.jsonl"}), \
+             patch("mnemon.hooks.framework.read_transcript", return_value="short"), \
+             patch("mnemon.store.Store") as mock_store_cls:
+            main()
+        mock_store_cls.assert_not_called()
+
+    def test_falls_back_to_regex(self):
+        from mnemon.hooks import handoff_generator
+        from mnemon.hooks.handoff_generator import main
+
+        mock_store = MagicMock()
+        mock_store.save.return_value = "doc-456"
+        mock_store.get.return_value = MagicMock(hash="def456")
+        with patch("mnemon.hooks.framework.read_stdin", return_value={"transcript_path": "/tmp/t.jsonl"}), \
+             patch("mnemon.hooks.framework.read_transcript", return_value="A" * 300), \
+             patch.object(handoff_generator, "generate_with_llm", return_value=None), \
+             patch.object(handoff_generator, "generate_with_regex", return_value={"title": "Regex handoff", "summary": "- Did stuff"}) as mock_regex, \
+             patch("mnemon.store.Store", return_value=mock_store), \
+             patch("mnemon.embedder.embed_document"):
+            main()
+        mock_regex.assert_called_once()
+        mock_store.save.assert_called_once()
+        call_kwargs = mock_store.save.call_args[1]
+        assert call_kwargs["content_type"] == "handoff"
+        assert "Regex handoff" in call_kwargs["title"]
+
+    def test_skips_when_llm_says_none(self):
+        from mnemon.hooks import handoff_generator
+        from mnemon.hooks.handoff_generator import main
+
+        with patch("mnemon.hooks.framework.read_stdin", return_value={"transcript_path": "/tmp/t.jsonl"}), \
+             patch("mnemon.hooks.framework.read_transcript", return_value="A" * 300), \
+             patch.object(handoff_generator, "generate_with_llm", return_value={"skip": True}), \
+             patch("mnemon.store.Store") as mock_store_cls:
+            main()
+        mock_store_cls.assert_not_called()
+
+    def test_saves_llm_handoff(self):
+        from mnemon.hooks import handoff_generator
+        from mnemon.hooks.handoff_generator import main
+
+        mock_store = MagicMock()
+        mock_store.save.return_value = "doc-789"
+        mock_store.get.return_value = MagicMock(hash="ghi789")
+        with patch("mnemon.hooks.framework.read_stdin", return_value={"transcript_path": "/tmp/t.jsonl"}), \
+             patch("mnemon.hooks.framework.read_transcript", return_value="A" * 300), \
+             patch.object(handoff_generator, "generate_with_llm", return_value={"title": "LLM summary", "summary": "- Deployed feature X"}), \
+             patch("mnemon.store.Store", return_value=mock_store), \
+             patch("mnemon.embedder.embed_document"):
+            main()
+        mock_store.save.assert_called_once()
+        call_kwargs = mock_store.save.call_args[1]
+        assert call_kwargs["title"] == "Session: LLM summary"
+        assert call_kwargs["content"] == "- Deployed feature X"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,680 @@
+"""Tests for the MCP server tool handlers."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mnemon.server as server_mod
+from mnemon.server import (
+    memory_check_contradictions,
+    memory_forget,
+    memory_get,
+    memory_pin,
+    memory_rebuild,
+    memory_related,
+    memory_save,
+    memory_search,
+    memory_status,
+    memory_sweep,
+    memory_timeline,
+    profile_get,
+    profile_update,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_store():
+    """Reset the singleton store between tests."""
+    server_mod._store = None
+    yield
+    server_mod._store = None
+
+
+def _make_search_result(**overrides):
+    """Build a mock ScoredResult (as returned by search())."""
+    defaults = {
+        "doc_id": 1,
+        "title": "Test Memory",
+        "content": "Some content",
+        "content_type": "note",
+        "memory_type": "explicit",
+        "confidence": 0.80,
+        "created_at": "2026-04-01T00:00:00Z",
+        "composite_score": 0.75,
+    }
+    defaults.update(overrides)
+    m = MagicMock()
+    for k, v in defaults.items():
+        setattr(m, k, v)
+    return m
+
+
+def _make_document(**overrides):
+    """Build a mock Document."""
+    defaults = {
+        "id": 1,
+        "collection": "default",
+        "path": None,
+        "title": "Test Doc",
+        "hash": "abc123",
+        "content_type": "note",
+        "memory_type": "explicit",
+        "confidence": 0.80,
+        "access_count": 1,
+        "is_pinned": False,
+        "is_invalidated": False,
+        "created_at": "2026-04-01T00:00:00Z",
+        "updated_at": "2026-04-01T00:00:00Z",
+        "content": "Full document content here.",
+        "source_client": None,
+    }
+    defaults.update(overrides)
+    m = MagicMock()
+    for k, v in defaults.items():
+        setattr(m, k, v)
+    return m
+
+
+def _make_sweep_candidate(**overrides):
+    """Build a mock SweepCandidate."""
+    defaults = {
+        "id": 5,
+        "title": "Old Memory",
+        "content_type": "note",
+        "age_days": 120,
+    }
+    defaults.update(overrides)
+    m = MagicMock()
+    for k, v in defaults.items():
+        setattr(m, k, v)
+    return m
+
+
+def _make_related(**overrides):
+    """Build a mock RelatedDocument."""
+    defaults = {
+        "id": 2,
+        "title": "Related Doc",
+        "relation_type": "supports",
+        "weight": 0.85,
+    }
+    defaults.update(overrides)
+    m = MagicMock()
+    for k, v in defaults.items():
+        setattr(m, k, v)
+    return m
+
+
+# ── _get_store ───────────────────────────────────────────────────────────────
+
+
+class TestGetStore:
+    @patch("mnemon.server.Store")
+    def test_creates_store_on_first_call(self, MockStore):
+        store = server_mod._get_store()
+        MockStore.assert_called_once()
+        assert store is MockStore.return_value
+
+    @patch("mnemon.server.Store")
+    def test_returns_same_store_on_subsequent_calls(self, MockStore):
+        s1 = server_mod._get_store()
+        s2 = server_mod._get_store()
+        MockStore.assert_called_once()
+        assert s1 is s2
+
+
+# ── memory_search ────────────────────────────────────────────────────────────
+
+
+class TestMemorySearch:
+    @patch("mnemon.server.search")
+    @patch("mnemon.server.Store")
+    def test_no_results(self, MockStore, mock_search):
+        mock_search.return_value = []
+        result = memory_search("test query")
+        assert result == "No memories found matching your query."
+
+    @patch("mnemon.server.search")
+    @patch("mnemon.server.Store")
+    def test_with_results(self, MockStore, mock_search):
+        r1 = _make_search_result(doc_id=1, title="Alpha", composite_score=0.9, confidence=0.85)
+        r2 = _make_search_result(doc_id=2, title="Beta", composite_score=0.7, confidence=0.60)
+        mock_search.return_value = [r1, r2]
+
+        result = memory_search("test query", limit=5)
+        assert "1. [note] **Alpha**" in result
+        assert "2. [note] **Beta**" in result
+        assert "score: 0.900" in result
+        assert "confidence: 0.85" in result
+        assert "id: 1" in result
+        assert "id: 2" in result
+
+    @patch("mnemon.server.search")
+    @patch("mnemon.server.Store")
+    def test_long_content_truncated(self, MockStore, mock_search):
+        long_content = "x" * 500
+        r = _make_search_result(content=long_content)
+        mock_search.return_value = [r]
+
+        result = memory_search("query")
+        assert "..." in result
+        # Only first 300 chars of content should appear
+        assert "x" * 300 in result
+        assert "x" * 301 not in result
+
+    @patch("mnemon.server.search")
+    @patch("mnemon.server.Store")
+    def test_short_content_no_ellipsis(self, MockStore, mock_search):
+        r = _make_search_result(content="short")
+        mock_search.return_value = [r]
+
+        result = memory_search("query")
+        assert "..." not in result
+
+    @patch("mnemon.server.search")
+    @patch("mnemon.server.Store")
+    def test_passes_content_type(self, MockStore, mock_search):
+        mock_search.return_value = []
+        memory_search("query", content_type="decision")
+        mock_search.assert_called_once_with(
+            MockStore.return_value, "query", limit=10, content_type="decision"
+        )
+
+
+# ── memory_get ───────────────────────────────────────────────────────────────
+
+
+class TestMemoryGet:
+    @patch("mnemon.server.Store")
+    def test_found(self, MockStore):
+        doc = _make_document(
+            title="My Decision",
+            content_type="decision",
+            confidence=0.90,
+            created_at="2026-04-01",
+            content="We chose option A.",
+        )
+        MockStore.return_value.get.return_value = doc
+
+        result = memory_get(1)
+        assert result.startswith("# My Decision")
+        assert "decision" in result
+        assert "0.90" in result
+        assert "We chose option A." in result
+
+    @patch("mnemon.server.Store")
+    def test_not_found(self, MockStore):
+        MockStore.return_value.get.return_value = None
+        result = memory_get(999)
+        assert result == "Memory #999 not found."
+
+
+# ── memory_timeline ──────────────────────────────────────────────────────────
+
+
+class TestMemoryTimeline:
+    @patch("mnemon.server.Store")
+    def test_empty(self, MockStore):
+        MockStore.return_value.timeline.return_value = []
+        result = memory_timeline()
+        assert result == "No memories found."
+
+    @patch("mnemon.server.Store")
+    def test_populated(self, MockStore):
+        d1 = _make_document(id=10, title="First", content_type="note", created_at="2026-04-01")
+        d2 = _make_document(id=11, title="Second", content_type="decision", created_at="2026-04-02")
+        MockStore.return_value.timeline.return_value = [d1, d2]
+
+        result = memory_timeline(limit=5, content_type="note")
+        assert "**First** [note]" in result
+        assert "**Second** [decision]" in result
+        assert "id: 10" in result
+        assert "id: 11" in result
+
+    @patch("mnemon.server.Store")
+    def test_passes_args(self, MockStore):
+        MockStore.return_value.timeline.return_value = []
+        memory_timeline(limit=30, content_type="preference")
+        MockStore.return_value.timeline.assert_called_once_with(30, "preference")
+
+
+# ── memory_save ──────────────────────────────────────────────────────────────
+
+
+class TestMemorySave:
+    @patch("mnemon.server.Store")
+    def test_success(self, MockStore):
+        mock_store = MockStore.return_value
+        mock_store.save.return_value = 42
+        mock_store.get.return_value = _make_document(id=42, hash="h42")
+
+        with patch("mnemon.server.embed_document", create=True):
+            result = memory_save("My Note", "Content here", content_type="note")
+
+        assert result == 'Saved memory #42: "My Note" [note]'
+        mock_store.save.assert_called_once_with(
+            title="My Note",
+            content="Content here",
+            content_type="note",
+            collection="default",
+            source_client=None,
+        )
+
+    @patch("mnemon.server.Store")
+    def test_embedding_failure_still_succeeds(self, MockStore):
+        mock_store = MockStore.return_value
+        mock_store.save.return_value = 7
+        mock_store.get.return_value = _make_document(id=7, hash="h7")
+
+        # The embed import inside memory_save will raise — that's fine
+        result = memory_save("Title", "Content")
+        assert result == 'Saved memory #7: "Title" [note]'
+
+    @patch("mnemon.server.Store")
+    def test_passes_all_params(self, MockStore):
+        mock_store = MockStore.return_value
+        mock_store.save.return_value = 1
+        mock_store.get.return_value = None  # embed won't run
+
+        memory_save(
+            "T", "C",
+            content_type="decision",
+            collection="work",
+            source_client="claude",
+        )
+        mock_store.save.assert_called_once_with(
+            title="T",
+            content="C",
+            content_type="decision",
+            collection="work",
+            source_client="claude",
+        )
+
+
+# ── memory_pin ───────────────────────────────────────────────────────────────
+
+
+class TestMemoryPin:
+    @patch("mnemon.server.Store")
+    def test_success(self, MockStore):
+        MockStore.return_value.pin.return_value = True
+        result = memory_pin(5)
+        assert result == "Pinned memory #5."
+
+    @patch("mnemon.server.Store")
+    def test_not_found(self, MockStore):
+        MockStore.return_value.pin.return_value = False
+        result = memory_pin(999)
+        assert result == "Memory #999 not found."
+
+
+# ── memory_forget ────────────────────────────────────────────────────────────
+
+
+class TestMemoryForget:
+    @patch("mnemon.server.Store")
+    def test_success(self, MockStore):
+        MockStore.return_value.forget.return_value = True
+        result = memory_forget(3)
+        assert result == "Forgot memory #3."
+
+    @patch("mnemon.server.Store")
+    def test_not_found(self, MockStore):
+        MockStore.return_value.forget.return_value = False
+        result = memory_forget(999)
+        assert result == "Memory #999 not found or already forgotten."
+
+
+# ── memory_status ────────────────────────────────────────────────────────────
+
+
+class TestMemoryStatus:
+    @patch("mnemon.server.Store")
+    def test_returns_formatted_status(self, MockStore):
+        MockStore.return_value.status.return_value = {
+            "vault_path": "/home/user/.mnemon/default.sqlite",
+            "total_documents": 42,
+            "total_vectors": 38,
+            "pinned": 3,
+            "invalidated": 1,
+            "by_type": [
+                {"content_type": "note", "count": 30},
+                {"content_type": "decision", "count": 12},
+            ],
+        }
+
+        result = memory_status()
+        assert "Vault: /home/user/.mnemon/default.sqlite" in result
+        assert "Total memories: 42" in result
+        assert "Vectors: 38" in result
+        assert "Pinned: 3" in result
+        assert "Invalidated: 1" in result
+        assert "note: 30" in result
+        assert "decision: 12" in result
+
+    @patch("mnemon.server.Store")
+    def test_empty_vault(self, MockStore):
+        MockStore.return_value.status.return_value = {
+            "vault_path": "/tmp/test.sqlite",
+            "total_documents": 0,
+            "total_vectors": 0,
+            "pinned": 0,
+            "invalidated": 0,
+            "by_type": [],
+        }
+
+        result = memory_status()
+        assert "Total memories: 0" in result
+        assert "By type:" in result
+
+
+# ── memory_sweep ─────────────────────────────────────────────────────────────
+
+
+class TestMemorySweep:
+    @patch("mnemon.server.Store")
+    def test_no_candidates(self, MockStore):
+        MockStore.return_value.sweep.return_value = {"candidates": []}
+        result = memory_sweep()
+        assert result == "No stale memories to archive."
+
+    @patch("mnemon.server.Store")
+    def test_dry_run_with_candidates(self, MockStore):
+        c1 = _make_sweep_candidate(id=10, title="Old Note", content_type="note", age_days=90)
+        c2 = _make_sweep_candidate(id=11, title="Stale Obs", content_type="observation", age_days=200)
+        MockStore.return_value.sweep.return_value = {"candidates": [c1, c2]}
+
+        result = memory_sweep(dry_run=True)
+        assert "Would archive 2 memories:" in result
+        assert '#10 "Old Note" [note]' in result
+        assert '#11 "Stale Obs" [observation]' in result
+        assert "90 days old" in result
+
+    @patch("mnemon.server.Store")
+    def test_real_sweep(self, MockStore):
+        c = _make_sweep_candidate(id=5, title="Gone", content_type="note", age_days=365)
+        MockStore.return_value.sweep.return_value = {"candidates": [c]}
+
+        result = memory_sweep(dry_run=False)
+        assert "Archived 1 memories:" in result
+        assert "Would archive" not in result
+
+    @patch("mnemon.server.Store")
+    def test_passes_dry_run_arg(self, MockStore):
+        MockStore.return_value.sweep.return_value = {"candidates": []}
+        memory_sweep(dry_run=False)
+        MockStore.return_value.sweep.assert_called_once_with(False)
+
+
+# ── memory_related ───────────────────────────────────────────────────────────
+
+
+class TestMemoryRelated:
+    @patch("mnemon.server.Store")
+    def test_empty(self, MockStore):
+        MockStore.return_value.get_related.return_value = []
+        result = memory_related(1)
+        assert result == "No related memories found for #1."
+
+    @patch("mnemon.server.Store")
+    def test_populated(self, MockStore):
+        r1 = _make_related(id=2, title="Supporting Doc", relation_type="supports", weight=0.90)
+        r2 = _make_related(id=3, title="Contradicting Doc", relation_type="contradicts", weight=0.70)
+        MockStore.return_value.get_related.return_value = [r1, r2]
+
+        result = memory_related(1, limit=5)
+        assert "[supports] **Supporting Doc**" in result
+        assert "weight: 0.90" in result
+        assert "[contradicts] **Contradicting Doc**" in result
+        assert "id: 2" in result
+        assert "id: 3" in result
+
+    @patch("mnemon.server.Store")
+    def test_passes_args(self, MockStore):
+        MockStore.return_value.get_related.return_value = []
+        memory_related(7, limit=3)
+        MockStore.return_value.get_related.assert_called_once_with(7, 3)
+
+
+# ── memory_rebuild ───────────────────────────────────────────────────────────
+
+
+class TestMemoryRebuild:
+    @patch("mnemon.server.Store")
+    def test_success(self, MockStore):
+        d1 = _make_document(hash="h1", title="Doc 1", content="Content 1")
+        d2 = _make_document(hash="h2", title="Doc 2", content="Content 2")
+        MockStore.return_value.timeline.return_value = [d1, d2]
+
+        with patch.dict("sys.modules", {"mnemon.embedder": MagicMock()}):
+            with patch("mnemon.server.embed_document", create=True) as mock_embed:
+                # Need to patch the import inside the function
+                import importlib
+                # Instead, patch at the point of import within memory_rebuild
+                pass
+
+        # More direct approach: patch the import mechanism
+        mock_embed_fn = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {"mnemon.embedder": MagicMock(embed_document=mock_embed_fn)},
+        ):
+            result = memory_rebuild()
+
+        assert "2 documents embedded" in result
+        assert "0 failed" in result
+
+    @patch("mnemon.server.Store")
+    def test_import_error_no_fastembed(self, MockStore):
+        MockStore.return_value.timeline.return_value = [_make_document()]
+
+        # Ensure the import fails
+        import sys
+        original = sys.modules.get("mnemon.embedder")
+        sys.modules["mnemon.embedder"] = None  # type: ignore[assignment]
+        try:
+            result = memory_rebuild()
+        finally:
+            if original is not None:
+                sys.modules["mnemon.embedder"] = original
+            else:
+                sys.modules.pop("mnemon.embedder", None)
+
+        assert "FastEmbed not installed" in result
+
+    @patch("mnemon.server.Store")
+    def test_partial_failure(self, MockStore):
+        d1 = _make_document(hash="h1", title="Good", content="ok")
+        d2 = _make_document(hash="h2", title="Bad", content="fail")
+        d3 = _make_document(hash="h3", title="Good2", content="ok2")
+        MockStore.return_value.timeline.return_value = [d1, d2, d3]
+
+        mock_embed_fn = MagicMock(side_effect=[None, Exception("embed error"), None])
+        with patch.dict(
+            "sys.modules",
+            {"mnemon.embedder": MagicMock(embed_document=mock_embed_fn)},
+        ):
+            result = memory_rebuild()
+
+        assert "2 documents embedded" in result
+        assert "1 failed" in result
+
+    @patch("mnemon.server.Store")
+    def test_empty_timeline(self, MockStore):
+        MockStore.return_value.timeline.return_value = []
+
+        mock_embed_fn = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {"mnemon.embedder": MagicMock(embed_document=mock_embed_fn)},
+        ):
+            result = memory_rebuild()
+
+        assert "0 documents embedded" in result
+        assert "0 failed" in result
+
+
+# ── profile_get ──────────────────────────────────────────────────────────────
+
+
+class TestProfileGet:
+    @patch("mnemon.server.Store")
+    def test_no_data(self, MockStore):
+        MockStore.return_value.timeline.return_value = []
+
+        result = profile_get()
+        assert "No profile data yet" in result
+
+    @patch("mnemon.server.Store")
+    def test_only_preferences(self, MockStore):
+        pref = _make_document(title="Dark Mode", content="User prefers dark mode in all editors.")
+        mock_store = MockStore.return_value
+        mock_store.timeline.side_effect = lambda limit, ct: (
+            [pref] if ct == "preference" else []
+        )
+
+        result = profile_get()
+        assert "## Preferences" in result
+        assert "**Dark Mode**" in result
+        assert "## Key Decisions" not in result
+
+    @patch("mnemon.server.Store")
+    def test_only_decisions(self, MockStore):
+        dec = _make_document(title="Use Python", content="Decided to use Python over TypeScript.")
+        mock_store = MockStore.return_value
+        mock_store.timeline.side_effect = lambda limit, ct: (
+            [dec] if ct == "decision" else []
+        )
+
+        result = profile_get()
+        assert "## Key Decisions" in result
+        assert "**Use Python**" in result
+        assert "## Preferences" not in result
+
+    @patch("mnemon.server.Store")
+    def test_both_preferences_and_decisions(self, MockStore):
+        pref = _make_document(title="Vim Keys", content="Prefers vim keybindings.")
+        dec = _make_document(title="Chose SQLite", content="SQLite over Postgres for simplicity.")
+        mock_store = MockStore.return_value
+        mock_store.timeline.side_effect = lambda limit, ct: (
+            [pref] if ct == "preference" else [dec] if ct == "decision" else []
+        )
+
+        result = profile_get()
+        assert "## Preferences" in result
+        assert "## Key Decisions" in result
+        assert "**Vim Keys**" in result
+        assert "**Chose SQLite**" in result
+
+    @patch("mnemon.server.Store")
+    def test_long_content_truncated(self, MockStore):
+        pref = _make_document(title="Long Pref", content="z" * 500)
+        mock_store = MockStore.return_value
+        mock_store.timeline.side_effect = lambda limit, ct: (
+            [pref] if ct == "preference" else []
+        )
+
+        result = profile_get()
+        # Content should be truncated to 200 chars
+        assert "z" * 200 in result
+        assert "z" * 201 not in result
+
+
+# ── profile_update ───────────────────────────────────────────────────────────
+
+
+class TestProfileUpdate:
+    @patch("mnemon.server.Store")
+    def test_success(self, MockStore):
+        mock_store = MockStore.return_value
+        mock_store.save.return_value = 15
+        mock_store.get.return_value = _make_document(id=15, hash="h15")
+
+        result = profile_update("Theme", "Prefers dark mode")
+        assert result == 'Profile updated — saved preference #15: "Theme"'
+        mock_store.save.assert_called_once_with(
+            title="Theme",
+            content="Prefers dark mode",
+            content_type="preference",
+            source_client="mcp-profile",
+        )
+
+    @patch("mnemon.server.Store")
+    def test_embedding_failure_still_succeeds(self, MockStore):
+        mock_store = MockStore.return_value
+        mock_store.save.return_value = 20
+        mock_store.get.return_value = _make_document(id=20, hash="h20")
+
+        # Embedding import will fail — should still return success
+        result = profile_update("Editor", "VS Code")
+        assert 'Profile updated — saved preference #20: "Editor"' == result
+
+
+# ── memory_check_contradictions ──────────────────────────────────────────────
+
+
+class TestMemoryCheckContradictions:
+    @patch("mnemon.server.Store")
+    def test_not_found(self, MockStore):
+        MockStore.return_value.get.return_value = None
+        result = memory_check_contradictions(999)
+        assert result == "Memory #999 not found."
+
+    @patch("mnemon.server.check_contradictions", create=True)
+    @patch("mnemon.server.Store")
+    def test_no_contradictions(self, MockStore, mock_check):
+        doc = _make_document(id=5, title="Some Fact", content="The sky is blue.")
+        MockStore.return_value.get.return_value = doc
+
+        mock_check_fn = MagicMock(return_value={"relationships": [], "decayed": 0})
+        with patch.dict(
+            "sys.modules",
+            {"mnemon.contradiction": MagicMock(check_contradictions=mock_check_fn)},
+        ):
+            result = memory_check_contradictions(5)
+
+        assert result == "No contradictions found for memory #5."
+
+    @patch("mnemon.server.Store")
+    def test_with_contradictions(self, MockStore):
+        doc = _make_document(id=5, title="New Fact", content="Python is best.")
+        MockStore.return_value.get.return_value = doc
+
+        contradiction_result = {
+            "relationships": [
+                {"doc_id": 2, "title": "Old Fact", "relationship": "contradiction"},
+                {"doc_id": 3, "title": "Similar Fact", "relationship": "update"},
+            ],
+            "decayed": 1,
+        }
+        mock_check_fn = MagicMock(return_value=contradiction_result)
+        with patch.dict(
+            "sys.modules",
+            {"mnemon.contradiction": MagicMock(check_contradictions=mock_check_fn)},
+        ):
+            result = memory_check_contradictions(5)
+
+        assert 'Contradiction check for #5 "New Fact"' in result
+        assert '#2 "Old Fact" \u2192 **contradiction**' in result
+        assert '#3 "Similar Fact" \u2192 **update**' in result
+        assert "1 memories had their confidence decayed." in result
+
+    @patch("mnemon.server.Store")
+    def test_zero_decayed(self, MockStore):
+        doc = _make_document(id=1, title="Fact", content="Content")
+        MockStore.return_value.get.return_value = doc
+
+        contradiction_result = {
+            "relationships": [
+                {"doc_id": 9, "title": "Same Thing", "relationship": "same"},
+            ],
+            "decayed": 0,
+        }
+        mock_check_fn = MagicMock(return_value=contradiction_result)
+        with patch.dict(
+            "sys.modules",
+            {"mnemon.contradiction": MagicMock(check_contradictions=mock_check_fn)},
+        ):
+            result = memory_check_contradictions(1)
+
+        assert "0 memories had their confidence decayed." in result


### PR DESCRIPTION
## Summary
- Add 142 new tests (111 → 253 total), bringing coverage from 56% to 90%
- Professional README refresh with badges (Python, MIT, tests, coverage, MCP, PyPI) and TOC
- Add pytest-cov to dev dependencies

## Test coverage improvements

| Module | Before | After |
|--------|--------|-------|
| cli.py | 0% | 99% |
| server.py | 25% | 99% |
| embedder.py | 41% | 100% |
| context_surfacing.py | 0% | 91% |
| framework.py | 28% | 96% |
| session_extractor.py | 41% | 91% |
| handoff_generator.py | 46% | 92% |
| **TOTAL** | **56%** | **90%** |

## New test files
- `test_cli.py` — 33 tests covering all CLI commands
- `test_server.py` — 43 tests covering all 13 MCP tool handlers
- `test_hooks_extended.py` — 50 tests for framework, context surfacing, session extractor, handoff generator
- `test_embedder.py` — 16 tests for fragmentize, embed, embed_document

## Test plan
- [x] All 253 tests pass
- [x] 90% overall coverage verified via pytest-cov
- [x] Gitleaks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)