### PR TITLE
Fix stale docs and code smells from system audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)]()
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-253_passing-brightgreen.svg)]()
+[![Tests](https://img.shields.io/badge/tests-327_passing-brightgreen.svg)]()
 [![Coverage](https://img.shields.io/badge/coverage-90%25-brightgreen.svg)]()
 [![MCP](https://img.shields.io/badge/MCP-compatible-blueviolet.svg)](https://modelcontextprotocol.io)
 [![PyPI](https://img.shields.io/badge/PyPI-v0.2.0-blue.svg)](https://pypi.org/project/mnemon-memory/)
@@ -151,7 +151,7 @@ For use with Claude.ai web or iOS (any Streamable HTTP MCP client):
 mnemon serve-remote
 
 # With authentication (at proxy/infra level)
-MNEMON_TOKEN=your-secret-token mnemon serve-remote
+MNEMON_LOCAL_TOKEN=your-secret-token mnemon serve-remote
 
 # Custom port
 PORT=9000 mnemon serve-remote
@@ -199,7 +199,7 @@ Requires the AWS CLI (`aws`) on your PATH with valid credentials.
 | Env var | Default | Description |
 |---------|---------|-------------|
 | `MNEMON_VAULT_DIR` | `~/.mnemon` | Vault directory |
-| `MNEMON_TOKEN` | (none) | Bearer token for remote server auth |
+| `MNEMON_LOCAL_TOKEN` | (none) | Bearer token for remote server auth |
 | `MNEMON_MODEL_DIR` | `~/.mnemon/models` | Directory for LLM model files |
 | `PORT` | `8502` | Remote server port |
 

--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -183,7 +183,7 @@ Usage:
 
 Env vars:
   MNEMON_VAULT_DIR    Vault directory (default: ~/.mnemon)
-  MNEMON_TOKEN        Bearer token for remote server auth
+  MNEMON_LOCAL_TOKEN  Bearer token for remote server auth
   MNEMON_S3_BUCKET    S3 bucket for vault sync
   PORT                Remote server port (default: 8502)
 

--- a/src/mnemon/hooks/handoff_generator.py
+++ b/src/mnemon/hooks/handoff_generator.py
@@ -69,7 +69,7 @@ def generate_with_llm(transcript: str) -> dict | None:
         return None
 
 
-# ── Regex Fallback (Phase 2 heuristics) ────────────────────────────────────
+# ── Regex Fallback (when LLM unavailable) ──────────────────────────────────
 
 def generate_with_regex(transcript: str) -> dict | None:
     """Fallback: generate handoff using regex heuristics."""

--- a/src/mnemon/hooks/session_extractor.py
+++ b/src/mnemon/hooks/session_extractor.py
@@ -80,7 +80,7 @@ def extract_with_llm(transcript: str) -> list[dict] | None:
         return None
 
 
-# ── Regex Fallback (Phase 2 heuristics) ────────────────────────────────────
+# ── Regex Fallback (when LLM unavailable) ──────────────────────────────────
 
 DECISION_PATTERNS = [
     re.compile(r"(?:decided|decision|chose|choosing|going with|went with|settled on)\s+(.{20,200})", re.I),
@@ -149,8 +149,7 @@ def is_duplicate_remote(title: str, content: str) -> bool:
         # The server returns formatted text with similarity scores like:
         #   "1. [type] **title** (score: 0.456, confidence: 0.80)"
         # Check if any score exceeds our dedup threshold.
-        import re as _re
-        scores = _re.findall(r"score:\s*([\d.]+)", raw)
+        scores = re.findall(r"score:\s*([\d.]+)", raw)
         return any(float(s) > 0.92 for s in scores)
     except Exception:
         return False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,7 +53,7 @@ class TestVersionAndHelp:
         _print_usage()
         out = capsys.readouterr().out
         assert "MNEMON_VAULT_DIR" in out
-        assert "MNEMON_TOKEN" in out
+        assert "MNEMON_LOCAL_TOKEN" in out
         assert "MNEMON_S3_BUCKET" in out
 
 


### PR DESCRIPTION
## Summary
- Fix `MNEMON_TOKEN` → `MNEMON_LOCAL_TOKEN` in CLI help, README env var table, and README example (P0 — users would set wrong env var)
- Remove redundant `import re as _re` inside `is_duplicate_remote` (module-level `re` already imported)
- Update test count badge: 253 → 327
- Fix misleading "Phase 2 heuristics" comments → "when LLM unavailable"

From system audit at `private/mnemon-system-audit-260412.md`.

## Test plan
- [x] All 327 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)