### PR TITLE
R2: Replace text-parsing dedup with memory_search_structured tool

### DIFF
--- a/src/mnemon/hooks/session_extractor.py
+++ b/src/mnemon/hooks/session_extractor.py
@@ -131,26 +131,31 @@ def extract_with_regex(transcript: str) -> list[dict]:
 def is_duplicate_remote(title: str, content: str) -> bool:
     """Check if an observation is too similar to existing memories via remote search.
 
-    Searches the Fly vault for content matching the combined title+content.
-    If any result has a similarity score > 0.92, consider it a duplicate.
-    Returns False on any error (network, timeout, etc.) — prefer saving a
-    possible duplicate over silently dropping a novel observation.
+    Searches the Fly vault for content matching the combined title+content
+    using the structured ``memory_search_structured`` tool, which returns a
+    JSON array with explicit ``composite_score`` fields — no text parsing.
+    If any result scores above ``HOOK_DEDUP_SIMILARITY_THRESHOLD``, treat
+    it as a duplicate. Returns False on any error (network, timeout,
+    JSON parse failure) — prefer saving a possible duplicate over
+    silently dropping a novel observation.
     """
+    import json
+
     try:
         from ._remote_client import call_tool_sync
 
         query = f"{title}: {content}"
         raw, _elapsed = call_tool_sync(
-            "memory_search",
+            "memory_search_structured",
             {"query": query, "limit": 3},
             timeout=HOOK_DEDUP_TIMEOUT_SEC,
             client_label=CLIENT_LABEL,
         )
-        # The server returns formatted text with similarity scores like:
-        #   "1. [type] **title** (score: 0.456, confidence: 0.80)"
-        # Check if any score exceeds our dedup threshold.
-        scores = re.findall(r"score:\s*([\d.]+)", raw)
-        return any(float(s) > HOOK_DEDUP_SIMILARITY_THRESHOLD for s in scores)
+        results = json.loads(raw)
+        return any(
+            r.get("composite_score", 0.0) > HOOK_DEDUP_SIMILARITY_THRESHOLD
+            for r in results
+        )
     except Exception:
         return False
 

--- a/src/mnemon/server.py
+++ b/src/mnemon/server.py
@@ -7,6 +7,7 @@ Tools: memory_search, memory_get, memory_save, memory_pin, memory_forget,
 
 from __future__ import annotations
 
+import json
 import os
 
 from mcp.server.fastmcp import FastMCP
@@ -90,6 +91,40 @@ def memory_search(
             f"   _id: {r.doc_id} | created: {r.created_at}_"
         )
     return "\n\n".join(lines)
+
+
+@mcp.tool()
+def memory_search_structured(
+    query: str,
+    limit: int = 10,
+    content_type: str | None = None,
+) -> str:
+    """Search memories and return results as a JSON array.
+
+    Machine-readable counterpart to ``memory_search``. Use this when a
+    client needs to act on score thresholds or individual fields rather
+    than present the results to a human. Returns a JSON string with one
+    object per result; empty array when nothing matches.
+
+    Each result object contains: doc_id, title, content, content_type,
+    confidence, composite_score, created_at. Score fields are floats —
+    callers can compare against thresholds without text parsing.
+    """
+    store = _get_store()
+    results = search(store, query, limit=limit, content_type=content_type)
+    payload = [
+        {
+            "doc_id": r.doc_id,
+            "title": r.title,
+            "content": r.content,
+            "content_type": r.content_type,
+            "confidence": r.confidence,
+            "composite_score": r.composite_score,
+            "created_at": r.created_at,
+        }
+        for r in results
+    ]
+    return json.dumps(payload)
 
 
 @mcp.tool()

--- a/tests/test_hooks_extended.py
+++ b/tests/test_hooks_extended.py
@@ -638,14 +638,14 @@ class TestSessionExtractorIsDuplicateRemote:
     def test_not_duplicate_when_low_similarity(self):
         from mnemon.hooks.session_extractor import is_duplicate_remote
 
