### PR TITLE
Add MNEMON_LOCAL_TOKEN static bearer auth path

### DIFF
--- a/src/mnemon/auth.py
+++ b/src/mnemon/auth.py
@@ -18,6 +18,7 @@ mounted FastMCP app.
 
 from __future__ import annotations
 
+import hmac
 import json
 import logging
 import os
@@ -33,11 +34,25 @@ ASGIApp = Callable[[ASGIScope, ASGIReceive, ASGISend], Awaitable[None]]
 
 
 class OAuthConfig:
-    """OAuth resource-server configuration loaded from environment.
+    """Resource-server auth configuration loaded from environment.
 
-    All fields are optional. If ``issuer``, ``jwks_url``, and ``audience`` are
-    all set, the server operates in authenticated mode. Otherwise the server
-    runs without auth (intended for local development only).
+    All fields are optional. Two auth paths are supported and can be enabled
+    independently or together:
+
+    1. **OAuth 2.1 JWT / userinfo** — when ``issuer``, ``jwks_url``, and
+       ``audience`` are set, the server accepts JWT bearer tokens from the
+       configured authorization server. Intended for browser-capable MCP
+       clients (claude.ai web/mobile, Claude Desktop) that can complete a
+       DCR + PKCE flow.
+    2. **Local static bearer** — when ``local_token`` is set, the server
+       accepts a specific bearer token value directly, without any network
+       roundtrip to the authorization server. Intended for headless clients
+       that cannot complete a browser OAuth flow (Claude Code hooks, Cursor,
+       scripts).
+
+    If both are configured, the local token is checked first. If neither is
+    configured, the server runs without auth (intended for local development
+    only — do not expose an unauthenticated server to the public internet).
     """
 
     def __init__(
@@ -47,6 +62,7 @@ class OAuthConfig:
         audience: str | None = None,
         public_url: str | None = None,
         userinfo_url: str | None = None,
+        local_token: str | None = None,
     ) -> None:
         self.issuer = issuer
         self.jwks_url = jwks_url
@@ -56,10 +72,16 @@ class OAuthConfig:
         # audience's scheme+host if unset.
         self.public_url = public_url
         # userinfo_url is an optional fallback for token introspection when
-        # JWT validation fails. Needed because some OAuth providers (e.g.,
-        # Auth0) issue opaque tokens for OIDC-only flows instead of JWTs
-        # bound to the requested audience. If unset, no fallback is used.
+        # JWT validation fails. Needed because some OAuth providers issue
+        # opaque tokens for OIDC-only flows instead of JWTs bound to the
+        # requested audience. If unset, no fallback is used.
         self.userinfo_url = userinfo_url
+        # local_token is a static bearer accepted for headless clients that
+        # cannot complete a browser OAuth flow. When set, the middleware
+        # accepts requests whose bearer matches this value exactly (using a
+        # constant-time comparison) without any network roundtrip. This value
+        # must never be logged — only the ``X-Mnemon-Client`` header label is.
+        self.local_token = local_token
 
     @classmethod
     def from_env(cls) -> OAuthConfig:
@@ -69,6 +91,7 @@ class OAuthConfig:
             audience=os.environ.get("MNEMON_OAUTH_AUDIENCE") or None,
             public_url=os.environ.get("MNEMON_PUBLIC_URL") or None,
             userinfo_url=os.environ.get("MNEMON_OAUTH_USERINFO_URL") or None,
+            local_token=os.environ.get("MNEMON_LOCAL_TOKEN") or None,
         )
 
     @property
@@ -142,8 +165,10 @@ class OAuthMiddleware:
             await _send_json(send, 200, self._protected_resource_metadata())
             return
 
-        # Unauthenticated mode — pass through.
-        if not self.config.enabled:
+        # Unauthenticated mode — pass through only when NEITHER auth method
+        # is configured. If local_token is set but OAuth is not, we still
+        # enforce auth below.
+        if not self.config.enabled and not self.config.local_token:
             await self.app(scope, receive, send)
             return
 
@@ -154,6 +179,38 @@ class OAuthMiddleware:
             return
 
         token = auth_header[7:].decode("ascii", errors="replace").strip()
+
+        # Local-token fast path: static bearer validated directly against
+        # MNEMON_LOCAL_TOKEN with a constant-time comparison. Used by clients
+        # that cannot complete a browser OAuth flow (Claude Code hooks,
+        # Cursor, headless scripts). Skips JWT and userinfo entirely — no
+        # network hop, no external AS dependency. Checked first so local
+        # clients don't pay the network cost of a failed JWT validation.
+        if self.config.local_token and hmac.compare_digest(
+            token, self.config.local_token
+        ):
+            client_header = _get_header(scope, b"x-mnemon-client")
+            client_label = (
+                client_header.decode("ascii", errors="replace")
+                if client_header
+                else "unknown"
+            )
+            logger.info("Accepted local token from client=%s", client_label)
+            await self.app(scope, receive, send)
+            return
+
+        # If only local_token is configured (no OAuth), any non-matching
+        # token is invalid — do not fall through to JWT/userinfo because
+        # neither is configured and _validate_token would raise on missing
+        # jwks_url. This path also covers the self-hosted / Phase 2 world
+        # where the OAuth block may be absent entirely.
+        if not self.config.enabled:
+            await self._send_401(
+                send,
+                error="invalid_token",
+                description="bearer token did not match local token",
+            )
+            return
 
         # Try JWT validation first (spec-compliant path).
         jwt_error: _OAuthError | None = None

--- a/src/mnemon/server_remote.py
+++ b/src/mnemon/server_remote.py
@@ -13,7 +13,13 @@ resource server per the MCP authorization spec (2025-06-18): it validates
 JWT bearer tokens from an external authorization server and serves RFC 9728
 Protected Resource Metadata for client discovery.
 
-When those env vars are unset, the server runs without auth (local
+``MNEMON_LOCAL_TOKEN`` enables a secondary static-bearer auth path for
+headless clients (Claude Code hooks, Cursor, scripts) that cannot complete
+a browser OAuth flow. The value must match exactly — the middleware does
+a constant-time comparison and skips JWT/userinfo validation on match.
+Can be combined with OAuth or used alone.
+
+When none of these env vars are set, the server runs without auth (local
 development only — do NOT expose an unauthenticated server to the public
 internet).
 
@@ -58,11 +64,17 @@ def run_remote() -> None:
             f"audience={config.audience})",
             file=sys.stderr,
         )
-    else:
+    if config.local_token:
+        print(
+            "Auth: local static bearer token enabled (MNEMON_LOCAL_TOKEN set)",
+            file=sys.stderr,
+        )
+    if not config.enabled and not config.local_token:
         print(
             "Auth: DISABLED — do not expose this server to the public internet. "
             "Set MNEMON_OAUTH_ISSUER, MNEMON_OAUTH_JWKS_URL, and "
-            "MNEMON_OAUTH_AUDIENCE to enable OAuth.",
+            "MNEMON_OAUTH_AUDIENCE to enable OAuth, or MNEMON_LOCAL_TOKEN "
+            "to enable local static bearer auth.",
             file=sys.stderr,
         )
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -508,3 +508,242 @@ async def test_no_userinfo_fallback_when_not_configured(oauth_config):
     # Description should only mention JWT failure, not userinfo
     desc = json.loads(body).get("error_description", "")
     assert "userinfo" not in desc
+
+
+# --- Local static bearer token path ---------------------------------------
+#
+# These tests cover the MNEMON_LOCAL_TOKEN auth path used by headless
+# clients (Claude Code hooks, Cursor, scripts) that cannot complete a
+# browser OAuth flow. The local token is checked before JWT/userinfo and
+# bypasses both on match.
+
+
+LOCAL_TOKEN_VALUE = "test-local-token-abcdef123456"
+
+
+@pytest.fixture
+def oauth_config_with_local_token(oauth_config) -> OAuthConfig:
+    """OAuth config with BOTH OAuth and local_token set."""
+    return OAuthConfig(
+        issuer=oauth_config.issuer,
+        jwks_url=oauth_config.jwks_url,
+        audience=oauth_config.audience,
+        public_url=oauth_config.public_url,
+        local_token=LOCAL_TOKEN_VALUE,
+    )
+
+
+@pytest.fixture
+def local_token_only_config() -> OAuthConfig:
+    """Config with ONLY local_token set — OAuth disabled entirely.
+
+    This previews the Phase 2 world where Auth0 is gone. If any middleware
+    code path silently requires OAuth env vars, tests using this fixture
+    will fail loudly.
+    """
+    return OAuthConfig(local_token=LOCAL_TOKEN_VALUE)
+
+
+@pytest.mark.asyncio
+async def test_local_token_accepted(oauth_config_with_local_token):
+    """Correct local token bypasses JWT validation and reaches downstream."""
+    downstream_called: list[bool] = []
+    app = _stub_downstream_factory(downstream_called)
+    mw = OAuthMiddleware(app, oauth_config_with_local_token)
+
+    status, _, body = await _call_middleware(
+        mw,
+        "/mcp",
+        headers=[(b"authorization", f"Bearer {LOCAL_TOKEN_VALUE}".encode())],
+    )
+
+    assert status == 200
+    assert json.loads(body) == {"ok": True}
+    assert downstream_called == [True]
+    # JWT client must NOT have been initialized — the local-token path
+    # should have short-circuited before _validate_token ran.
+    assert mw._jwks_client is None
+
+
+@pytest.mark.asyncio
+async def test_local_token_wrong_value_returns_401_when_oauth_enabled(
+    oauth_config_with_local_token, rsa_keypair, mock_signing_key
+):
+    """When OAuth is also configured, a wrong token falls through to JWT
+    validation (which also fails here because the wrong value isn't a JWT).
+    The downstream response must be a 401 with a proper WWW-Authenticate
+    header — never a 200, never a silent pass-through."""
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, oauth_config_with_local_token)
+
+    status, headers, body = await _call_middleware(
+        mw,
+        "/mcp",
+        headers=[(b"authorization", b"Bearer definitely-not-the-local-token")],
+    )
+
+    assert status == 401
+    assert b"www-authenticate" in headers
+    assert b"Bearer" in headers[b"www-authenticate"]
+    assert json.loads(body)["error"] == "invalid_token"
+
+
+@pytest.mark.asyncio
+async def test_local_token_precedence_over_oauth(
+    oauth_config_with_local_token,
+):
+    """When both auth methods are enabled and the token matches the local
+    token, the JWT path must not run at all. Verified by inspecting that
+    ``_jwks_client`` was never lazily initialized.
+
+    This test deliberately does NOT use the ``mock_signing_key`` fixture —
+    if the middleware incorrectly falls into the JWT path, PyJWKClient
+    would attempt a real network fetch against the fake JWKS URL and the
+    test would fail loudly rather than silently pass.
+    """
+    downstream_called: list[bool] = []
+    app = _stub_downstream_factory(downstream_called)
+    mw = OAuthMiddleware(app, oauth_config_with_local_token)
+
+    status, _, _ = await _call_middleware(
+        mw,
+        "/mcp",
+        headers=[(b"authorization", f"Bearer {LOCAL_TOKEN_VALUE}".encode())],
+    )
+
+    assert status == 200
+    assert downstream_called == [True]
+    assert mw._jwks_client is None
+
+
+@pytest.mark.asyncio
+async def test_local_token_works_without_oauth_config(local_token_only_config):
+    """Local token auth must work with OAuth entirely unconfigured.
+
+    This is a guardrail test for the Phase 2 / self-hosted-AS future: when
+    ``MNEMON_OAUTH_*`` env vars are all unset, the middleware should still
+    enforce auth via the local token path. Any regression here means a
+    hidden Auth0/OAuth dependency has crept in.
+    """
+    downstream_called: list[bool] = []
+    app = _stub_downstream_factory(downstream_called)
+    mw = OAuthMiddleware(app, local_token_only_config)
+
+    # Correct token → accepted, downstream called.
+    status, _, body = await _call_middleware(
+        mw,
+        "/mcp",
+        headers=[(b"authorization", f"Bearer {LOCAL_TOKEN_VALUE}".encode())],
+    )
+    assert status == 200
+    assert json.loads(body) == {"ok": True}
+    assert downstream_called == [True]
+    assert mw._jwks_client is None
+
+
+@pytest.mark.asyncio
+async def test_local_token_only_rejects_wrong_token(local_token_only_config):
+    """With only local token configured, wrong tokens must return 401 —
+    not fall through to a JWT path that would raise on missing jwks_url."""
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, local_token_only_config)
+
+    status, headers, body = await _call_middleware(
+        mw,
+        "/mcp",
+        headers=[(b"authorization", b"Bearer wrong-token-value")],
+    )
+
+    assert status == 401
+    assert b"www-authenticate" in headers
+    assert json.loads(body)["error"] == "invalid_token"
+    # JWT path must NOT have been entered — no jwks_url to fetch.
+    assert mw._jwks_client is None
+
+
+@pytest.mark.asyncio
+async def test_local_token_only_missing_auth_header_returns_401(
+    local_token_only_config,
+):
+    """Missing Authorization header returns 401 even when only local token
+    is configured — auth is still required, just via a different path."""
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, local_token_only_config)
+
+    status, _, body = await _call_middleware(mw, "/mcp")
+
+    assert status == 401
+    assert json.loads(body)["error"] == "missing_token"
+
+
+@pytest.mark.asyncio
+async def test_local_token_logs_client_header(
+    oauth_config_with_local_token, caplog
+):
+    """The X-Mnemon-Client header value should appear in the accept log
+    line for attribution. The token value itself must NEVER be logged."""
+    import logging as _logging
+
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, oauth_config_with_local_token)
+
+    with caplog.at_level(_logging.INFO, logger="mnemon.auth"):
+        status, _, _ = await _call_middleware(
+            mw,
+            "/mcp",
+            headers=[
+                (b"authorization", f"Bearer {LOCAL_TOKEN_VALUE}".encode()),
+                (b"x-mnemon-client", b"claude-code"),
+            ],
+        )
+
+    assert status == 200
+    # Client label surfaced in logs.
+    assert any("claude-code" in record.message for record in caplog.records)
+    # Token value must not appear anywhere in log output.
+    for record in caplog.records:
+        assert LOCAL_TOKEN_VALUE not in record.message
+
+
+@pytest.mark.asyncio
+async def test_local_token_logs_unknown_when_header_missing(
+    oauth_config_with_local_token, caplog
+):
+    """When no X-Mnemon-Client header is sent, the accept log records
+    the client as 'unknown' rather than crashing or omitting the field."""
+    import logging as _logging
+
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, oauth_config_with_local_token)
+
+    with caplog.at_level(_logging.INFO, logger="mnemon.auth"):
+        status, _, _ = await _call_middleware(
+            mw,
+            "/mcp",
+            headers=[(b"authorization", f"Bearer {LOCAL_TOKEN_VALUE}".encode())],
+        )
+
+    assert status == 200
+    assert any("unknown" in record.message for record in caplog.records)
+
+
+# --- Config loading — local token path -----------------------------------
+
+
+def test_oauth_config_local_token_none_by_default(monkeypatch):
+    monkeypatch.delenv("MNEMON_LOCAL_TOKEN", raising=False)
+    config = OAuthConfig.from_env()
+    assert config.local_token is None
+
+
+def test_oauth_config_loads_local_token_from_env(monkeypatch):
+    monkeypatch.setenv("MNEMON_LOCAL_TOKEN", "env-loaded-token-value")
+    config = OAuthConfig.from_env()
+    assert config.local_token == "env-loaded-token-value"
+
+
+def test_oauth_config_empty_local_token_coerced_to_none(monkeypatch):
+    """Empty string env var is treated as unset (matches other env fields)."""
+    monkeypatch.setenv("MNEMON_LOCAL_TOKEN", "")
+    config = OAuthConfig.from_env()
+    assert config.local_token is None


### PR DESCRIPTION
## Summary

Adds a second auth path to the mnemon remote server: a static bearer token validated directly by the middleware, checked before JWT/userinfo and bypassing both on match. Used by headless clients (Claude Code hooks, Cursor, scripts) that cannot complete a browser OAuth flow.

This is work item 2 of the Phase 3 unification plan (`private/mnemon-plan-unification-260410.md`). With this merged, the local-token side of the plan is ready; hooks rewrite (work items 4–5) is next.

## Why

OAuth 2.1 DCR + PKCE works great for claude.ai web/mobile and Claude Desktop's Connectors UI, but headless clients can't complete a browser flow. Rather than build a device-code flow or per-machine M2M client-credentials setup, a static long-lived bearer (stored 0600 on the machine that owns it) is the simplest path that doesn't add infrastructure. Trade-offs accepted in the plan doc under "Decision 1."

## Design

- **Two independent auth paths on the same server.** OAuth stays for browser-capable clients; local token added for headless. Either can be enabled alone or both together. Neither set → passthrough (local dev only).
- **Local token is checked first** so local clients skip the Auth0 network hop entirely. If the token doesn't match and OAuth isn't configured, 401 immediately — no fallback to a JWT path that would raise on missing jwks_url.
- **Constant-time comparison via `hmac.compare_digest`** to avoid timing attacks that could leak the token character by character.
- **`X-Mnemon-Client` header** is logged on accepted local-token requests for per-client attribution (`claude-code`, `cursor`, etc.). The token value itself is never logged.

## Phase 2 compatibility

The scope update in the plan doc requires Phase 3 work to be written provider-agnostic so that Phase 2 (replace Auth0 with a self-hosted AS via authlib) becomes a config swap, not a refactor. Specifically for this PR:

- No `auth0` string appears in any new code, log line, error text, or comment
- Test case `test_local_token_works_without_oauth_config` runs the middleware with `MNEMON_OAUTH_*` entirely unset — if any code path silently requires OAuth env vars, this test fails loudly
- `server_remote.py` startup log and docstring report the local-token path independently of the OAuth path

## Changes

- **`src/mnemon/auth.py`**
  - `OAuthConfig`: new `local_token` field loaded from `MNEMON_LOCAL_TOKEN`
  - `OAuthMiddleware.__call__`: passthrough check now requires both auth methods unset; local-token fast path added between header extraction and JWT validation
- **`src/mnemon/server_remote.py`**: startup log prints each active auth mode; docstring describes the local-token path; `DISABLED` message now only fires when NEITHER mode is configured
- **`tests/test_auth.py`**: 11 new tests

## Test plan

- [x] 282 tests passing locally (271 pre-existing + 11 new)
  - `test_local_token_accepted` — correct token + both methods enabled → 200, downstream called, `_jwks_client` never initialized
  - `test_local_token_wrong_value_returns_401_when_oauth_enabled` — wrong token + JWT mock → 401 with proper WWW-Authenticate
  - `test_local_token_precedence_over_oauth` — deliberately omits JWT mock; passing proves local-token path bypassed JWT path entirely
  - `test_local_token_works_without_oauth_config` — guardrail test for Phase 2 world
  - `test_local_token_only_rejects_wrong_token` — wrong token with only local_token configured → 401 (no JWT fallthrough)
  - `test_local_token_only_missing_auth_header_returns_401` — missing header still returns 401
  - `test_local_token_logs_client_header` — `X-Mnemon-Client` appears in logs, token value does NOT
  - `test_local_token_logs_unknown_when_header_missing` — graceful fallback when header absent
  - Three `from_env` tests for env var loading (present / missing / empty string)
- [ ] Deploy to Fly, set `MNEMON_LOCAL_TOKEN` as a Fly secret, verify with curl both auth paths work independently against the live deployment (post-merge)

## Deployment (post-merge)

```
python -c "import secrets; print(secrets.token_urlsafe(32))"   # record in password manager
fly secrets set MNEMON_LOCAL_TOKEN="<value>" -a mnemon-memory
fly deploy -a mnemon-memory
```

Then verify:

```
curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer <value>" -H "X-Mnemon-Client: curl-test" https://mnemon-memory.fly.dev/mcp   # expect non-401
curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer wrong-token" https://mnemon-memory.fly.dev/mcp   # expect 401
```

Existing Auth0 path should continue to work unchanged for claude.ai web/mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)