### PR TITLE
OAuth: userinfo introspection fallback for opaque tokens

### DIFF
--- a/src/mnemon/auth.py
+++ b/src/mnemon/auth.py
@@ -46,6 +46,7 @@ class OAuthConfig:
         jwks_url: str | None = None,
         audience: str | None = None,
         public_url: str | None = None,
+        userinfo_url: str | None = None,
     ) -> None:
         self.issuer = issuer
         self.jwks_url = jwks_url
@@ -54,6 +55,11 @@ class OAuthConfig:
         # resource_metadata URL in WWW-Authenticate headers. Falls back to
         # audience's scheme+host if unset.
         self.public_url = public_url
+        # userinfo_url is an optional fallback for token introspection when
+        # JWT validation fails. Needed because some OAuth providers (e.g.,
+        # Auth0) issue opaque tokens for OIDC-only flows instead of JWTs
+        # bound to the requested audience. If unset, no fallback is used.
+        self.userinfo_url = userinfo_url
 
     @classmethod
     def from_env(cls) -> OAuthConfig:
@@ -62,6 +68,7 @@ class OAuthConfig:
             jwks_url=os.environ.get("MNEMON_OAUTH_JWKS_URL") or None,
             audience=os.environ.get("MNEMON_OAUTH_AUDIENCE") or None,
             public_url=os.environ.get("MNEMON_PUBLIC_URL") or None,
+            userinfo_url=os.environ.get("MNEMON_OAUTH_USERINFO_URL") or None,
         )
 
     @property
@@ -109,6 +116,7 @@ class OAuthMiddleware:
         self.app = app
         self.config = config
         self._jwks_client: Any = None  # Lazy-init PyJWKClient
