### PR TITLE
Add interactive Streamlit dashboard with UMAP graph visualization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,11 @@ llm = [
     "llama-cpp-python>=0.3",
     "huggingface-hub>=0.20",
 ]
+ui = [
+    "streamlit>=1.30",
+    "plotly>=5.18",
+    "umap-learn>=0.5",
+]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
@@ -45,7 +50,7 @@ dev = [
     "httpx>=0.27",
 ]
 all = [
-    "mnemon-memory[llm,dev]",
+    "mnemon-memory[llm,dev,ui]",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "mcp>=1.27",
     "numpy>=1.24",
     "fastembed>=0.3",
+    "httpx[socks]>=0.25",
 ]
 
 [project.optional-dependencies]

--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -3,6 +3,7 @@
 Usage:
     mnemon serve              Start MCP server (stdio transport)
     mnemon serve-remote       Start HTTP server (Streamable HTTP)
+    mnemon dashboard [port]   Launch web dashboard (default port: 8503)
     mnemon status             Show vault health stats
     mnemon search <query>     Search memories
     mnemon save <title> <content>  Save a memory
@@ -39,6 +40,17 @@ def main() -> None:
     elif command == "serve-remote":
         from .server_remote import run_remote
         run_remote()
+
+    elif command == "dashboard":
+        import subprocess
+        from pathlib import Path
+        app_path = Path(__file__).parent / "dashboard" / "app.py"
+        port = args[1] if len(args) > 1 else "8503"
+        try:
+            subprocess.run(["streamlit", "run", str(app_path), f"--server.port={port}", "--theme.base=dark"], check=True)
+        except FileNotFoundError:
+            print("streamlit not found. Install with: pip install 'mnemon-memory[ui]'", file=sys.stderr)
+            sys.exit(1)
 
     elif command == "status":
         from .store import Store
@@ -158,6 +170,7 @@ def _print_usage() -> None:
 Usage:
   mnemon serve              Start MCP server (stdio transport)
   mnemon serve-remote       Start HTTP server (Streamable HTTP)
+  mnemon dashboard [port]   Launch web dashboard (default: 8503)
   mnemon status             Show vault health stats
   mnemon search <query>     Search memories
   mnemon save <title> <c>   Save a memory

--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -47,7 +47,7 @@ def main() -> None:
         app_path = Path(__file__).parent / "dashboard" / "app.py"
         port = args[1] if len(args) > 1 else "8503"
         try:
-            subprocess.run(["streamlit", "run", str(app_path), f"--server.port={port}", "--theme.base=dark"], check=True)
+            subprocess.run(["streamlit", "run", str(app_path), f"--server.port={port}", "--theme.base=dark", "--client.toolbarMode=minimal"], check=True)
         except FileNotFoundError:
             print("streamlit not found. Install with: pip install 'mnemon-memory[ui]'", file=sys.stderr)
             sys.exit(1)

--- a/src/mnemon/dashboard/__init__.py
+++ b/src/mnemon/dashboard/__init__.py
@@ -1,0 +1,1 @@
+"""mnemon dashboard — interactive web UI for vault exploration."""

--- a/src/mnemon/dashboard/app.py
+++ b/src/mnemon/dashboard/app.py
@@ -8,8 +8,8 @@ st.set_page_config(
     initial_sidebar_state="expanded",
 )
 
-from .loaders import load_status, load_timeline, load_sweep
-from .charts import make_type_distribution_chart, make_accumulation_chart
+from mnemon.dashboard.loaders import load_status, load_timeline, load_sweep
+from mnemon.dashboard.charts import make_type_distribution_chart, make_accumulation_chart
 
 
 def _render_metrics(status: dict) -> None:

--- a/src/mnemon/dashboard/app.py
+++ b/src/mnemon/dashboard/app.py
@@ -1,0 +1,63 @@
+"""mnemon Dashboard — Home / Vault Health."""
+
+import streamlit as st
+
+st.set_page_config(
+    page_title="mnemon — Memory Vault",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
+from .loaders import load_status, load_timeline, load_sweep
+from .charts import make_type_distribution_chart, make_accumulation_chart
+
+
+def _render_metrics(status: dict) -> None:
+    c1, c2, c3, c4 = st.columns(4)
+    c1.metric("Total Memories", status["total_documents"])
+    c2.metric("Vectors", status["total_vectors"])
+    c3.metric("Pinned", status["pinned"])
+    c4.metric("Invalidated", status["invalidated"])
+
+
+def _render_sweep_candidates(sweep: dict) -> None:
+    candidates = sweep.get("candidates", [])
+    if not candidates:
+        st.info("No stale memories found.")
+        return
+    st.dataframe(
+        [{"Title": c["title"], "Type": c["content_type"], "Age (days)": c["age_days"]} for c in candidates],
+        use_container_width=True,
+        hide_index=True,
+    )
+
+
+def main() -> None:
+    st.title("mnemon — Memory Vault")
+    st.caption("Long-term memory for AI agents")
+
+    status = load_status()
+    if not status or status["total_documents"] == 0:
+        st.warning("Vault is empty. Start saving memories with `mnemon save` or via MCP tools.")
+        st.stop()
+
+    st.subheader("Vault Health")
+    _render_metrics(status)
+
+    st.divider()
+    col1, col2 = st.columns(2)
+    with col1:
+        fig = make_type_distribution_chart(status.get("by_type", []))
+        st.plotly_chart(fig, use_container_width=True)
+    with col2:
+        timeline = load_timeline(limit=500)
+        fig = make_accumulation_chart(timeline)
+        st.plotly_chart(fig, use_container_width=True)
+
+    st.divider()
+    st.subheader("Stale Memory Candidates")
+    sweep = load_sweep()
+    _render_sweep_candidates(sweep)
+
+
+main()

--- a/src/mnemon/dashboard/charts.py
+++ b/src/mnemon/dashboard/charts.py
@@ -1,0 +1,218 @@
+"""Plotly chart builders for the dashboard."""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timedelta
+
+import numpy as np
+import plotly.graph_objects as go
+
+CONTENT_TYPE_COLORS = {
+    "decision": "#636EFA",
+    "preference": "#EF553B",
+    "antipattern": "#FFA15A",
+    "observation": "#00CC96",
+    "research": "#AB63FA",
+    "project": "#19D3F3",
+    "handoff": "#FF6692",
+    "note": "#B6E880",
+}
+
+_LAYOUT_DEFAULTS = dict(
+    plot_bgcolor="rgba(0,0,0,0)",
+    paper_bgcolor="rgba(0,0,0,0)",
+    margin=dict(t=40, b=30, l=40, r=20),
+    legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+)
+
+
+def make_type_distribution_chart(by_type: list[dict]) -> go.Figure:
+    """Donut chart of memory count by content_type."""
+    if not by_type:
+        fig = go.Figure()
+        fig.update_layout(title="No data", **_LAYOUT_DEFAULTS)
+        return fig
+
+    labels = [t["content_type"] for t in by_type]
+    values = [t["count"] for t in by_type]
+    colors = [CONTENT_TYPE_COLORS.get(l, "#999") for l in labels]
+
+    fig = go.Figure(data=[go.Pie(
+        labels=labels,
+        values=values,
+        hole=0.4,
+        marker=dict(colors=colors),
+        textinfo="label+value",
+        hovertemplate="%{label}: %{value} memories<extra></extra>",
+    )])
+    fig.update_layout(title="Memory Types", showlegend=False, height=350, **_LAYOUT_DEFAULTS)
+    return fig
+
+
+def make_accumulation_chart(timeline_docs: list[dict]) -> go.Figure:
+    """Bar chart: memories saved per day over last 30 days."""
+    if not timeline_docs:
+        fig = go.Figure()
+        fig.update_layout(title="No data", **_LAYOUT_DEFAULTS)
+        return fig
+
+    cutoff = datetime.now() - timedelta(days=30)
+    dates = []
+    for d in timeline_docs:
+        created = datetime.fromisoformat(d["created_at"])
+        if created >= cutoff:
+            dates.append(created.date())
+
+    if not dates:
+        fig = go.Figure()
+        fig.update_layout(title="No memories in last 30 days", **_LAYOUT_DEFAULTS)
+        return fig
+
+    counts = Counter(dates)
+    sorted_dates = sorted(counts.keys())
+    x = [str(d) for d in sorted_dates]
+    y = [counts[d] for d in sorted_dates]
+
+    fig = go.Figure(data=[go.Bar(x=x, y=y, marker_color="#636EFA")])
+    fig.update_layout(title="Memories Saved (Last 30 Days)", xaxis_title="Date", yaxis_title="Count", height=350, **_LAYOUT_DEFAULTS)
+    return fig
+
+
+def make_score_bars(composite: float, recency: float, confidence: float) -> go.Figure:
+    """Horizontal progress bars for search result score breakdown."""
+    fig = go.Figure()
+    labels = ["Relevance", "Recency", "Confidence"]
+    values = [composite, recency, confidence]
+    colors = ["#636EFA", "#00CC96", "#FFA15A"]
+
+    for label, val, color in zip(labels, values, colors):
+        fig.add_trace(go.Bar(
+            y=[label], x=[val], orientation="h",
+            marker_color=color, name=label,
+            text=[f"{val:.3f}"], textposition="auto",
+            showlegend=False,
+        ))
+
+    fig.update_layout(
+        height=120,
+        xaxis=dict(range=[0, 1], showticklabels=False),
+        yaxis=dict(autorange="reversed"),
+        bargap=0.3,
+        margin=dict(t=5, b=5, l=80, r=10),
+        plot_bgcolor="rgba(0,0,0,0)",
+        paper_bgcolor="rgba(0,0,0,0)",
+    )
+    return fig
+
+
+def make_graph_scatter(
+    coords_2d: np.ndarray,
+    vec_ids: list[str],
+    doc_map: dict[str, dict],
+    visible_types: set[str] | None = None,
+) -> go.Figure:
+    """UMAP scatter plot — one trace per content_type."""
+    fig = go.Figure()
+
+    type_groups: dict[str, dict] = {}
+    unmapped = {"x": [], "y": [], "text": [], "customdata": []}
+
+    for i, vid in enumerate(vec_ids):
+        x, y = float(coords_2d[i, 0]), float(coords_2d[i, 1])
+        info = doc_map.get(vid)
+
+        if info is None:
+            unmapped["x"].append(x)
+            unmapped["y"].append(y)
+            unmapped["text"].append(f"Orphan vector: {vid[:16]}...")
+            unmapped["customdata"].append({"vec_id": vid})
+            continue
+
+        ct = info["content_type"]
+        if visible_types and ct not in visible_types:
+            continue
+
+        if ct not in type_groups:
+            type_groups[ct] = {"x": [], "y": [], "text": [], "customdata": []}
+        g = type_groups[ct]
+        g["x"].append(x)
+        g["y"].append(y)
+        g["text"].append(
+            f"<b>{info['title']}</b><br>"
+            f"Type: {ct}<br>"
+            f"Confidence: {info['confidence']:.0%}<br>"
+            f"Created: {info['created_at']}"
+        )
+        g["customdata"].append({"doc_id": info["id"], "vec_id": vid})
+
+    for ct, g in type_groups.items():
+        fig.add_trace(go.Scatter(
+            x=g["x"], y=g["y"],
+            mode="markers",
+            name=ct,
+            marker=dict(color=CONTENT_TYPE_COLORS.get(ct, "#999"), size=8, opacity=0.7),
+            hovertemplate="%{text}<extra></extra>",
+            text=g["text"],
+            customdata=g["customdata"],
+        ))
+
+    if unmapped["x"]:
+        fig.add_trace(go.Scatter(
+            x=unmapped["x"], y=unmapped["y"],
+            mode="markers",
+            name="unmapped",
+            marker=dict(color="#666", size=5, opacity=0.3),
+            hovertemplate="%{text}<extra></extra>",
+            text=unmapped["text"],
+            customdata=unmapped["customdata"],
+        ))
+
+    fig.update_layout(
+        title="Memory Vector Space (UMAP 2D)",
+        xaxis=dict(visible=False),
+        yaxis=dict(visible=False),
+        height=650,
+        **_LAYOUT_DEFAULTS,
+    )
+    return fig
+
+
+def add_relation_edges(
+    fig: go.Figure,
+    coords_2d: np.ndarray,
+    vec_ids: list[str],
+    doc_map: dict[str, dict],
+    relations: dict[int, list[dict]],
+) -> go.Figure:
+    """Overlay relation edges as semi-transparent lines."""
+    doc_id_to_idx: dict[int, int] = {}
+    for i, vid in enumerate(vec_ids):
+        info = doc_map.get(vid)
+        if info and info["id"] not in doc_id_to_idx:
+            doc_id_to_idx[info["id"]] = i
+
+    edge_x: list[float | None] = []
+    edge_y: list[float | None] = []
+
+    for source_id, rels in relations.items():
+        if source_id not in doc_id_to_idx:
+            continue
+        src_idx = doc_id_to_idx[source_id]
+        for rel in rels:
+            target_id = rel.get("id")
+            if target_id not in doc_id_to_idx:
+                continue
+            tgt_idx = doc_id_to_idx[target_id]
+            edge_x.extend([float(coords_2d[src_idx, 0]), float(coords_2d[tgt_idx, 0]), None])
+            edge_y.extend([float(coords_2d[src_idx, 1]), float(coords_2d[tgt_idx, 1]), None])
+
+    if edge_x:
+        fig.add_trace(go.Scatter(
+            x=edge_x, y=edge_y,
+            mode="lines",
+            name="relations",
+            line=dict(color="rgba(150,150,150,0.3)", width=1),
+            hoverinfo="skip",
+        ))
+    return fig

--- a/src/mnemon/dashboard/loaders.py
+++ b/src/mnemon/dashboard/loaders.py
@@ -89,22 +89,33 @@ def load_umap_coords(_vectors: np.ndarray, n_neighbors: int = 15) -> np.ndarray:
 
 
 def build_vector_doc_map(vec_ids: list[str]) -> dict[str, dict]:
-    """Map vector IDs to document metadata via content_hash."""
-    store = get_store()
+    """Map vector IDs to document metadata via content_hash.
+
+    Opens a separate SQLite connection to avoid cross-thread errors
+    (Streamlit runs pages in different threads than the cached Store).
+    """
+    import sqlite3
+    from mnemon.config import vault_path
+
     hash_to_vec_ids: dict[str, list[str]] = {}
     for vid in vec_ids:
         content_hash = vid.rsplit("_", 1)[0]
         hash_to_vec_ids.setdefault(content_hash, []).append(vid)
 
     result = {}
-    for content_hash, vids in hash_to_vec_ids.items():
-        row = store.db.execute(
-            "SELECT d.id, d.title, d.content_type, d.confidence, d.created_at "
-            "FROM documents d WHERE d.hash = ? AND d.invalidated_at IS NULL LIMIT 1",
-            (content_hash,),
-        ).fetchone()
-        if row:
-            doc_info = dict(row)
-            for vid in vids:
-                result[vid] = doc_info
+    db = sqlite3.connect(str(vault_path()), check_same_thread=False)
+    db.row_factory = sqlite3.Row
+    try:
+        for content_hash, vids in hash_to_vec_ids.items():
+            row = db.execute(
+                "SELECT d.id, d.title, d.content_type, d.confidence, d.created_at "
+                "FROM documents d WHERE d.hash = ? AND d.invalidated_at IS NULL LIMIT 1",
+                (content_hash,),
+            ).fetchone()
+            if row:
+                doc_info = dict(row)
+                for vid in vids:
+                    result[vid] = doc_info
+    finally:
+        db.close()
     return result

--- a/src/mnemon/dashboard/loaders.py
+++ b/src/mnemon/dashboard/loaders.py
@@ -1,0 +1,110 @@
+"""Data access layer for the dashboard — wraps Store with Streamlit caching."""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import numpy as np
+import streamlit as st
+
+
+@st.cache_resource
+def get_store():
+    """Singleton read-only Store connection."""
+    from ..store import Store
+    return Store()
+
+
+@st.cache_data(ttl=300)
+def load_status() -> dict:
+    """Vault health stats."""
+    return get_store().status()
+
+
+@st.cache_data(ttl=300)
+def load_timeline(limit: int = 200, content_type: str | None = None) -> list[dict]:
+    """Recent memories as list of dicts."""
+    docs = get_store().timeline(limit, content_type)
+    return [dataclasses.asdict(d) for d in docs]
+
+
+@st.cache_data(ttl=300)
+def load_search(query: str, limit: int = 20, content_type: str | None = None) -> list[dict]:
+    """Hybrid search results as list of dicts."""
+    from ..search import search
+    results = search(get_store(), query, limit=limit, content_type=content_type, use_vector=True)
+    return [dataclasses.asdict(r) for r in results]
+
+
+@st.cache_data(ttl=300)
+def load_sweep() -> dict:
+    """Stale memory candidates (dry_run=True)."""
+    result = get_store().sweep(dry_run=True)
+    result["candidates"] = [dataclasses.asdict(c) for c in result["candidates"]]
+    return result
+
+
+@st.cache_data(ttl=300)
+def load_document(doc_id: int) -> dict | None:
+    """Single document by ID."""
+    doc = get_store().get(doc_id)
+    return dataclasses.asdict(doc) if doc else None
+
+
+@st.cache_data(ttl=300)
+def load_related(doc_id: int, limit: int = 10) -> list[dict]:
+    """Related documents for a given doc_id."""
+    rels = get_store().get_related(doc_id, limit)
+    return [dataclasses.asdict(r) for r in rels]
+
+
+@st.cache_data(ttl=900)
+def load_vectors() -> tuple[list, np.ndarray] | None:
+    """Raw vectors from .npz file. Returns (ids, vectors) or None."""
+    from ..config import vault_path
+    vec_path = str(vault_path()).replace(".sqlite", ".vec.npz")
+    if not Path(vec_path).exists():
+        return None
+    data = np.load(vec_path, allow_pickle=True)
+    ids = data["ids"].tolist()
+    vectors = data["vectors"].astype(np.float32)
+    if len(ids) == 0:
+        return None
+    return ids, vectors
+
+
+@st.cache_data(ttl=900)
+def load_umap_coords(_vectors: np.ndarray, n_neighbors: int = 15) -> np.ndarray:
+    """UMAP 384d -> 2D. Cached aggressively."""
+    import umap
+    reducer = umap.UMAP(
+        n_components=2,
+        n_neighbors=n_neighbors,
+        min_dist=0.1,
+        metric="cosine",
+        random_state=42,
+    )
+    return reducer.fit_transform(_vectors)
+
+
+def build_vector_doc_map(vec_ids: list[str]) -> dict[str, dict]:
+    """Map vector IDs to document metadata via content_hash."""
+    store = get_store()
+    hash_to_vec_ids: dict[str, list[str]] = {}
+    for vid in vec_ids:
+        content_hash = vid.rsplit("_", 1)[0]
+        hash_to_vec_ids.setdefault(content_hash, []).append(vid)
+
+    result = {}
+    for content_hash, vids in hash_to_vec_ids.items():
+        row = store.db.execute(
+            "SELECT d.id, d.title, d.content_type, d.confidence, d.created_at "
+            "FROM documents d WHERE d.hash = ? AND d.invalidated_at IS NULL LIMIT 1",
+            (content_hash,),
+        ).fetchone()
+        if row:
+            doc_info = dict(row)
+            for vid in vids:
+                result[vid] = doc_info
+    return result

--- a/src/mnemon/dashboard/loaders.py
+++ b/src/mnemon/dashboard/loaders.py
@@ -12,7 +12,7 @@ import streamlit as st
 @st.cache_resource
 def get_store():
     """Singleton read-only Store connection."""
-    from ..store import Store
+    from mnemon.store import Store
     return Store()
 
 
@@ -32,7 +32,7 @@ def load_timeline(limit: int = 200, content_type: str | None = None) -> list[dic
 @st.cache_data(ttl=300)
 def load_search(query: str, limit: int = 20, content_type: str | None = None) -> list[dict]:
     """Hybrid search results as list of dicts."""
-    from ..search import search
+    from mnemon.search import search
     results = search(get_store(), query, limit=limit, content_type=content_type, use_vector=True)
     return [dataclasses.asdict(r) for r in results]
 
@@ -62,7 +62,7 @@ def load_related(doc_id: int, limit: int = 10) -> list[dict]:
 @st.cache_data(ttl=900)
 def load_vectors() -> tuple[list, np.ndarray] | None:
     """Raw vectors from .npz file. Returns (ids, vectors) or None."""
-    from ..config import vault_path
+    from mnemon.config import vault_path
     vec_path = str(vault_path()).replace(".sqlite", ".vec.npz")
     if not Path(vec_path).exists():
         return None

--- a/src/mnemon/dashboard/loaders.py
+++ b/src/mnemon/dashboard/loaders.py
@@ -11,9 +11,17 @@ import streamlit as st
 
 @st.cache_resource
 def get_store():
-    """Singleton read-only Store connection."""
+    """Singleton read-only Store connection (cross-thread safe for Streamlit)."""
+    import sqlite3
     from mnemon.store import Store
-    return Store()
+    store = Store()
+    # Reopen with check_same_thread=False for Streamlit's multi-threaded pages
+    store.db.close()
+    store.db = sqlite3.connect(store.db_path, check_same_thread=False)
+    store.db.row_factory = sqlite3.Row
+    store.db.execute("PRAGMA journal_mode = WAL")
+    store.db.execute("PRAGMA busy_timeout = 15000")
+    return store
 
 
 @st.cache_data(ttl=300)

--- a/src/mnemon/dashboard/pages/1_Search.py
+++ b/src/mnemon/dashboard/pages/1_Search.py
@@ -1,0 +1,29 @@
+"""Search — hybrid BM25 + vector search with score breakdown."""
+
+import streamlit as st
+
+st.set_page_config(page_title="Search — mnemon", layout="wide")
+st.title("Search Memories")
+
+from mnemon.dashboard.loaders import load_search
+from mnemon.dashboard.charts import make_score_bars
+
+CONTENT_TYPES = ["All", "decision", "preference", "antipattern", "observation", "research", "project", "handoff", "note"]
+
+query = st.text_input("Search query", placeholder="e.g. deployment architecture")
+content_type_filter = st.selectbox("Filter by type", CONTENT_TYPES)
+
+if query:
+    ct = None if content_type_filter == "All" else content_type_filter
+    results = load_search(query, limit=20, content_type=ct)
+
+    if not results:
+        st.info("No results found.")
+    else:
+        st.caption(f"{len(results)} results")
+        for r in results:
+            with st.expander(f"**{r['title']}** — `{r['content_type']}` — score: {r['composite_score']:.3f}"):
+                fig = make_score_bars(r["composite_score"], r["recency_score"], r["confidence"])
+                st.plotly_chart(fig, use_container_width=True, key=f"score_{r['doc_id']}")
+                st.markdown(r["content"])
+                st.caption(f"ID: {r['doc_id']} | Created: {r['created_at']}")

--- a/src/mnemon/dashboard/pages/2_Timeline.py
+++ b/src/mnemon/dashboard/pages/2_Timeline.py
@@ -1,0 +1,40 @@
+"""Timeline — chronological memory feed with filters."""
+
+import streamlit as st
+from datetime import datetime, date
+
+st.set_page_config(page_title="Timeline — mnemon", layout="wide")
+st.title("Memory Timeline")
+
+from mnemon.dashboard.loaders import load_timeline
+from mnemon.dashboard.charts import CONTENT_TYPE_COLORS
+
+CONTENT_TYPES = ["decision", "preference", "antipattern", "observation", "research", "project", "handoff", "note"]
+
+types = st.sidebar.multiselect("Content types", CONTENT_TYPES, default=CONTENT_TYPES)
+col1, col2 = st.sidebar.columns(2)
+date_from = col1.date_input("From", value=date(2024, 1, 1))
+date_to = col2.date_input("To", value=date.today())
+
+timeline = load_timeline(limit=500)
+
+filtered = [
+    d for d in timeline
+    if d["content_type"] in types
+    and date_from <= datetime.fromisoformat(d["created_at"]).date() <= date_to
+]
+
+if not filtered:
+    st.info("No memories match your filters.")
+    st.stop()
+
+st.caption(f"Showing {len(filtered)} memories")
+
+for doc in filtered:
+    color = CONTENT_TYPE_COLORS.get(doc["content_type"], "#999")
+    pinned = " (pinned)" if doc.get("pinned") else ""
+    header = f"**{doc['title']}** — :{color}[{doc['content_type']}] — confidence: {doc['confidence']:.0%}{pinned}"
+
+    with st.expander(header):
+        st.caption(f"Created: {doc['created_at']} | ID: {doc['id']} | Accessed: {doc.get('access_count', 0)}x")
+        st.markdown(doc["content"])

--- a/src/mnemon/dashboard/pages/2_Timeline.py
+++ b/src/mnemon/dashboard/pages/2_Timeline.py
@@ -7,7 +7,6 @@ st.set_page_config(page_title="Timeline — mnemon", layout="wide")
 st.title("Memory Timeline")
 
 from mnemon.dashboard.loaders import load_timeline
-from mnemon.dashboard.charts import CONTENT_TYPE_COLORS
 
 CONTENT_TYPES = ["decision", "preference", "antipattern", "observation", "research", "project", "handoff", "note"]
 
@@ -31,9 +30,8 @@ if not filtered:
 st.caption(f"Showing {len(filtered)} memories")
 
 for doc in filtered:
-    color = CONTENT_TYPE_COLORS.get(doc["content_type"], "#999")
     pinned = " (pinned)" if doc.get("pinned") else ""
-    header = f"**{doc['title']}** — :{color}[{doc['content_type']}] — confidence: {doc['confidence']:.0%}{pinned}"
+    header = f"{doc['title']} — [{doc['content_type']}] — confidence: {doc['confidence']:.0%}{pinned}"
 
     with st.expander(header):
         st.caption(f"Created: {doc['created_at']} | ID: {doc['id']} | Accessed: {doc.get('access_count', 0)}x")

--- a/src/mnemon/dashboard/pages/3_Graph.py
+++ b/src/mnemon/dashboard/pages/3_Graph.py
@@ -24,7 +24,11 @@ if len(vec_ids) < 5:
 
 # Sidebar controls
 max_neighbors = min(50, len(vec_ids) - 1)
-n_neighbors = st.sidebar.slider("UMAP n_neighbors", min_value=5, max_value=max_neighbors, value=min(15, max_neighbors), step=5, help="Higher = more global structure, lower = more local clusters")
+if max_neighbors > 5:
+    n_neighbors = st.sidebar.slider("UMAP n_neighbors", min_value=5, max_value=max_neighbors, value=min(15, max_neighbors), step=5, help="Higher = more global structure, lower = more local clusters")
+else:
+    n_neighbors = max_neighbors
+    st.sidebar.caption(f"UMAP n_neighbors: {n_neighbors} (auto — small vault)")
 visible_types = st.sidebar.multiselect("Visible types", CONTENT_TYPES, default=CONTENT_TYPES)
 show_edges = st.sidebar.checkbox("Show relation edges", value=True)
 

--- a/src/mnemon/dashboard/pages/3_Graph.py
+++ b/src/mnemon/dashboard/pages/3_Graph.py
@@ -1,0 +1,73 @@
+"""Memory Graph — UMAP 2D projection of the vector space."""
+
+import streamlit as st
+
+st.set_page_config(page_title="Memory Graph — mnemon", layout="wide")
+st.title("Memory Graph")
+
+from mnemon.dashboard.loaders import load_vectors, load_umap_coords, build_vector_doc_map, load_related
+from mnemon.dashboard.charts import make_graph_scatter, add_relation_edges
+
+CONTENT_TYPES = ["decision", "preference", "antipattern", "observation", "research", "project", "handoff", "note"]
+
+# Load vectors
+vec_data = load_vectors()
+if vec_data is None:
+    st.warning("No vectors found. Save some memories with embeddings first.")
+    st.stop()
+
+vec_ids, vectors = vec_data
+
+if len(vec_ids) < 5:
+    st.warning(f"Only {len(vec_ids)} vectors — need at least 5 for UMAP projection.")
+    st.stop()
+
+# Sidebar controls
+max_neighbors = min(50, len(vec_ids) - 1)
+n_neighbors = st.sidebar.slider("UMAP n_neighbors", min_value=5, max_value=max_neighbors, value=min(15, max_neighbors), step=5, help="Higher = more global structure, lower = more local clusters")
+visible_types = st.sidebar.multiselect("Visible types", CONTENT_TYPES, default=CONTENT_TYPES)
+show_edges = st.sidebar.checkbox("Show relation edges", value=True)
+
+# UMAP reduction
+with st.spinner("Computing UMAP projection..."):
+    coords_2d = load_umap_coords(vectors, n_neighbors=n_neighbors)
+
+# Map vectors to documents
+doc_map = build_vector_doc_map(vec_ids)
+
+# Build scatter plot
+fig = make_graph_scatter(coords_2d, vec_ids, doc_map, visible_types=set(visible_types))
+
+# Relation edges
+if show_edges:
+    all_doc_ids = {info["id"] for info in doc_map.values()}
+    relations: dict[int, list[dict]] = {}
+    for doc_id in all_doc_ids:
+        rels = load_related(doc_id, limit=5)
+        if rels:
+            relations[doc_id] = rels
+    if relations:
+        fig = add_relation_edges(fig, coords_2d, vec_ids, doc_map, relations)
+
+# Render
+selected = st.plotly_chart(fig, use_container_width=True, on_select="rerun", key="graph_scatter")
+
+# Click detail
+if selected and selected.selection and selected.selection.points:
+    point = selected.selection.points[0]
+    custom = point.get("customdata")
+    if custom and isinstance(custom, dict) and "doc_id" in custom:
+        from mnemon.dashboard.loaders import load_document
+        with st.sidebar:
+            st.divider()
+            st.subheader("Memory Detail")
+            doc = load_document(custom["doc_id"])
+            if doc:
+                st.markdown(f"**{doc['title']}**")
+                st.caption(f"{doc['content_type']} | confidence: {doc['confidence']:.0%} | {doc['created_at']}")
+                st.markdown(doc["content"])
+                related = load_related(custom["doc_id"])
+                if related:
+                    st.subheader("Related")
+                    for r in related:
+                        st.markdown(f"- **{r['title']}** ({r.get('relation_type', '')}, weight: {r.get('weight', 0):.2f})")

--- a/src/mnemon/dashboard/pages/4_Profile.py
+++ b/src/mnemon/dashboard/pages/4_Profile.py
@@ -1,0 +1,30 @@
+"""Profile — preferences and decisions."""
+
+import streamlit as st
+
+st.set_page_config(page_title="Profile — mnemon", layout="wide")
+st.title("Your Profile")
+
+from mnemon.dashboard.loaders import load_timeline
+
+col1, col2 = st.columns(2)
+
+with col1:
+    st.subheader("Preferences")
+    prefs = load_timeline(limit=50, content_type="preference")
+    if not prefs:
+        st.info("No preferences stored yet.")
+    for p in prefs:
+        with st.expander(f"**{p['title']}** — confidence: {p['confidence']:.0%}"):
+            st.markdown(p["content"])
+            st.caption(f"Created: {p['created_at']} | ID: {p['id']}")
+
+with col2:
+    st.subheader("Decisions")
+    decisions = load_timeline(limit=50, content_type="decision")
+    if not decisions:
+        st.info("No decisions stored yet.")
+    for d in decisions:
+        with st.expander(f"**{d['title']}** — confidence: {d['confidence']:.0%}"):
+            st.markdown(d["content"])
+            st.caption(f"Created: {d['created_at']} | ID: {d['id']}")


### PR DESCRIPTION
## Summary
- 5-page Streamlit dashboard for vault exploration and debugging
- **Home**: vault health metrics, type distribution donut chart, accumulation bar chart, stale candidates
- **Search**: hybrid BM25+vector search with composite score breakdown bars (relevance/recency/confidence)
- **Timeline**: filterable memory feed by content_type and date range
- **Graph**: UMAP 2D projection of 384d vector space, one trace per content_type, relation edges, click-to-detail
- **Profile**: preferences and decisions with confidence scores
- New `[ui]` optional dependency: streamlit, plotly, umap-learn
- CLI: `mnemon dashboard [port]` (default 8503)

## Install
```bash
pip install "mnemon-memory[ui]"
mnemon dashboard
```

## Test plan
- [x] 253 tests pass (no regressions)
- [x] Data layer smoke test: loads 17 docs, 6 vectors from vault
- [x] All imports resolve (charts, loaders, umap)
- [x] Gitleaks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)