### PR TITLE
Add health visibility to context-surfacing hook

### DIFF
--- a/src/mnemon/hooks/_remote_client.py
+++ b/src/mnemon/hooks/_remote_client.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import time
 from pathlib import Path
 from typing import Any
 
@@ -163,7 +164,7 @@ def call_tool_sync(
     *,
     timeout: float = DEFAULT_TIMEOUT_SEC,
     client_label: str = DEFAULT_CLIENT_LABEL,
-) -> str:
+) -> tuple[str, float]:
     """Synchronous wrapper for hook scripts.
 
     Runs :func:`_call_tool_async` on a fresh event loop per call. Hooks
@@ -171,13 +172,20 @@ def call_tool_sync(
     run, so the per-call loop cost is negligible compared to the network
     round-trip.
 
+    Returns:
+        A ``(result, elapsed_seconds)`` tuple. ``elapsed_seconds`` is the
+        wall-clock time for the full call, measured with
+        :func:`time.monotonic`. Callers can use it to surface latency
+        warnings when the round-trip exceeds a threshold.
+
     Raises:
         RemoteClientConfigError: if URL or token can't be resolved.
         asyncio.TimeoutError: if the call exceeds ``timeout`` seconds.
         Other exceptions propagate from the MCP SDK / httpx for the caller
         to log as it sees fit.
     """