-        raw = "1. [note] **Existing** (score: 0.456, confidence: 0.80)\n   content"
+        raw = json.dumps([{"doc_id": 1, "title": "Existing", "composite_score": 0.456}])
         with patch("mnemon.hooks._remote_client.call_tool_sync", return_value=(raw, 0.3)):
             assert is_duplicate_remote("title", "content") is False
 
     def test_duplicate_when_high_similarity(self):
         from mnemon.hooks.session_extractor import is_duplicate_remote
 
-        raw = "1. [note] **Same thing** (score: 0.950, confidence: 0.90)\n   content"
+        raw = json.dumps([{"doc_id": 1, "title": "Same thing", "composite_score": 0.950}])
         with patch("mnemon.hooks._remote_client.call_tool_sync", return_value=(raw, 0.3)):
             assert is_duplicate_remote("title", "content") is True
 
@@ -655,22 +655,44 @@ class TestSessionExtractorIsDuplicateRemote:
         with patch("mnemon.hooks._remote_client.call_tool_sync", side_effect=Exception("network")):
             assert is_duplicate_remote("title", "content") is False
 
+    def test_returns_false_on_invalid_json(self):
+        """Dedup must not crash if the server returns malformed JSON —
+        treat as 'not duplicate' and let the save proceed."""
+        from mnemon.hooks.session_extractor import is_duplicate_remote
+
+        with patch("mnemon.hooks._remote_client.call_tool_sync", return_value=("not json", 0.2)):
+            assert is_duplicate_remote("title", "content") is False
+
     def test_no_results_not_duplicate(self):
         from mnemon.hooks.session_extractor import is_duplicate_remote
 
-        raw = "No memories found matching your query."
+        raw = json.dumps([])
         with patch("mnemon.hooks._remote_client.call_tool_sync", return_value=(raw, 0.2)):
             assert is_duplicate_remote("title", "content") is False
 
     def test_multiple_scores_only_needs_one_above_threshold(self):
         from mnemon.hooks.session_extractor import is_duplicate_remote
 
-        raw = (
-            "1. [note] **A** (score: 0.800, confidence: 0.80)\n   a\n"
-            "2. [note] **B** (score: 0.930, confidence: 0.90)\n   b"
-        )
+        raw = json.dumps([
+            {"doc_id": 1, "title": "A", "composite_score": 0.800},
+            {"doc_id": 2, "title": "B", "composite_score": 0.930},
+        ])
         with patch("mnemon.hooks._remote_client.call_tool_sync", return_value=(raw, 0.3)):
             assert is_duplicate_remote("title", "content") is True
