### PR TITLE
Refactor: consolidate hook constants, rename mmr_filter, unify LLM fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ dist/
 build/
 .venv/
 .pytest_cache/
+pytest-of-*/
+fastembed_cache/
 
 # Vault data (local only)
 *.sqlite

--- a/src/mnemon/config.py
+++ b/src/mnemon/config.py
@@ -67,6 +67,35 @@ COMPOSITE_WEIGHTS = (0.5, 0.25, 0.25)  # (relevance, recency, confidence)
 RECENCY_HALF_LIFE_DAYS = 30
 PIN_BOOST = 0.3
 
+# Hook timeouts and budgets (seconds / chars)
+#
+# HOOK_REMOTE_TIMEOUT_SEC — matches Claude Code's ~/.claude/settings.json
+# hook timeout budget. Longer than the 2s the original plan called for
+# because Fly cold starts (wake machine + load FastEmbed ONNX) can take
+# 15-25s before the machine responds; 8s lets a warm machine always
+# succeed while a cold one surfaces a clean timeout.
+HOOK_REMOTE_TIMEOUT_SEC = 8.0
+
+# HOOK_DEDUP_TIMEOUT_SEC — tighter budget for the session_extractor
+# dedup check (memory_search against the Fly vault). Runs in a Stop
+# hook loop so each observation gets its own call; shorter timeout keeps
+# the loop from stacking up against the 30s hook ceiling.
+HOOK_DEDUP_TIMEOUT_SEC = 5.0
+
+# HOOK_DEDUP_SIMILARITY_THRESHOLD — cosine similarity above which a new
+# observation is treated as a duplicate of an existing memory.
+HOOK_DEDUP_SIMILARITY_THRESHOLD = 0.92
+
+# Context surfacing budget (context_surfacing hook)
+HOOK_TOKEN_BUDGET = 800          # approx tokens injected per prompt
+HOOK_CHARS_PER_TOKEN = 4         # rough conversion factor
+HOOK_CHAR_BUDGET = HOOK_TOKEN_BUDGET * HOOK_CHARS_PER_TOKEN
+
+# HOOK_SLOW_THRESHOLD_SEC — elapsed time above which a successful
+# context_surfacing call prefixes a ⚠ slow warning. Lets the user see
+# latency degradation in the prompt itself without watching logs.
+HOOK_SLOW_THRESHOLD_SEC = 3.0
+
 # Content type enum values for validation
 CONTENT_TYPE_VALUES = [ct.value for ct in ContentType]
 

--- a/src/mnemon/hooks/_remote_client.py
+++ b/src/mnemon/hooks/_remote_client.py
@@ -48,14 +48,12 @@ import time
 from pathlib import Path
 from typing import Any
 
-# 8 seconds gives us headroom for Fly cold starts — when auto_stop_machines
-# lets the VM sleep between sessions, the first request has to wake the
-# machine (1-3s), warm up uvicorn (~1s), and load the FastEmbed ONNX model
-# on the first memory_search call (2-4s). 2s (the plan's original value) was
-# too tight and caused silent timeouts that surfaced as empty-string errors.
-# Claude Code's own hook timeout is 8s in ~/.claude/settings.json, so this
-# matches — if the hook runs out of budget, it runs out of budget.
-DEFAULT_TIMEOUT_SEC = 8.0
+from ..config import HOOK_REMOTE_TIMEOUT_SEC
+
+# Re-exported for callers that import DEFAULT_TIMEOUT_SEC directly. See
+# ``config.HOOK_REMOTE_TIMEOUT_SEC`` for the rationale on why this is 8s
+# rather than the plan's original 2s (Fly cold-start handling).
+DEFAULT_TIMEOUT_SEC = HOOK_REMOTE_TIMEOUT_SEC
 DEFAULT_CLIENT_LABEL = "claude-code"
 
 MNEMON_DIR = Path.home() / ".mnemon"