-    return asyncio.run(
+    t0 = time.monotonic()
+    result = asyncio.run(
         _call_tool_async(
             tool_name,
             arguments,
@@ -185,3 +193,4 @@ def call_tool_sync(
             client_label=client_label,
         )
     )
+    return result, time.monotonic() - t0

--- a/src/mnemon/hooks/context_surfacing.py
+++ b/src/mnemon/hooks/context_surfacing.py
@@ -37,8 +37,11 @@ SEARCH_LIMIT = 8
 # Kept in sync with src/mnemon/server.py memory_search().
 NO_RESULTS_SENTINEL = "No memories found matching your query."
 
+# Wall-clock threshold above which a successful call is flagged as slow.
+SLOW_THRESHOLD_SEC = 3.0
 
-def build_context(raw_text: str) -> str:
+
+def build_context(raw_text: str, *, prefix: str = "") -> str:
     """Wrap the ``memory_search`` response in a ``<mnemon-context>`` block.
 
     The server returns a pre-formatted markdown list of matches, each
@@ -46,6 +49,9 @@ def build_context(raw_text: str) -> str:
     and wrap it in a containing tag so Claude can recognise it as mnemon
     context. A character budget is enforced as a safety net in case the
     server ever returns an unexpectedly long payload.
+
+    ``prefix`` is prepended inside the block before the memories header —
+    used to surface latency warnings on slow-but-successful calls.
 
     Returns an empty string when there's nothing worth injecting — empty
     input, the server's no-results sentinel, or whitespace-only content.
@@ -59,12 +65,23 @@ def build_context(raw_text: str) -> str:
         return ""
     if len(trimmed) > CHAR_BUDGET:
         trimmed = trimmed[:CHAR_BUDGET].rstrip() + "\n...[truncated]"
-    return (
-        "<mnemon-context>\n"
-        "Relevant memories from previous sessions:\n"
-        f"{trimmed}\n"
-        "</mnemon-context>"
-    )
+    lines = []
+    if prefix:
+        lines.append(prefix)
+    lines.append("Relevant memories from previous sessions:")
+    lines.append(trimmed)
+    inner = "\n".join(lines)
+    return f"<mnemon-context>\n{inner}\n</mnemon-context>"
+
+
+def build_warning_context(message: str) -> str:
+    """Wrap a health-indicator warning in a ``<mnemon-context>`` block.
+
+    Used when the remote call fails or is misconfigured — emits a visible
+    warning into the prompt context rather than silently logging to stderr.
+    The user sees it on every affected prompt without having to watch logs.
+    """
+    return f"<mnemon-context>\n{message}\n</mnemon-context>"
 
 
 def main() -> None:
@@ -87,31 +104,41 @@ def main() -> None:
             return
 
         try:
-            raw = call_tool_sync(
+            raw, elapsed = call_tool_sync(
                 "memory_search",
                 {"query": prompt, "limit": SEARCH_LIMIT},
                 client_label=CLIENT_LABEL,
             )
         except RemoteClientConfigError as e:
-            # Configuration problem — URL or token not resolvable. Report
-            # once to stderr and continue with no context; there's no point
-            # retrying a misconfiguration inside a hook. Do NOT mark_seen —
-            # the user can fix the config and retry the same prompt
-            # immediately.
-            print(
-                f"mnemon context-surfacing config error: {e}",
-                file=sys.stderr,
-            )
+            # Configuration problem — URL or token not resolvable. Emit a
+            # visible warning block so the user sees it in the prompt context,
+            # not just buried in stderr. Do NOT mark_seen — the user can fix
+            # the config and retry the same prompt immediately.
+            msg = f"⚠ mnemon config error: {e}"
+            print(f"mnemon context-surfacing config error: {e}", file=sys.stderr)
+            write_output({
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": build_warning_context(msg),
+                },
+            })
             return
         except Exception as e:
             # Network error, timeout, auth failure, or MCP protocol error.
-            # Log to stderr and continue — never crash Claude Code. Do NOT
+            # Emit a visible warning block and log to stderr. Do NOT
             # mark_seen so the same prompt can retry after the transient
-            # failure clears (e.g., wifi reconnect).
+            # failure clears (e.g., wifi reconnect, Fly cold-start wakes).
+            msg = f"⚠ mnemon unavailable: {type(e).__name__}: {e}"
             print(
                 f"mnemon context-surfacing remote error: {type(e).__name__}: {e}",
                 file=sys.stderr,
             )
+            write_output({
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": build_warning_context(msg),
+                },
+            })
             return
 
         # Remote call succeeded — record the prompt as seen so we don't
@@ -120,7 +147,12 @@ def main() -> None:
         # clean and retryable.
         mark_seen(prompt)
 
-        context = build_context(raw)
+        slow_prefix = (
+            f"⚠ mnemon slow: {elapsed:.1f}s"
+            if elapsed > SLOW_THRESHOLD_SEC
+            else ""
+        )
+        context = build_context(raw, prefix=slow_prefix)
         if not context:
             return
 

--- a/tests/test_hooks_extended.py
+++ b/tests/test_hooks_extended.py
@@ -318,7 +318,7 @@ class TestContextSurfacingMain:
             "mnemon.hooks.framework.write_output"
         ) as mock_write, patch(
             "mnemon.hooks._remote_client.call_tool_sync",
-            return_value=raw_tool_output,
+            return_value=(raw_tool_output, 0.5),
         ) as mock_call:
             main()
 
@@ -402,7 +402,7 @@ class TestContextSurfacingMain:
             "mnemon.hooks.framework.write_output"
         ) as mock_write, patch(
             "mnemon.hooks._remote_client.call_tool_sync",
-            return_value=NO_RESULTS_SENTINEL,
+            return_value=(NO_RESULTS_SENTINEL, 0.3),
         ):
             main()
         mock_write.assert_not_called()
@@ -412,10 +412,11 @@ class TestContextSurfacingMain:
         self, capsys
     ):
         """Network errors must not crash the hook — log to stderr, exit 0,
-        no output written. Critically, mark_seen must NOT fire on failure,
-        so the exact same prompt can be retried immediately once the
-        transient failure clears (wifi reconnect, Fly cold start wakes,
-        etc.). The exception type is included in the stderr line so
+        and emit a visible warning context block so the user sees the
+        outage without having to watch logs. Critically, mark_seen must NOT
+        fire on failure so the exact same prompt can be retried immediately
+        once the transient failure clears (wifi reconnect, Fly cold-start
+        wakes, etc.). The exception type is included in the stderr line so
         empty-str exceptions like asyncio.TimeoutError still produce a
         debuggable trace."""
         from mnemon.hooks.context_surfacing import main
@@ -436,7 +437,12 @@ class TestContextSurfacingMain:
             side_effect=ConnectionError("connection refused"),
         ):
             main()
-        mock_write.assert_not_called()
+        # Warning context block emitted so user sees it in the prompt.
+        mock_write.assert_called_once()
+        injected = mock_write.call_args[0][0]["hookSpecificOutput"]["additionalContext"]
+        assert "⚠ mnemon unavailable" in injected
+        assert "ConnectionError" in injected
+        assert "connection refused" in injected
         mock_mark_seen.assert_not_called()
         captured = capsys.readouterr()
         assert "remote error" in captured.err
@@ -447,7 +453,8 @@ class TestContextSurfacingMain:
         """asyncio.TimeoutError has an empty str() which caused the
         original 'remote error: ' empty message during smoke testing.
         The rewritten error handler includes the exception class name so
-        even empty-message exceptions produce a debuggable log line."""
+        even empty-message exceptions produce a debuggable log line and
+        a visible warning context block."""
         import asyncio
 
         from mnemon.hooks.context_surfacing import main
@@ -463,18 +470,22 @@ class TestContextSurfacingMain:
             "mnemon.hooks.framework.mark_seen"
         ), patch(
             "mnemon.hooks.framework.write_output"
-        ), patch(
+        ) as mock_write, patch(
             "mnemon.hooks._remote_client.call_tool_sync",
             side_effect=asyncio.TimeoutError(),
         ):
             main()
         captured = capsys.readouterr()
         assert "TimeoutError" in captured.err
+        mock_write.assert_called_once()
+        injected = mock_write.call_args[0][0]["hookSpecificOutput"]["additionalContext"]
+        assert "⚠ mnemon unavailable" in injected
+        assert "TimeoutError" in injected
 
     def test_config_error_degrades_gracefully(self, capsys):
-        """Missing URL/token should log a specific config error, exit 0,
-        and must NOT mark the prompt as seen — the user can fix the
-        config and retry immediately."""
+        """Missing URL/token should log a specific config error, emit a
+        visible warning context block, exit 0, and must NOT mark the prompt
+        as seen — the user can fix the config and retry immediately."""
         from mnemon.hooks._remote_client import RemoteClientConfigError
         from mnemon.hooks.context_surfacing import main
 
@@ -494,10 +505,86 @@ class TestContextSurfacingMain:
             side_effect=RemoteClientConfigError("no token"),
         ):
             main()
