### PR TITLE
OAuth 2.1 resource server for remote MCP (Phase 1)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.venv/
+.git/
+.pytest_cache/
+__pycache__/
+*.egg-info/
+dist/
+build/
+ts/
+node_modules/
+.coverage
+*.sqlite
+*.vec.npz
+*.gguf
+.DS_Store
+.claude/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+# Install mnemon with server deps (uvicorn, starlette, pyjwt[crypto])
+COPY . .
+RUN pip install --no-cache-dir ".[server]"
+
+# Vault data persists in /data (mount a Fly volume here)
+ENV MNEMON_VAULT_DIR=/data
+RUN mkdir -p /data
+
+# Default port (Fly.io uses 8080 internally)
+ENV PORT=8080
+
+EXPOSE 8080
+
+# Lightweight health check — hits /health which bypasses auth
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD python -c "import urllib.request, sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8080/health', timeout=3).status == 200 else 1)"
+
+CMD ["mnemon", "serve-remote"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,22 @@
+app = "mnemon-memory"
+primary_region = "sea"
+
+[build]
+
+[env]
+  PORT = "8080"
+  MNEMON_VAULT_DIR = "/data"
+  MNEMON_PUBLIC_URL = "https://mnemon-memory.fly.dev"
+  MNEMON_OAUTH_AUDIENCE = "https://mnemon-memory.fly.dev/mcp"
+  # MNEMON_OAUTH_ISSUER and MNEMON_OAUTH_JWKS_URL are set via `fly secrets set`
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+[mounts]
+  source = "mnemon_data"
+  destination = "/data"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,14 +44,22 @@ ui = [
     "plotly>=5.18",
     "umap-learn>=0.5",
 ]
+server = [
+    "uvicorn>=0.29",
+    "starlette>=0.37",
+    "pyjwt[crypto]>=2.8",
+]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-cov>=5.0",
     "httpx>=0.27",
+    "uvicorn>=0.29",
+    "starlette>=0.37",
+    "pyjwt[crypto]>=2.8",
 ]
 all = [
-    "mnemon-memory[llm,dev,ui]",
+    "mnemon-memory[llm,dev,ui,server]",
 ]
 
 [project.scripts]