--- a/src/mnemon/hooks/context_surfacing.py
+++ b/src/mnemon/hooks/context_surfacing.py
@@ -24,11 +24,18 @@ from __future__ import annotations
 
 import sys
 
-# Overall character budget for the injected context. Kept generous
-# because the server already truncates each result to a 300-char snippet.
-TOKEN_BUDGET = 800
-CHARS_PER_TOKEN = 4
-CHAR_BUDGET = TOKEN_BUDGET * CHARS_PER_TOKEN
+from ..config import (
+    HOOK_CHAR_BUDGET,
+    HOOK_CHARS_PER_TOKEN,
+    HOOK_SLOW_THRESHOLD_SEC,
+    HOOK_TOKEN_BUDGET,
+)
+
+# Re-exported for tests and external callers. See ``config`` for rationale.
+TOKEN_BUDGET = HOOK_TOKEN_BUDGET
+CHARS_PER_TOKEN = HOOK_CHARS_PER_TOKEN
+CHAR_BUDGET = HOOK_CHAR_BUDGET
+SLOW_THRESHOLD_SEC = HOOK_SLOW_THRESHOLD_SEC
 
 CLIENT_LABEL = "claude-code-context-surfacing"
 SEARCH_LIMIT = 8
@@ -36,9 +43,6 @@ SEARCH_LIMIT = 8
 # Sentinel string the server returns when memory_search finds nothing.
 # Kept in sync with src/mnemon/server.py memory_search().
 NO_RESULTS_SENTINEL = "No memories found matching your query."
-
-# Wall-clock threshold above which a successful call is flagged as slow.
-SLOW_THRESHOLD_SEC = 3.0
 
 
 def build_context(raw_text: str, *, prefix: str = "") -> str:

--- a/src/mnemon/hooks/handoff_generator.py
+++ b/src/mnemon/hooks/handoff_generator.py
@@ -57,16 +57,14 @@ def parse_handoff(response: str) -> dict | None:
 
 def generate_with_llm(transcript: str) -> dict | None:
     """Generate handoff using local LLM. Returns None if LLM unavailable."""
-    try:
-        from ..llm import generate, is_available
-        if not is_available():
-            return None
-        response = generate(HANDOFF_SYSTEM_PROMPT, transcript, max_tokens=500)
-        if "<none/>" in response:
-            return {"skip": True}
-        return parse_handoff(response)
-    except Exception:
+    from ..llm import try_generate
+
+    response = try_generate(HANDOFF_SYSTEM_PROMPT, transcript, max_tokens=500)
+    if response is None:
         return None
+    if "<none/>" in response:
+        return {"skip": True}
+    return parse_handoff(response)
 
 
 # ── Regex Fallback (when LLM unavailable) ──────────────────────────────────

--- a/src/mnemon/hooks/session_extractor.py
+++ b/src/mnemon/hooks/session_extractor.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import re
 import sys
 
