### PR TITLE
PyPI publish prep — CHANGELOG, py.typed, metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,11 @@ build/
 # Logs / caches
 *.log
 .cache/
+.coverage
+
+# Legacy TypeScript
+ts/
+node_modules/
+
+# Flow Doctor (testing artifact)
+flow_doctor.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+## [0.2.0] - 2026-04-09
+
+### Added
+- Full Python rewrite (was TypeScript/Bun in v0.1.x)
+- 13 MCP tools: search, get, timeline, save, pin, forget, status, sweep, related, rebuild, check_contradictions, profile_get, profile_update
+- Hybrid BM25 + vector search with Reciprocal Rank Fusion and MMR diversity filtering
+- Composite scoring: 0.5 * relevance + 0.25 * recency + 0.25 * confidence
+- FastEmbed embeddings (bge-small-en-v1.5, 384d ONNX — no PyTorch needed)
+- Memory lifecycle: content-type-based half-life decay, pinning, archival via sweep
+- Contradiction detection with confidence decay (vector similarity + optional LLM classification)
+- Claude Code hooks: context surfacing (UserPromptSubmit), session extraction (Stop), handoff generation (Stop)
+- Auto-configure command: `mnemon setup claude-code|cursor|gemini|hooks`
+- Remote Streamable HTTP server via FastMCP native transport
+- S3 vault sync (push/pull via AWS CLI)
+- CLI: serve, serve-remote, status, search, save, forget, sync, setup
+- Optional local LLM (QMD-1.7B via llama-cpp-python) for query expansion, extraction, contradiction detection
+- 253 tests, 90% coverage
+
+### Changed
+- Rewritten from TypeScript (Bun) to Python (>=3.10)
+- Storage: SQLite + FTS5 + numpy vector store (was SQLite + FTS5 + TypeScript vector store)
+- Embedding: FastEmbed bge-small-en-v1.5 (was EmbeddingGemma-300M)
+- Build: hatchling (was Bun bundler)
+- Package distribution: PyPI (was npm)
+
+## [0.1.x] - 2026-04-08
+
+Initial TypeScript implementation (deprecated, replaced by Python rewrite in v0.2.0).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,12 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
 authors = [
-    { name = "Brian McMahon" },
+    { name = "Brian McMahon", email = "cipher813@gmail.com" },
 ]
 urls.Homepage = "https://github.com/cipher813/mnemon"
 urls.Repository = "https://github.com/cipher813/mnemon"
 urls.Issues = "https://github.com/cipher813/mnemon/issues"
+urls.Changelog = "https://github.com/cipher813/mnemon/blob/main/CHANGELOG.md"
 keywords = ["mcp", "memory", "ai", "agents", "llm", "sqlite", "vector-search"]
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
## Summary
- Add CHANGELOG.md documenting v0.2.0 (Python rewrite) and v0.1.x (deprecated TS)
- Add `py.typed` marker for PEP 561 type hint support
- Add author email to pyproject.toml
- Add Changelog URL to project URLs
- Gitignore cleanup: ts/, node_modules/, .coverage, flow_doctor.db

## Post-merge
1. `git tag v0.2.0 && git push origin v0.2.0`
2. `source .venv/bin/activate && pip install build && python -m build`
3. `pip install twine && python -m twine upload dist/mnemon-0.2.0*`

## Test plan
- [x] 253 tests pass
- [x] Gitleaks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)