--- a/src/mnemon/auth.py
+++ b/src/mnemon/auth.py
@@ -1,0 +1,295 @@
+"""OAuth 2.1 resource server middleware for mnemon remote MCP server.
+
+Implements the MCP authorization specification (2025-06-18) resource-server
+side: serves RFC 9728 Protected Resource Metadata, returns RFC 6750 compliant
+401 responses with WWW-Authenticate header on missing/invalid tokens, and
+validates JWT bearer tokens against an external OAuth 2.1 authorization server.
+
+This is Phase 1 of the mnemon OAuth build — the AS (authorization server) is
+external (e.g., Auth0, Logto). Phase 2 will implement a self-hosted AS inside
+mnemon. See private/mnemon-plan-optimized-260410.md for context.
+
+The middleware is pure ASGI (not Starlette BaseHTTPMiddleware) because
+BaseHTTPMiddleware has known compatibility issues with mounted ASGI sub-apps
+and streaming responses — the original c5828c2 commit's bearer middleware
+had a bug where it did not actually enforce auth for requests reaching the
+mounted FastMCP app.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+ASGIScope = dict[str, Any]
+ASGIMessage = dict[str, Any]
+ASGIReceive = Callable[[], Awaitable[ASGIMessage]]
+ASGISend = Callable[[ASGIMessage], Awaitable[None]]
+ASGIApp = Callable[[ASGIScope, ASGIReceive, ASGISend], Awaitable[None]]
+
+
+class OAuthConfig:
+    """OAuth resource-server configuration loaded from environment.
+
+    All fields are optional. If ``issuer``, ``jwks_url``, and ``audience`` are
+    all set, the server operates in authenticated mode. Otherwise the server
+    runs without auth (intended for local development only).
+    """
+
+    def __init__(
+        self,
+        issuer: str | None = None,
+        jwks_url: str | None = None,
+        audience: str | None = None,
+        public_url: str | None = None,
+    ) -> None:
+        self.issuer = issuer
+        self.jwks_url = jwks_url
+        self.audience = audience
+        # public_url is the externally-reachable base URL, used to build the
+        # resource_metadata URL in WWW-Authenticate headers. Falls back to
+        # audience's scheme+host if unset.
+        self.public_url = public_url
+
+    @classmethod
+    def from_env(cls) -> OAuthConfig:
+        return cls(
+            issuer=os.environ.get("MNEMON_OAUTH_ISSUER") or None,
+            jwks_url=os.environ.get("MNEMON_OAUTH_JWKS_URL") or None,
+            audience=os.environ.get("MNEMON_OAUTH_AUDIENCE") or None,
+            public_url=os.environ.get("MNEMON_PUBLIC_URL") or None,
+        )
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.issuer and self.jwks_url and self.audience)
+
+    @property
+    def resource_metadata_url(self) -> str:
+        """URL of the Protected Resource Metadata endpoint."""
+        base = self.public_url or self._derive_base_from_audience()
+        return f"{base.rstrip('/')}/.well-known/oauth-protected-resource"
+
+    def _derive_base_from_audience(self) -> str:
+        """Fallback: derive scheme+host from audience if public_url unset."""
+        if not self.audience:
+            return ""
+        from urllib.parse import urlparse
+
+        parsed = urlparse(self.audience)
+        return f"{parsed.scheme}://{parsed.netloc}"
+
+
+class OAuthMiddleware:
+    """Pure-ASGI OAuth 2.1 resource-server middleware.
+
+    Wraps a downstream ASGI application (the FastMCP streamable-http app).
+    Intercepts three categories of requests:
+
+    1. ``/health`` — served unauthenticated with ``{"status": "ok"}``.
+    2. ``/.well-known/oauth-protected-resource`` — served unauthenticated
+       with RFC 9728 Protected Resource Metadata JSON pointing at the
+       configured authorization server.
+    3. Everything else — requires a valid JWT bearer token. The token is
+       validated against the configured JWKS; on failure, returns 401 with
+       an RFC 6750 / RFC 9728 compliant ``WWW-Authenticate`` header.
+
+    If the OAuth config is not enabled (any of issuer/jwks_url/audience
+    unset), the middleware operates in pass-through mode: all requests go
+    through unauthenticated, /health still works, and the resource metadata
+    endpoint returns 404. This mirrors the pre-c5828c2 behavior of
+    ``mnemon serve-remote`` without env vars.
+    """
+
+    def __init__(self, app: ASGIApp, config: OAuthConfig) -> None:
+        self.app = app
+        self.config = config
+        self._jwks_client: Any = None  # Lazy-init PyJWKClient
+
+    async def __call__(
+        self, scope: ASGIScope, receive: ASGIReceive, send: ASGISend
+    ) -> None:
+        if scope["type"] != "http":
+            # ASGI lifespan, websockets etc. — pass through unchanged.
+            await self.app(scope, receive, send)
+            return
+
+        path: str = scope.get("path", "")
+
+        # Unauthenticated endpoints.
+        if path == "/health":
+            await _send_json(send, 200, {"status": "ok"})
+            return
+
+        if path == "/.well-known/oauth-protected-resource":
+            if not self.config.enabled:
+                await _send_json(
+                    send, 404, {"error": "oauth not configured on this server"}
+                )
+                return
+            await _send_json(send, 200, self._protected_resource_metadata())
+            return
+
+        # Unauthenticated mode — pass through.
+        if not self.config.enabled:
+            await self.app(scope, receive, send)
+            return
+
+        # Extract Authorization header (case-insensitive).
+        auth_header = _get_header(scope, b"authorization")
+        if not auth_header or not auth_header.lower().startswith(b"bearer "):
+            await self._send_401(send, error="missing_token")
+            return
+
+        token = auth_header[7:].decode("ascii", errors="replace").strip()
+        try:
+            self._validate_token(token)
+        except _OAuthError as e:
+            logger.info("JWT validation failed: %s", e)
+            await self._send_401(send, error=e.code, description=e.description)
+            return
+        except Exception as e:  # noqa: BLE001
+            logger.exception("Unexpected error during JWT validation")
+            await self._send_401(
+                send, error="invalid_token", description=f"validation error: {e}"
+            )
+            return
+
+        # Token valid — forward to downstream app.
+        await self.app(scope, receive, send)
+
+    def _protected_resource_metadata(self) -> dict[str, Any]:
+        """Build the RFC 9728 Protected Resource Metadata JSON body."""
+        assert self.config.audience and self.config.issuer
+        return {
+            "resource": self.config.audience,
+            "authorization_servers": [self.config.issuer],
+            "bearer_methods_supported": ["header"],
+            "resource_documentation": "https://github.com/cipher813/mnemon",
+        }
+
+    def _validate_token(self, token: str) -> dict[str, Any]:
+        """Validate JWT signature, issuer, audience, and expiry.
+
+        Raises :class:`_OAuthError` on validation failure.
+        """
+        try:
+            import jwt
+            from jwt import PyJWKClient
+        except ImportError as e:
+            raise _OAuthError(
+                "server_error",
+                "pyjwt not installed — install mnemon-memory[server]",
+            ) from e
+
+        if self._jwks_client is None:
+            assert self.config.jwks_url
+            self._jwks_client = PyJWKClient(
+                self.config.jwks_url, cache_keys=True, lifespan=3600
+            )
+
+        try:
+            signing_key = self._jwks_client.get_signing_key_from_jwt(token)
+        except jwt.PyJWKClientError as e:
+            raise _OAuthError(
+                "invalid_token", f"could not fetch signing key: {e}"
+            ) from e
+        except jwt.DecodeError as e:
+            raise _OAuthError("invalid_token", f"malformed token: {e}") from e
+
+        try:
+            return jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=["RS256"],
+                audience=self.config.audience,
+                issuer=self.config.issuer,
+                options={"require": ["exp", "iat", "iss", "aud"]},
+            )
+        except jwt.ExpiredSignatureError as e:
+            raise _OAuthError("invalid_token", "token expired") from e
+        except jwt.InvalidAudienceError as e:
+            raise _OAuthError(
+                "invalid_token", f"audience mismatch (expected {self.config.audience})"
+            ) from e
+        except jwt.InvalidIssuerError as e:
+            raise _OAuthError(
+                "invalid_token", f"issuer mismatch (expected {self.config.issuer})"
+            ) from e
+        except jwt.InvalidTokenError as e:
+            raise _OAuthError("invalid_token", str(e)) from e
+
+    async def _send_401(
+        self,
+        send: ASGISend,
+        *,
+        error: str = "invalid_token",
+        description: str | None = None,
+    ) -> None:
+        """Return 401 with RFC 6750 + RFC 9728 WWW-Authenticate header."""
+        www_auth_parts = [
+            'Bearer realm="mnemon"',
+            f'resource_metadata="{self.config.resource_metadata_url}"',
+            f'error="{error}"',
+        ]
+        if description:
+            # Escape quotes conservatively.
+            safe_desc = description.replace('"', "'")
+            www_auth_parts.append(f'error_description="{safe_desc}"')
+        www_authenticate = ", ".join(www_auth_parts)
+
+        body_obj: dict[str, Any] = {"error": error}
+        if description:
+            body_obj["error_description"] = description
+        body = json.dumps(body_obj).encode("utf-8")
+
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 401,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode("ascii")),
+                    (b"www-authenticate", www_authenticate.encode("ascii")),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body, "more_body": False})
+
+
+class _OAuthError(Exception):
+    """Internal OAuth validation error — carries an RFC 6750 error code."""
+
+    def __init__(self, code: str, description: str) -> None:
+        super().__init__(f"{code}: {description}")
+        self.code = code
+        self.description = description
+
+
+def _get_header(scope: ASGIScope, name: bytes) -> bytes | None:
+    """Case-insensitive header lookup from ASGI scope."""
+    name_lower = name.lower()
+    for header_name, header_value in scope.get("headers", []):
+        if header_name.lower() == name_lower:
+            return header_value
+    return None
+
+
+async def _send_json(send: ASGISend, status: int, body: dict[str, Any]) -> None:
+    """Minimal JSON response helper."""
+    body_bytes = json.dumps(body).encode("utf-8")
+    await send(
+        {
+            "type": "http.response.start",
+            "status": status,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body_bytes)).encode("ascii")),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body_bytes, "more_body": False})

--- a/src/mnemon/server_remote.py
+++ b/src/mnemon/server_remote.py
@@ -1,12 +1,35 @@
-"""Remote HTTP server — Streamable HTTP transport for MCP.
+"""Remote HTTP server — Streamable HTTP transport for MCP with OAuth 2.1.
 
-Exposes the same MCP tools as stdio mode, accessible from Claude.ai
-web and iOS via Streamable HTTP. Bearer token auth.
+Exposes the same MCP tools as stdio mode, accessible over public HTTPS to
+MCP clients that speak the Streamable HTTP transport (claude.ai web, Claude
+Desktop, Claude mobile apps via custom connectors, Claude Code via
+``claude mcp add --transport http``, Cursor via mcp.json, etc.).
 
-Usage:
-    mnemon serve-remote                          # port 8502, no auth
-    MNEMON_TOKEN=secret mnemon serve-remote      # with bearer token auth
-    PORT=9000 mnemon serve-remote                # custom port
+Authentication
+--------------
+When ``MNEMON_OAUTH_ISSUER``, ``MNEMON_OAUTH_JWKS_URL``, and
+``MNEMON_OAUTH_AUDIENCE`` are set, the server operates as an OAuth 2.1
+resource server per the MCP authorization spec (2025-06-18): it validates
+JWT bearer tokens from an external authorization server and serves RFC 9728
+Protected Resource Metadata for client discovery.
+
+When those env vars are unset, the server runs without auth (local
+development only — do NOT expose an unauthenticated server to the public
+internet).
+
+Usage
+-----
+Local, no auth::
+
+    mnemon serve-remote
+
+Cloud, with external AS (e.g., Auth0)::
+
+    export MNEMON_OAUTH_ISSUER=https://your-tenant.us.auth0.com/
+    export MNEMON_OAUTH_JWKS_URL=https://your-tenant.us.auth0.com/.well-known/jwks.json
+    export MNEMON_OAUTH_AUDIENCE=https://your-mnemon.fly.dev/mcp
+    export MNEMON_PUBLIC_URL=https://your-mnemon.fly.dev
+    mnemon serve-remote
 """
 
 from __future__ import annotations
