### PR TITLE
Gitignore private/ planning docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+private/
+
 # Python
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
## Summary
- Ignore `private/` so local planning docs (e.g. `mnemon-plan-optimized-260410.md`) aren't accidentally committed to the public repo

## Test plan
- [x] `.gitignore` rule verified — `private/mnemon-plan-optimized-260410.md` does not appear in `git status`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>