-        mock_write.assert_not_called()
+        mock_write.assert_called_once()
+        injected = mock_write.call_args[0][0]["hookSpecificOutput"]["additionalContext"]
+        assert "⚠ mnemon config error" in injected
+        assert "no token" in injected
         mock_mark_seen.assert_not_called()
         captured = capsys.readouterr()
         assert "config error" in captured.err
+
+
+    def test_slow_success_prepends_warning(self):
+        """When the remote call succeeds but takes >3s, the context block
+        must start with a ⚠ mnemon slow: warning so the user sees the
+        latency degradation without watching logs."""
+        from mnemon.hooks.context_surfacing import SLOW_THRESHOLD_SEC, main
+
+        raw_tool_output = (
+            "1. [note] **Thing** (score: 0.80)\n"
+            "   Some content\n"
+            "   _id: 1 | created: 2026-04-11_"
+        )
+        slow_elapsed = SLOW_THRESHOLD_SEC + 1.0
+
+        with patch(
+            "mnemon.hooks.framework.read_stdin",
+            return_value={"prompt": "how does it work?"},
+        ), patch(
+            "mnemon.hooks.framework.is_noise", return_value=False
+        ), patch(
+            "mnemon.hooks.framework.is_duplicate", return_value=False
+        ), patch(
+            "mnemon.hooks.framework.mark_seen"
+        ), patch(
+            "mnemon.hooks.framework.write_output"
+        ) as mock_write, patch(
+            "mnemon.hooks._remote_client.call_tool_sync",
+            return_value=(raw_tool_output, slow_elapsed),
+        ):
+            main()
+
+        mock_write.assert_called_once()
+        injected = mock_write.call_args[0][0]["hookSpecificOutput"]["additionalContext"]
+        assert "⚠ mnemon slow:" in injected
+        assert f"{slow_elapsed:.1f}s" in injected
+        # Memories still present after the warning.
+        assert "Thing" in injected
+        assert "Some content" in injected
+
+    def test_fast_success_no_slow_warning(self):
+        """When elapsed is within the threshold, no slow warning is emitted —
+        the context block contains only the memories header and results."""
+        from mnemon.hooks.context_surfacing import SLOW_THRESHOLD_SEC, main
+
+        raw_tool_output = (
+            "1. [note] **Fast** (score: 0.90)\n"
+            "   Quick response\n"
+            "   _id: 2 | created: 2026-04-11_"
+        )
+        fast_elapsed = SLOW_THRESHOLD_SEC - 0.5
+
+        with patch(
+            "mnemon.hooks.framework.read_stdin",
+            return_value={"prompt": "quick query"},
+        ), patch(
+            "mnemon.hooks.framework.is_noise", return_value=False
+        ), patch(
+            "mnemon.hooks.framework.is_duplicate", return_value=False
+        ), patch(
+            "mnemon.hooks.framework.mark_seen"
+        ), patch(
+            "mnemon.hooks.framework.write_output"
+        ) as mock_write, patch(
+            "mnemon.hooks._remote_client.call_tool_sync",
+            return_value=(raw_tool_output, fast_elapsed),
+        ):
+            main()
+
+        mock_write.assert_called_once()
+        injected = mock_write.call_args[0][0]["hookSpecificOutput"]["additionalContext"]
+        assert "⚠ mnemon slow" not in injected
+        assert "Fast" in injected
 
 
 # ── session_extractor.py: extract_with_llm ───────────────────────────────────