+from ..config import HOOK_DEDUP_SIMILARITY_THRESHOLD, HOOK_DEDUP_TIMEOUT_SEC
+
 # ── LLM Extraction ──────────────────────────────────────────────────────────
 
 EXTRACTION_SYSTEM_PROMPT = (
@@ -68,16 +70,14 @@ def parse_observations(response: str) -> list[dict]:
 
 def extract_with_llm(transcript: str) -> list[dict] | None:
     """Extract observations using local LLM. Returns None if LLM unavailable."""
-    try:
-        from ..llm import generate, is_available
-        if not is_available():
-            return None
-        response = generate(EXTRACTION_SYSTEM_PROMPT, transcript, max_tokens=2000)
-        if "<none/>" in response:
-            return []
-        return parse_observations(response)
-    except Exception:
+    from ..llm import try_generate
+
+    response = try_generate(EXTRACTION_SYSTEM_PROMPT, transcript, max_tokens=2000)
+    if response is None:
         return None
+    if "<none/>" in response:
+        return []
+    return parse_observations(response)
 
 
 # ── Regex Fallback (when LLM unavailable) ──────────────────────────────────
@@ -143,14 +143,14 @@ def is_duplicate_remote(title: str, content: str) -> bool:
         raw, _elapsed = call_tool_sync(
             "memory_search",
             {"query": query, "limit": 3},
-            timeout=5.0,
+            timeout=HOOK_DEDUP_TIMEOUT_SEC,
             client_label=CLIENT_LABEL,
         )
         # The server returns formatted text with similarity scores like:
         #   "1. [type] **title** (score: 0.456, confidence: 0.80)"
         # Check if any score exceeds our dedup threshold.
         scores = re.findall(r"score:\s*([\d.]+)", raw)
-        return any(float(s) > 0.92 for s in scores)
+        return any(float(s) > HOOK_DEDUP_SIMILARITY_THRESHOLD for s in scores)
     except Exception:
         return False
 

--- a/src/mnemon/llm.py
+++ b/src/mnemon/llm.py
@@ -111,3 +111,27 @@ def is_available() -> bool:
         return True
     except FileNotFoundError:
         return False
+
+
+def try_generate(
+    system_prompt: str, user_message: str, max_tokens: int = 2000
+) -> str | None:
+    """Try to generate an LLM response, returning None if unavailable.
+
+    Unifies the try-import, check-available, generate-or-fail pattern
+    duplicated across ``session_extractor.extract_with_llm``,
+    ``handoff_generator.generate_with_llm``, and ``search.expand_query``.
+    Each caller still does its own parsing of the returned text; this
+    helper only covers the "is the LLM usable right now" plumbing.
+
+    Returns:
+        The raw LLM output string, or None if the backend is unavailable
+        or the call raises any exception. Callers should treat None as
+        "fall back to regex/empty" rather than an error.
+    """
+    try:
+        if not is_available():
+            return None
+        return generate(system_prompt, user_message, max_tokens=max_tokens)
+    except Exception:
+        return None

--- a/src/mnemon/search.py
+++ b/src/mnemon/search.py
@@ -76,8 +76,16 @@ def _jaccard_similarity(a: set[str], b: set[str]) -> float:
     return intersection / union if union > 0 else 0.0
 
 
-def mmr_filter(results: list[ScoredResult]) -> list[ScoredResult]:
-    """MMR diversity filtering — demote results too similar to already-selected ones."""
+def mmr_rerank(results: list[ScoredResult]) -> list[ScoredResult]:
+    """MMR diversity reranking — demote (not remove) results too similar
+    to already-selected ones.
+
+    All candidate results are kept in the output; similar ones have their
+    composite score cut by 50%, then the list is re-sorted. Name is
+    ``rerank`` (not ``filter``) to reflect that items are never dropped —
+    the 50% demotion is usually enough to push near-duplicates below more
+    diverse lower-scoring results.
+    """
     if len(results) <= 1:
         return results
 
@@ -142,23 +150,23 @@ def expand_query(query: str) -> list[str]:
 
     Returns up to 3 alternative queries. Falls back to empty list if LLM unavailable.
     """
-    try:
-        from .llm import generate
-        response = generate(
-            "Generate 3 alternative search queries for the given query. "
-            "Output one per line, no numbering or bullets. "
-            "Keep them short and diverse — include synonyms, related concepts, "
-            "and different phrasings.",
-            query,
-            max_tokens=200,
-        )
-        expansions = [
-            line.strip() for line in response.split("\n")
-            if 3 < len(line.strip()) < 200
-        ]
-        return expansions[:3]
-    except Exception:
+    from .llm import try_generate
+
+    response = try_generate(
+        "Generate 3 alternative search queries for the given query. "
+        "Output one per line, no numbering or bullets. "
+        "Keep them short and diverse — include synonyms, related concepts, "
+        "and different phrasings.",
+        query,
+        max_tokens=200,
+    )
+    if response is None:
         return []
+    expansions = [
+        line.strip() for line in response.split("\n")
+        if 3 < len(line.strip()) < 200
+    ]
+    return expansions[:3]
 
 
 def search(
@@ -213,4 +221,4 @@ def search(
     if content_type:
         scored = [r for r in scored if r.content_type == content_type]
 
-    return mmr_filter(scored[:limit])
+    return mmr_rerank(scored[:limit])

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -66,3 +66,30 @@ class TestGenerate:
         from mnemon.llm import generate
         result = generate("sys", "user")
         assert result == "contradiction"
+
+
+class TestTryGenerate:
+    def test_returns_none_when_unavailable(self):
+        with patch("mnemon.llm.is_available", return_value=False):
+            from mnemon.llm import try_generate
+            assert try_generate("sys", "user") is None
+
+    @patch("mnemon.llm.is_available", return_value=True)
+    @patch("mnemon.llm.generate", return_value="llm output")
+    def test_returns_generate_output_when_available(self, mock_gen, mock_avail):
+        from mnemon.llm import try_generate
+        assert try_generate("sys", "user", max_tokens=42) == "llm output"
+        # max_tokens is forwarded
+        assert mock_gen.call_args.kwargs["max_tokens"] == 42
+
+    @patch("mnemon.llm.is_available", return_value=True)
+    @patch("mnemon.llm.generate", side_effect=RuntimeError("oom"))
+    def test_returns_none_on_exception(self, mock_gen, mock_avail):
+        """try_generate must never raise — hooks rely on it as best-effort."""
+        from mnemon.llm import try_generate
+        assert try_generate("sys", "user") is None
+
+    def test_returns_none_when_is_available_raises(self):
+        with patch("mnemon.llm.is_available", side_effect=Exception("boom")):
+            from mnemon.llm import try_generate
+            assert try_generate("sys", "user") is None

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -11,7 +11,7 @@ from mnemon.search import (
     _jaccard_similarity,
     composite_score,
     compute_recency,
-    mmr_filter,
+    mmr_rerank,
     rrf_fuse,
     search,
 )
@@ -76,10 +76,10 @@ class TestMMR:
             ScoredResult(doc_id=1, title="A", content="unique content here", content_type="note", memory_type="semantic", confidence=0.5, created_at="2026-04-09", score=1.0, source="bm25", composite_score=0.9, recency_score=0.8),
             ScoredResult(doc_id=2, title="B", content="completely different text", content_type="note", memory_type="semantic", confidence=0.5, created_at="2026-04-09", score=0.8, source="bm25", composite_score=0.7, recency_score=0.8),
         ]
-        filtered = mmr_filter(results)
-        assert len(filtered) == 2
+        reranked = mmr_rerank(results)
+        assert len(reranked) == 2
         # Both should keep their scores since they're different
-        assert filtered[0].composite_score == 0.9
+        assert reranked[0].composite_score == 0.9
 
 
 class TestRRF:


### PR DESCRIPTION
## Summary
Three audit refactors bundled together:

- **R1 (constants consolidation):** Hook timeouts and budgets now live in `config.py` (`HOOK_REMOTE_TIMEOUT_SEC`, `HOOK_DEDUP_TIMEOUT_SEC`, `HOOK_SLOW_THRESHOLD_SEC`, `HOOK_CHAR_BUDGET`, `HOOK_DEDUP_SIMILARITY_THRESHOLD`). Hook modules re-export names for backward compat.
- **R4 (rename):** `mmr_filter` → `mmr_rerank` — it demotes similar items by 50% but never drops any, so "rerank" is accurate and "filter" was misleading.
- **R5 (LLM fallback helper):** New `llm.try_generate()` replaces the duplicated try-import / check-available / generate-or-fail pattern across `session_extractor.extract_with_llm`, `handoff_generator.generate_with_llm`, and `search.expand_query`.

Also adds `pytest-of-*/` and `fastembed_cache/` to `.gitignore` (test artifacts that kept appearing).

## Test plan
- [x] All 331 tests pass (4 new `TestTryGenerate` tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)