@@ -14,19 +37,45 @@ from __future__ import annotations
 import os
 import sys
 
+from .auth import OAuthConfig, OAuthMiddleware
+
 PORT = int(os.environ.get("PORT", "8502"))
-AUTH_TOKEN = os.environ.get("MNEMON_TOKEN", "")
 
 
 def run_remote() -> None:
-    """Start the remote HTTP server using FastMCP's built-in Streamable HTTP transport."""
+    """Start the remote HTTP server wrapped in the OAuth middleware."""
     from .server import mcp
 
-    # Set host/port for the Streamable HTTP transport
-    mcp.settings.host = "0.0.0.0"
-    mcp.settings.port = PORT
+    config = OAuthConfig.from_env()
 
-    print(f"mnemon remote server starting on http://0.0.0.0:{PORT}/mcp", file=sys.stderr)
-    print(f"Auth: {'enabled (Bearer token)' if AUTH_TOKEN else 'disabled'}", file=sys.stderr)
+    print(
+        f"mnemon remote server starting on http://0.0.0.0:{PORT}/mcp",
+        file=sys.stderr,
+    )
+    if config.enabled:
+        print(
+            f"Auth: OAuth 2.1 resource server (issuer={config.issuer}, "
+            f"audience={config.audience})",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            "Auth: DISABLED — do not expose this server to the public internet. "
+            "Set MNEMON_OAUTH_ISSUER, MNEMON_OAUTH_JWKS_URL, and "
+            "MNEMON_OAUTH_AUDIENCE to enable OAuth.",
+            file=sys.stderr,
+        )
 