--- a/tests/test_hooks_remote_client.py
+++ b/tests/test_hooks_remote_client.py
@@ -151,8 +151,9 @@ class TestCallToolSync:
 
         monkeypatch.setattr(_remote_client, "_call_tool_async", _fake)
 
-        result = call_tool_sync("memory_search", {"query": "test", "limit": 5})
+        result, elapsed = call_tool_sync("memory_search", {"query": "test", "limit": 5})
         assert result == "fake tool output"
+        assert elapsed >= 0
 
     def test_passes_custom_timeout_and_label(self, monkeypatch):
         captured = {}


### PR DESCRIPTION
## Summary

- `_remote_client.call_tool_sync` now returns `(str, float)` — the result plus wall-clock elapsed time, measured with `time.monotonic()`
- Slow calls (>3s) prepend `⚠ mnemon slow: X.Xs` inside the `<mnemon-context>` block so latency is visible in every affected prompt
- Network/timeout/auth failures now emit a `⚠ mnemon unavailable: <reason>` warning context block to stdout in addition to logging to stderr — previously silent from the user's perspective
- Config errors (missing URL/token) similarly emit `⚠ mnemon config error: <reason>` as a visible block

## Test plan

- [ ] Existing `TestContextSurfacingMain` tests updated to use tuple mocks; all pass
- [ ] New `test_slow_success_prepends_warning`: elapsed > threshold → slow warning in injected context
- [ ] New `test_fast_success_no_slow_warning`: elapsed < threshold → no warning
- [ ] Updated `test_remote_error_degrades_gracefully_and_does_not_mark_seen`: write_output now asserted called with ⚠ mnemon unavailable
- [ ] Updated `test_config_error_degrades_gracefully`: write_output now asserted called with ⚠ mnemon config error
- [ ] Full suite: 305 passed

Generated with Claude Code