+        self._userinfo_cache: dict[str, float] = {}  # token hash -> expiry ts
 
     async def __call__(
         self, scope: ASGIScope, receive: ASGIReceive, send: ASGISend
@@ -146,18 +154,47 @@ class OAuthMiddleware:
             return
 
         token = auth_header[7:].decode("ascii", errors="replace").strip()
+
+        # Try JWT validation first (spec-compliant path).
+        jwt_error: _OAuthError | None = None
         try:
             self._validate_token(token)
         except _OAuthError as e:
-            logger.info("JWT validation failed: %s", e)
-            await self._send_401(send, error=e.code, description=e.description)
-            return
+            jwt_error = e
         except Exception as e:  # noqa: BLE001
             logger.exception("Unexpected error during JWT validation")
-            await self._send_401(
-                send, error="invalid_token", description=f"validation error: {e}"
+            jwt_error = _OAuthError(
+                "invalid_token", f"validation error: {e}"
             )
-            return
+
+        if jwt_error is not None:
+            # JWT validation failed. If a userinfo URL is configured, try
+            # opaque-token introspection as a fallback. This works around
+            # OAuth providers (notably Auth0) that issue opaque /userinfo
+            # tokens instead of audience-bound JWTs for OIDC-only flows.
+            if self.config.userinfo_url:
+                try:
+                    await self._validate_via_userinfo(token)
+                except _OAuthError as ue:
+                    logger.info(
+                        "Both JWT and userinfo validation failed: jwt=%s userinfo=%s",
+                        jwt_error,
+                        ue,
+                    )
+                    await self._send_401(
+                        send,
+                        error=ue.code,
+                        description=f"jwt: {jwt_error.description}; userinfo: {ue.description}",
+                    )
+                    return
+                # Userinfo fallback succeeded — fall through.
+                logger.info("Token validated via userinfo fallback (JWT failed)")
+            else:
+                logger.info("JWT validation failed: %s", jwt_error)
+                await self._send_401(
+                    send, error=jwt_error.code, description=jwt_error.description
+                )
+                return
 
         # Token valid — forward to downstream app.
         await self.app(scope, receive, send)
@@ -222,6 +259,91 @@ class OAuthMiddleware:
             ) from e
         except jwt.InvalidTokenError as e:
             raise _OAuthError("invalid_token", str(e)) from e
+
+    async def _validate_via_userinfo(self, token: str) -> dict[str, Any]:
+        """Fallback: validate an opaque token by calling the OAuth provider's
+        userinfo endpoint (OIDC Core section 5.3).
+
+        Used when JWT decode fails — typically because the provider issued
+        an opaque access token scoped to /userinfo rather than an audience-
+        bound JWT. If the userinfo endpoint returns 200 with a user profile,
+        the token is valid and we extract identity claims.
+
+        Uses a small in-memory cache keyed by token hash to avoid repeat
+        network calls within a short window. Returns the decoded userinfo
+        payload on success. Raises :class:`_OAuthError` on failure.
+
+        This is less strict than JWT audience validation — any token that
+        the provider's /userinfo endpoint accepts will be allowed through,
+        regardless of whether it was specifically issued for mnemon. That's
+        acceptable for Phase 1 / single-user deployments. Phase 2's self-
+        hosted AS will enforce proper audience binding.
+        """
+        import hashlib
+        import time
+
+        assert self.config.userinfo_url
+
+        # Simple TTL cache: token_hash -> expiry_ts (accept until).
+        now = time.time()
+        token_hash = hashlib.sha256(token.encode("ascii", errors="replace")).hexdigest()
+        cached_until = self._userinfo_cache.get(token_hash, 0)
+        if cached_until > now:
+            return {"sub": "cached"}
+
+        try:
+            import httpx
+        except ImportError as e:
+            raise _OAuthError(
+                "server_error", "httpx not installed (required for userinfo fallback)"
+            ) from e
+
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.get(
+                    self.config.userinfo_url,
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        except httpx.TimeoutException as e:
+            raise _OAuthError(
+                "server_error", f"userinfo endpoint timeout: {e}"
+            ) from e
+        except httpx.HTTPError as e:
+            raise _OAuthError(
+                "server_error", f"userinfo endpoint error: {e}"
+            ) from e
+
+        if resp.status_code == 401 or resp.status_code == 403:
+            raise _OAuthError(
+                "invalid_token", "userinfo rejected token"
+            )
+        if resp.status_code != 200:
+            raise _OAuthError(
+                "invalid_token",
+                f"userinfo returned {resp.status_code}",
+            )
+
+        try:
+            profile = resp.json()
+        except ValueError as e:
+            raise _OAuthError(
+                "invalid_token", f"userinfo returned non-JSON: {e}"
+            ) from e
+
+        if not isinstance(profile, dict) or "sub" not in profile:
+            raise _OAuthError(
+                "invalid_token", "userinfo response missing 'sub' claim"
+            )
+
+        # Cache for 5 minutes to avoid hammering the provider.
+        self._userinfo_cache[token_hash] = now + 300
+        # Opportunistic cache eviction to prevent unbounded growth.
+        if len(self._userinfo_cache) > 256:
+            expired = [k for k, v in self._userinfo_cache.items() if v <= now]
+            for k in expired:
+                self._userinfo_cache.pop(k, None)
+
+        return profile
 
     async def _send_401(
         self,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -391,3 +391,120 @@ def test_oauth_config_public_url_derived_from_audience():
         config.resource_metadata_url
         == "https://mnemon.example.com/.well-known/oauth-protected-resource"
     )
+
+
+# --- Userinfo fallback --------------------------------------------------
+
+
+@pytest.fixture
+def oauth_config_with_userinfo() -> OAuthConfig:
+    return OAuthConfig(
+        issuer="https://test-issuer.example.com/",
+        jwks_url="https://test-issuer.example.com/.well-known/jwks.json",
+        audience="https://mnemon-test.example.com/mcp",
+        public_url="https://mnemon-test.example.com",
+        userinfo_url="https://test-issuer.example.com/userinfo",
+    )
+
+
+@pytest.mark.asyncio
+async def test_userinfo_fallback_accepts_opaque_token(
+    oauth_config_with_userinfo, monkeypatch
+):
+    """When JWT decode fails and userinfo returns 200, token is accepted."""
+    import httpx
+
+    class _FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"sub": "auth0|user123", "email": "test@example.com"}
+
+    class _FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, url, headers=None):
+            assert "Authorization" in headers
+            assert headers["Authorization"].startswith("Bearer ")
+            return _FakeResponse()
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+
+    downstream_called: list[bool] = []
+    app = _stub_downstream_factory(downstream_called)
+    mw = OAuthMiddleware(app, oauth_config_with_userinfo)
+
+    status, _, body = await _call_middleware(
+        mw,
+        "/mcp",
+        headers=[(b"authorization", b"Bearer opaque-token-not-a-jwt")],
+    )
+
+    assert status == 200
+    assert json.loads(body) == {"ok": True}
+    assert downstream_called == [True]
+
+
+@pytest.mark.asyncio
+async def test_userinfo_fallback_rejects_when_userinfo_returns_401(
+    oauth_config_with_userinfo, monkeypatch
+):
+    import httpx
+
+    class _FakeResponse:
+        status_code = 401
+
+        def json(self):
+            return {"error": "invalid_token"}
+
+    class _FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, url, headers=None):
+            return _FakeResponse()
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, oauth_config_with_userinfo)
+
+    status, _, body = await _call_middleware(
+        mw,
+        "/mcp",
+        headers=[(b"authorization", b"Bearer opaque-bad-token")],
+    )
+
+    assert status == 401
+    assert "userinfo rejected" in json.loads(body).get("error_description", "")
+
+
+@pytest.mark.asyncio
+async def test_no_userinfo_fallback_when_not_configured(oauth_config):
+    """When userinfo_url is unset, JWT failures produce immediate 401."""
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, oauth_config)  # no userinfo_url
+
+    status, _, body = await _call_middleware(
+        mw,
+        "/mcp",
+        headers=[(b"authorization", b"Bearer opaque-token")],
+    )
+
+    assert status == 401
+    # Description should only mention JWT failure, not userinfo
+    desc = json.loads(body).get("error_description", "")
+    assert "userinfo" not in desc


### PR DESCRIPTION
## Summary
Adds a userinfo introspection fallback for when JWT decode fails. Needed because Auth0's free/trial tier issues opaque access tokens scoped to /userinfo instead of audience-bound JWTs for OIDC-only flows — even when the client correctly sends RFC 8707 resource parameter.

## Problem
Investigation showed Auth0 logs reporting `audience: /userinfo` and pure OIDC scopes on tokens issued to claude.ai's DCR-registered client, despite the authorize request including `resource=https://mnemon-memory.fly.dev/mcp`. Mnemon's strict JWT middleware rejected these as "malformed payload" because they're opaque bytes, not JWTs.

## Fix
When JWT validation fails AND `MNEMON_OAUTH_USERINFO_URL` is set, the middleware falls back to calling the OAuth provider's /userinfo endpoint with the token. If /userinfo returns 200 with a profile, accept the token.

- Less strict than JWT audience binding (any valid tenant token accepted)
- 1 extra network hop per unique token (cached 5 min)
- Strict JWT-only mode preserved when `MNEMON_OAUTH_USERINFO_URL` is unset

## Test plan
- [x] 3 new tests covering fallback paths (accept, reject, strict-without-fallback)
- [x] 271 total tests passing
- [ ] Fly deploy + retry claude.ai connector flow (next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)