-    mcp.run(transport="streamable-http")
+    try:
+        import uvicorn
+    except ImportError:
+        print(
+            "ERROR: uvicorn not installed. Install with `pip install "
+            "mnemon-memory[server]`.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    mcp_app = mcp.streamable_http_app()
+    wrapped = OAuthMiddleware(mcp_app, config)
+    uvicorn.run(wrapped, host="0.0.0.0", port=PORT, log_level="info")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,393 @@
+"""Tests for OAuth 2.1 resource-server middleware.
+
+Exercises the OAuthMiddleware class with locally-minted RSA-signed JWTs,
+mocking the JWKS fetch so the tests are offline and deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+import jwt
+
+from mnemon.auth import OAuthConfig, OAuthMiddleware
+
+
+# --- Test fixtures ---------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def rsa_keypair() -> dict[str, Any]:
+    """Generate an RSA keypair once per module for signing test JWTs."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return {
+        "private_key": private_key,
+        "public_key": public_key,
+        "private_pem": private_pem,
+        "public_pem": public_pem,
+    }
+
+
+@pytest.fixture
+def oauth_config() -> OAuthConfig:
+    return OAuthConfig(
+        issuer="https://test-issuer.example.com/",
+        jwks_url="https://test-issuer.example.com/.well-known/jwks.json",
+        audience="https://mnemon-test.example.com/mcp",
+        public_url="https://mnemon-test.example.com",
+    )
+
+
+@pytest.fixture
+def mock_signing_key(rsa_keypair):
+    """Patch PyJWKClient.get_signing_key_from_jwt to return our test key."""
+
+    class _FakeSigningKey:
+        def __init__(self, key):
+            self.key = key
+
+    def _get_key(self, _token):
+        return _FakeSigningKey(rsa_keypair["public_pem"])
+
+    with patch(
+        "jwt.PyJWKClient.get_signing_key_from_jwt", _get_key
+    ):
+        yield
+
+
+def _mint_token(
+    private_key: Any,
+    *,
+    issuer: str = "https://test-issuer.example.com/",
+    audience: str = "https://mnemon-test.example.com/mcp",
+    subject: str = "user-123",
+    expires_in: int = 300,
+    issued_at_offset: int = 0,
+) -> str:
+    now = int(time.time()) + issued_at_offset
+    payload = {
+        "iss": issuer,
+        "aud": audience,
+        "sub": subject,
+        "iat": now,
+        "exp": now + expires_in,
+    }
+    return jwt.encode(payload, private_key, algorithm="RS256")
+
+
+async def _call_middleware(
+    middleware: OAuthMiddleware,
+    path: str,
+    *,
+    headers: list[tuple[bytes, bytes]] | None = None,
+    downstream_called: list[bool] | None = None,
+) -> tuple[int, dict[bytes, bytes], bytes]:
+    """Invoke the middleware synchronously and collect the response.
+
+    Returns ``(status, headers_dict, body)``.
+    """
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "headers": headers or [],
+    }
+
+    response: dict[str, Any] = {"status": None, "headers": {}, "body": b""}
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        if message["type"] == "http.response.start":
+            response["status"] = message["status"]
+            response["headers"] = {k: v for k, v in message.get("headers", [])}
+        elif message["type"] == "http.response.body":
+            response["body"] += message.get("body", b"")
+
+    await middleware(scope, receive, send)
+    return response["status"], response["headers"], response["body"]
+
+
+def _stub_downstream_factory(called_flag: list[bool]):
+    """Return a stub downstream ASGI app that records invocations."""
+
+    async def app(scope, receive, send):
+        called_flag.append(True)
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send(
+            {"type": "http.response.body", "body": b'{"ok": true}', "more_body": False}
+        )
+
+    return app
+
+
+# --- Health endpoint -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_unauthenticated(oauth_config):
+    downstream_called: list[bool] = []
+    app = _stub_downstream_factory(downstream_called)
+    mw = OAuthMiddleware(app, oauth_config)
+
+    status, headers, body = await _call_middleware(mw, "/health")
+
+    assert status == 200
+    assert json.loads(body) == {"status": "ok"}
+    assert downstream_called == []  # Did not forward to downstream
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_works_when_oauth_disabled():
+    downstream_called: list[bool] = []
+    app = _stub_downstream_factory(downstream_called)
+    mw = OAuthMiddleware(app, OAuthConfig())
+
+    status, _, body = await _call_middleware(mw, "/health")
+
+    assert status == 200
+    assert json.loads(body) == {"status": "ok"}
+    assert downstream_called == []
+
+
+# --- Protected Resource Metadata -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_protected_resource_metadata_returns_rfc9728_json(oauth_config):
+    downstream_called: list[bool] = []
+    app = _stub_downstream_factory(downstream_called)
+    mw = OAuthMiddleware(app, oauth_config)
+
+    status, headers, body = await _call_middleware(
+        mw, "/.well-known/oauth-protected-resource"
+    )
+
+    assert status == 200
+    assert headers[b"content-type"] == b"application/json"
+    data = json.loads(body)
+    assert data["resource"] == oauth_config.audience
+    assert data["authorization_servers"] == [oauth_config.issuer]
+    assert data["bearer_methods_supported"] == ["header"]
+    assert downstream_called == []
+
+
+@pytest.mark.asyncio
+async def test_protected_resource_metadata_404_when_oauth_disabled():
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, OAuthConfig())
+
+    status, _, body = await _call_middleware(
+        mw, "/.well-known/oauth-protected-resource"
+    )
+
+    assert status == 404
+    assert "error" in json.loads(body)
+
+
+# --- Authenticated paths — unauth mode passes through ---------------------
+
+
+@pytest.mark.asyncio
+async def test_oauth_disabled_passes_through_all_requests():
+    downstream_called: list[bool] = []
+    app = _stub_downstream_factory(downstream_called)
+    mw = OAuthMiddleware(app, OAuthConfig())
+
+    status, _, body = await _call_middleware(mw, "/mcp")
+
+    assert status == 200
+    assert json.loads(body) == {"ok": True}
+    assert downstream_called == [True]
+
+
+# --- Missing / malformed Authorization header -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_authorization_header_returns_401(oauth_config):
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, oauth_config)
+
+    status, headers, body = await _call_middleware(mw, "/mcp")
+
+    assert status == 401
+    www_auth = headers[b"www-authenticate"].decode()
+    assert "Bearer" in www_auth
+    assert "resource_metadata=" in www_auth
+    assert oauth_config.resource_metadata_url in www_auth
+    assert json.loads(body)["error"] == "missing_token"
+
+
+@pytest.mark.asyncio
+async def test_non_bearer_authorization_returns_401(oauth_config):
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, oauth_config)
+
+    status, _, _ = await _call_middleware(
+        mw, "/mcp", headers=[(b"authorization", b"Basic dXNlcjpwYXNz")]
+    )
+
+    assert status == 401
+
+
+# --- Valid JWT flow -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_valid_jwt_passes_through(oauth_config, rsa_keypair, mock_signing_key):
+    downstream_called: list[bool] = []
+    app = _stub_downstream_factory(downstream_called)
+    mw = OAuthMiddleware(app, oauth_config)
+
+    token = _mint_token(rsa_keypair["private_pem"])
+    status, _, body = await _call_middleware(
+        mw,
+        "/mcp",
+        headers=[(b"authorization", f"Bearer {token}".encode())],
+    )
+
+    assert status == 200
+    assert json.loads(body) == {"ok": True}
+    assert downstream_called == [True]
+
+
+# --- Invalid JWT variants -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_expired_jwt_returns_401(oauth_config, rsa_keypair, mock_signing_key):
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, oauth_config)
+
+    # issued 10 minutes ago, expires in 1 minute → expired 9 minutes ago
+    token = _mint_token(
+        rsa_keypair["private_pem"], expires_in=60, issued_at_offset=-600
+    )
+    status, headers, body = await _call_middleware(
+        mw,
+        "/mcp",
+        headers=[(b"authorization", f"Bearer {token}".encode())],
+    )
+
+    assert status == 401
+    assert b"error=" in headers[b"www-authenticate"]
+    assert "expired" in json.loads(body).get("error_description", "")
+
+
+@pytest.mark.asyncio
+async def test_wrong_audience_returns_401(oauth_config, rsa_keypair, mock_signing_key):
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, oauth_config)
+
+    token = _mint_token(
+        rsa_keypair["private_pem"], audience="https://some-other-server.example.com/mcp"
+    )
+    status, _, body = await _call_middleware(
+        mw,
+        "/mcp",
+        headers=[(b"authorization", f"Bearer {token}".encode())],
+    )
+
+    assert status == 401
+    assert "audience" in json.loads(body).get("error_description", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_wrong_issuer_returns_401(oauth_config, rsa_keypair, mock_signing_key):
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, oauth_config)
+
+    token = _mint_token(
+        rsa_keypair["private_pem"], issuer="https://evil-issuer.example.com/"
+    )
+    status, _, body = await _call_middleware(
+        mw,
+        "/mcp",
+        headers=[(b"authorization", f"Bearer {token}".encode())],
+    )
+
+    assert status == 401
+    assert "issuer" in json.loads(body).get("error_description", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_malformed_jwt_returns_401(oauth_config):
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, oauth_config)
+
+    status, _, _ = await _call_middleware(
+        mw,
+        "/mcp",
+        headers=[(b"authorization", b"Bearer not.a.valid.jwt.token")],
+    )
+
+    assert status == 401
+
+
+# --- Config loading -------------------------------------------------------
+
+
+def test_oauth_config_disabled_by_default(monkeypatch):
+    for var in (
+        "MNEMON_OAUTH_ISSUER",
+        "MNEMON_OAUTH_JWKS_URL",
+        "MNEMON_OAUTH_AUDIENCE",
+        "MNEMON_PUBLIC_URL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    config = OAuthConfig.from_env()
+    assert not config.enabled
+
+
+def test_oauth_config_enabled_from_env(monkeypatch):
+    monkeypatch.setenv("MNEMON_OAUTH_ISSUER", "https://issuer.example.com/")
+    monkeypatch.setenv(
+        "MNEMON_OAUTH_JWKS_URL", "https://issuer.example.com/.well-known/jwks.json"
+    )
+    monkeypatch.setenv("MNEMON_OAUTH_AUDIENCE", "https://mnemon.example.com/mcp")
+    monkeypatch.setenv("MNEMON_PUBLIC_URL", "https://mnemon.example.com")
+    config = OAuthConfig.from_env()
+    assert config.enabled
+    assert config.issuer == "https://issuer.example.com/"
+    assert (
+        config.resource_metadata_url
+        == "https://mnemon.example.com/.well-known/oauth-protected-resource"
+    )
+
+
+def test_oauth_config_public_url_derived_from_audience():
+    config = OAuthConfig(
+        issuer="https://issuer.example.com/",
+        jwks_url="https://issuer.example.com/jwks",
+        audience="https://mnemon.example.com/mcp",
+        public_url=None,
+    )
+    assert (
+        config.resource_metadata_url
+        == "https://mnemon.example.com/.well-known/oauth-protected-resource"
+    )

--- a/tests/test_server_remote.py
+++ b/tests/test_server_remote.py
@@ -23,20 +23,29 @@ class TestRemoteConfig:
             importlib.reload(sr)
             assert sr.PORT == 9000
 
-    def test_auth_token_from_env(self):
-        with patch.dict(os.environ, {"MNEMON_TOKEN": "secret123"}):
-            import importlib
-            import mnemon.server_remote as sr
-            importlib.reload(sr)
-            assert sr.AUTH_TOKEN == "secret123"
+    def test_oauth_config_enabled_from_env(self):
+        env = {
+            "MNEMON_OAUTH_ISSUER": "https://issuer.example.com/",
+            "MNEMON_OAUTH_JWKS_URL": "https://issuer.example.com/.well-known/jwks.json",
+            "MNEMON_OAUTH_AUDIENCE": "https://mnemon.example.com/mcp",
+        }
+        with patch.dict(os.environ, env):
+            from mnemon.auth import OAuthConfig
+            config = OAuthConfig.from_env()
+            assert config.enabled
+            assert config.issuer == "https://issuer.example.com/"
 
-    def test_no_auth_by_default(self):
+    def test_oauth_config_disabled_by_default(self):
         with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("MNEMON_TOKEN", None)
-            import importlib
-            import mnemon.server_remote as sr
-            importlib.reload(sr)
-            assert sr.AUTH_TOKEN == ""
+            for var in (
+                "MNEMON_OAUTH_ISSUER",
+                "MNEMON_OAUTH_JWKS_URL",
+                "MNEMON_OAUTH_AUDIENCE",
+            ):
+                os.environ.pop(var, None)
+            from mnemon.auth import OAuthConfig
+            config = OAuthConfig.from_env()
+            assert not config.enabled
 
 
 class TestMcpServer:


### PR DESCRIPTION
## Summary

Implements the MCP authorization spec (2025-06-18) resource-server side so `claude.ai` custom connectors (web, mobile, desktop) can authenticate against mnemon via an external OAuth 2.1 authorization server. Phase 1 of the mnemon cloud build — AS is delegated (Auth0 for this PR); Phase 2 will implement a self-hosted AS inside mnemon using authlib.

## Why this is necessary

Investigation 1 (2026-04-10) confirmed claude.ai's Settings → Connectors dialog **only** exposes OAuth auth options — no bearer token or custom header field. Bearer-only auth as originally planned in the stranded `c5828c2` commit cannot connect to claude.ai.

## What's in this PR

- **`src/mnemon/auth.py`** — new `OAuthMiddleware` (pure ASGI, not `BaseHTTPMiddleware`) + `OAuthConfig` env loader
- **`src/mnemon/server_remote.py`** — rewritten to wrap FastMCP's streamable-http app in the OAuth middleware via uvicorn
- **`pyproject.toml`** — new `[server]` extra (uvicorn, starlette, pyjwt[crypto])
- **Dockerfile / fly.toml / .dockerignore** — cherry-picked from stranded `c5828c2` and updated; Dockerfile now installs `[server]` extra, HEALTHCHECK hits `/health`, fly.toml bakes in `MNEMON_PUBLIC_URL` and `MNEMON_OAUTH_AUDIENCE`
- **`tests/test_auth.py`** — 15 new tests, locally mints RS256 JWTs and mocks PyJWKClient. Covers all 401 paths and valid-JWT pass-through
- **`tests/test_server_remote.py`** — updated to drop obsolete `AUTH_TOKEN` references

## Two bugs in stranded c5828c2 — fixed here

1. `/health` returned 404 because `Mount("/", app=mcp_app)` shadowed `Route("/health")` in Starlette routing. **Fixed:** `/health` is now served from the ASGI middleware layer before the FastMCP mount.
2. Bearer middleware didn't enforce auth — wrong tokens returned 400 from downstream FastMCP instead of 401 from middleware, because Starlette `BaseHTTPMiddleware` has known compatibility issues with mounted ASGI sub-apps. **Fixed:** replaced with pure-ASGI middleware that intercepts all requests before delegation.

## Test plan

- [x] `pytest` — 268 passed (15 new auth tests + 253 pre-existing)
- [x] Local smoke test against Auth0 (`dev-gkh6lrxq3alntl4y.us.auth0.com`):
  - `/health` → 200 `{"status":"ok"}`
  - `/.well-known/oauth-protected-resource` → 200 with correct RFC 9728 body
  - `/mcp` no auth → 401 with `WWW-Authenticate: Bearer realm="mnemon", resource_metadata="...", error="missing_token"`
  - `/mcp` bad token → 401 with descriptive `error_description`
- [ ] Deploy to Fly, configure DCR flow end-to-end with claude.ai custom connector (follow-up)
- [ ] Verify claude.ai successfully completes DCR + PKCE + auth code flow against Auth0 and makes a successful MCP tool call (follow-up)

## Deployment (post-merge)

```
fly secrets set MNEMON_OAUTH_ISSUER="https://dev-gkh6lrxq3alntl4y.us.auth0.com/" MNEMON_OAUTH_JWKS_URL="https://dev-gkh6lrxq3alntl4y.us.auth0.com/.well-known/jwks.json" -a mnemon-memory
fly volumes create mnemon_data --region sea --size 1 -a mnemon-memory
fly deploy -a mnemon-memory
```

Then add as a claude.ai custom connector with URL `https://mnemon-memory.fly.dev/mcp` and blank OAuth Client ID/Secret (auto-registered via DCR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)