### PR TITLE
Rename PyPI package to mnemon-memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Tests](https://img.shields.io/badge/tests-253_passing-brightgreen.svg)]()
 [![Coverage](https://img.shields.io/badge/coverage-90%25-brightgreen.svg)]()
 [![MCP](https://img.shields.io/badge/MCP-compatible-blueviolet.svg)](https://modelcontextprotocol.io)
-[![PyPI](https://img.shields.io/pypi/v/mnemon.svg)](https://pypi.org/project/mnemon/)
+[![PyPI](https://img.shields.io/badge/PyPI-v0.2.0-blue.svg)](https://pypi.org/project/mnemon-memory/)
 
 > Universal long-term memory layer for AI agents via [MCP](https://modelcontextprotocol.io).
 
@@ -29,13 +29,13 @@ mnemon gives AI agents persistent, searchable memory that survives across sessio
 ## Install
 
 ```bash
-pip install mnemon
+pip install mnemon-memory
 ```
 
 With optional LLM support (local 1.7B model for query expansion, contradiction detection, and smarter session extraction):
 
 ```bash
-pip install "mnemon[llm]"
+pip install "mnemon-memory[llm]"
 ```
 
 From source:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "mnemon"
+name = "mnemon-memory"
 version = "0.2.0"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
@@ -45,7 +45,7 @@ dev = [
     "httpx>=0.27",
 ]
 all = [
-    "mnemon[llm,dev]",
+    "mnemon-memory[llm,dev]",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- PyPI name `mnemon` was taken — rename distribution to `mnemon-memory`
- Import name stays `mnemon` (unchanged for users)
- Updated install instructions, PyPI badge, and optional-dep self-reference

## Post-merge
```bash
rm -rf dist/ && python -m build
python -m twine upload dist/mnemon_memory-0.2.0*
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)