+
+    def test_calls_structured_tool_not_text(self):
+        """Guard against regression to text-parsing dedup. The hook must
+        use memory_search_structured so scores aren't parsed from
+        human-readable formatted output."""
+        from mnemon.hooks.session_extractor import is_duplicate_remote
+
+        raw = json.dumps([])
+        with patch(
+            "mnemon.hooks._remote_client.call_tool_sync",
+            return_value=(raw, 0.1),
+        ) as mock_call:
+            is_duplicate_remote("title", "content")
+        assert mock_call.call_args[0][0] == "memory_search_structured"
 
 
 # ── session_extractor.py: main ────────────────────────────────────────────────

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,6 +14,7 @@ from mnemon.server import (
     memory_related,
     memory_save,
     memory_search,
+    memory_search_structured,
     memory_status,
     memory_sweep,
     memory_timeline,
@@ -178,6 +179,62 @@ class TestMemorySearch:
         memory_search("query", content_type="decision")
         mock_search.assert_called_once_with(
             MockStore.return_value, "query", limit=10, content_type="decision"
+        )
+
+
+# ── memory_search_structured ─────────────────────────────────────────────────
+
+
+class TestMemorySearchStructured:
+    @patch("mnemon.server.search")
+    @patch("mnemon.server.Store")
+    def test_empty_results_returns_empty_json_array(self, MockStore, mock_search):
+        import json
+        mock_search.return_value = []
+        result = memory_search_structured("q")
+        assert json.loads(result) == []
+
+    @patch("mnemon.server.search")
+    @patch("mnemon.server.Store")
+    def test_results_are_json_objects_with_numeric_scores(self, MockStore, mock_search):
+        import json
+        r1 = _make_search_result(doc_id=1, title="Alpha", composite_score=0.9, confidence=0.85)
+        r2 = _make_search_result(doc_id=2, title="Beta", composite_score=0.7, confidence=0.60)
+        mock_search.return_value = [r1, r2]
+
+        result = memory_search_structured("q", limit=5)
+        parsed = json.loads(result)
+
+        assert len(parsed) == 2
+        assert parsed[0]["doc_id"] == 1
+        assert parsed[0]["title"] == "Alpha"
+        # Scores are native floats — callers can compare against thresholds
+        # without parsing any string format.
+        assert isinstance(parsed[0]["composite_score"], float)
+        assert parsed[0]["composite_score"] == 0.9
+        assert parsed[1]["composite_score"] == 0.7
+
+    @patch("mnemon.server.search")
+    @patch("mnemon.server.Store")
+    def test_includes_all_expected_fields(self, MockStore, mock_search):
+        import json
+        mock_search.return_value = [_make_search_result(
+            doc_id=42, title="T", content="C", content_type="decision",
+            confidence=0.9, composite_score=0.5, created_at="2026-04-12T00:00:00Z",
+        )]
+        result = memory_search_structured("q")
+        parsed = json.loads(result)[0]
+        expected = {"doc_id", "title", "content", "content_type",
+                    "confidence", "composite_score", "created_at"}
+        assert expected.issubset(parsed.keys())
+
+    @patch("mnemon.server.search")
+    @patch("mnemon.server.Store")
+    def test_passes_content_type(self, MockStore, mock_search):
+        mock_search.return_value = []
+        memory_search_structured("q", content_type="preference")
+        mock_search.assert_called_once_with(
+            MockStore.return_value, "q", limit=10, content_type="preference"
         )
 
 

--- a/tests/test_server_remote.py
+++ b/tests/test_server_remote.py
@@ -52,13 +52,14 @@ class TestMcpServer:
     def test_mcp_has_tools(self):
         from mnemon.server import mcp
         tools = mcp._tool_manager._tools
-        assert len(tools) == 13
+        assert len(tools) == 14
 
     def test_mcp_tool_names(self):
         from mnemon.server import mcp
         tool_names = set(mcp._tool_manager._tools.keys())
         expected = {
-            "memory_search", "memory_get", "memory_timeline",
+            "memory_search", "memory_search_structured",
+            "memory_get", "memory_timeline",
             "memory_save", "memory_pin", "memory_forget",
             "memory_status", "memory_sweep", "memory_related",
             "memory_rebuild", "memory_check_contradictions",


### PR DESCRIPTION
## Summary
- Add new MCP tool `memory_search_structured` that returns a JSON array with numeric `composite_score` fields alongside the existing text-format `memory_search`
- Update `is_duplicate_remote` (session_extractor hook) to call the structured tool and compare scores as floats, replacing the regex `score:\s*([\d.]+)` parse of human-readable output
- If the server's text format ever changes, dedup no longer breaks silently

Fixes audit item R2.

## Notable changes
- Server tool count: 13 → 14
- Depends on PR #32 merge status for the `HOOK_DEDUP_*` constants (both branches updated)

## Test plan
- [x] All 337 tests pass
- [x] New `TestMemorySearchStructured` (4 tests) validates JSON shape + types
- [x] Regression fence: `test_calls_structured_tool_not_text` asserts the hook calls `memory_search_structured`, not `memory_search`

🤖 Generated with [Claude Code](https://claude.com/claude-code)