### PR TITLE
Fix C7: expose vector_similarity in structured search, use for dedup

### DIFF
--- a/src/mnemon/hooks/session_extractor.py
+++ b/src/mnemon/hooks/session_extractor.py
@@ -132,11 +132,13 @@ def is_duplicate_remote(title: str, content: str) -> bool:
     """Check if an observation is too similar to existing memories via remote search.
 
     Searches the Fly vault for content matching the combined title+content
-    using the structured ``memory_search_structured`` tool, which returns a
-    JSON array with explicit ``composite_score`` fields — no text parsing.
-    If any result scores above ``HOOK_DEDUP_SIMILARITY_THRESHOLD``, treat
-    it as a duplicate. Returns False on any error (network, timeout,
-    JSON parse failure) — prefer saving a possible duplicate over
+    using ``memory_search_structured``, then compares the
+    ``vector_similarity`` (true cosine similarity from the vector store)
+    against ``HOOK_DEDUP_SIMILARITY_THRESHOLD``. Composite score is
+    deliberately NOT used — it's a rank-fusion weighted score, not a
+    similarity metric, and tops out far below 1.0 even for exact matches.
+    Returns False on any error (network, timeout, JSON parse, missing
+    vector_similarity field) — prefer saving a possible duplicate over
     silently dropping a novel observation.
     """
     import json
@@ -152,10 +154,11 @@ def is_duplicate_remote(title: str, content: str) -> bool:
             client_label=CLIENT_LABEL,
         )
         results = json.loads(raw)
-        return any(
-            r.get("composite_score", 0.0) > HOOK_DEDUP_SIMILARITY_THRESHOLD
-            for r in results
-        )
+        for r in results:
+            sim = r.get("vector_similarity")
+            if sim is not None and sim > HOOK_DEDUP_SIMILARITY_THRESHOLD:
+                return True
+        return False
     except Exception:
         return False
 

--- a/src/mnemon/search.py
+++ b/src/mnemon/search.py
@@ -29,6 +29,11 @@ class ScoredResult:
     source: str
     composite_score: float = 0.0
     recency_score: float = 0.0
+    # Raw cosine similarity from the vector store, preserved through RRF
+    # fusion so clients can do true-similarity comparisons (e.g., dedup)
+    # without trying to reverse-engineer it from composite_score. None
+    # when the result did not match a vector search (BM25-only).
+    vector_similarity: float | None = None
 
 
 def compute_recency(created_at: str) -> float:
@@ -203,6 +208,13 @@ def search(
         except Exception:
             pass  # Fall back to BM25-only
 
+    # Snapshot cosine similarities by doc_id before RRF fusion flattens
+    # the scores into opaque RRF values. Needed so downstream clients can
+    # do true-similarity dedup without recomputing embeddings locally.
+    vector_similarity_by_id: dict[int, float] = {
+        r.doc_id: r.score for r in vector_results
+    }
+
     # Fuse all result sets
     result_sets = [bm25_results]
     if vector_results:
@@ -217,6 +229,12 @@ def search(
         key=lambda r: r.composite_score,
         reverse=True,
     )
+
+    # Attach the pre-fusion cosine similarity to each result. Stays None
+    # for BM25-only matches; those shouldn't be treated as dedup
+    # candidates anyway (no semantic similarity signal).
+    for r in scored:
+        r.vector_similarity = vector_similarity_by_id.get(r.doc_id)
 
     if content_type:
         scored = [r for r in scored if r.content_type == content_type]

--- a/src/mnemon/server.py
+++ b/src/mnemon/server.py
@@ -107,8 +107,12 @@ def memory_search_structured(
     object per result; empty array when nothing matches.
 
     Each result object contains: doc_id, title, content, content_type,
-    confidence, composite_score, created_at. Score fields are floats —
-    callers can compare against thresholds without text parsing.
+    confidence, composite_score, vector_similarity, created_at. Score
+    fields are floats — callers can compare against thresholds without
+    text parsing. ``vector_similarity`` is the raw cosine similarity
+    (0.0–1.0) from the vector store, preserved before RRF fusion; it
+    is None for BM25-only matches and is the right signal for dedup
+    (composite_score is a weighted rank score, not a similarity).
     """
     store = _get_store()
     results = search(store, query, limit=limit, content_type=content_type)
@@ -120,6 +124,7 @@ def memory_search_structured(
             "content_type": r.content_type,
             "confidence": r.confidence,
             "composite_score": r.composite_score,
+            "vector_similarity": r.vector_similarity,
             "created_at": r.created_at,
         }
         for r in results

--- a/tests/test_hooks_extended.py
+++ b/tests/test_hooks_extended.py
@@ -638,16 +638,41 @@ class TestSessionExtractorIsDuplicateRemote:
     def test_not_duplicate_when_low_similarity(self):
         from mnemon.hooks.session_extractor import is_duplicate_remote
 
-        raw = json.dumps([{"doc_id": 1, "title": "Existing", "composite_score": 0.456}])
+        raw = json.dumps([{"doc_id": 1, "title": "Existing", "vector_similarity": 0.456}])
         with patch("mnemon.hooks._remote_client.call_tool_sync", return_value=(raw, 0.3)):
             assert is_duplicate_remote("title", "content") is False
 
     def test_duplicate_when_high_similarity(self):
         from mnemon.hooks.session_extractor import is_duplicate_remote
 
-        raw = json.dumps([{"doc_id": 1, "title": "Same thing", "composite_score": 0.950}])
+        raw = json.dumps([{"doc_id": 1, "title": "Same thing", "vector_similarity": 0.950}])
         with patch("mnemon.hooks._remote_client.call_tool_sync", return_value=(raw, 0.3)):
             assert is_duplicate_remote("title", "content") is True
+
+    def test_composite_score_alone_does_not_trip_dedup(self):
+        """Guard against the pre-C7 bug where is_duplicate_remote compared
+        composite_score against a 0.92 threshold it could never reach.
+        Now only vector_similarity matters."""
+        from mnemon.hooks.session_extractor import is_duplicate_remote
+
+        raw = json.dumps([{
+            "doc_id": 1,
+            "title": "Composite only",
+            "composite_score": 0.99,
+            "vector_similarity": None,
+        }])
+        with patch("mnemon.hooks._remote_client.call_tool_sync", return_value=(raw, 0.3)):
+            assert is_duplicate_remote("title", "content") is False
+
+    def test_null_vector_similarity_is_not_duplicate(self):
+        """BM25-only matches have vector_similarity=None and must not
+        trip dedup — they could easily be keyword-coincidence, not
+        semantic duplicates."""
+        from mnemon.hooks.session_extractor import is_duplicate_remote
+
+        raw = json.dumps([{"doc_id": 1, "title": "BM25 only", "vector_similarity": None}])
+        with patch("mnemon.hooks._remote_client.call_tool_sync", return_value=(raw, 0.3)):
+            assert is_duplicate_remote("title", "content") is False
 
     def test_returns_false_on_exception(self):
         from mnemon.hooks.session_extractor import is_duplicate_remote
@@ -670,12 +695,12 @@ class TestSessionExtractorIsDuplicateRemote:
         with patch("mnemon.hooks._remote_client.call_tool_sync", return_value=(raw, 0.2)):
             assert is_duplicate_remote("title", "content") is False
 
-    def test_multiple_scores_only_needs_one_above_threshold(self):
+    def test_multiple_results_only_needs_one_above_threshold(self):
         from mnemon.hooks.session_extractor import is_duplicate_remote
 
         raw = json.dumps([
-            {"doc_id": 1, "title": "A", "composite_score": 0.800},
-            {"doc_id": 2, "title": "B", "composite_score": 0.930},
+            {"doc_id": 1, "title": "A", "vector_similarity": 0.800},
+            {"doc_id": 2, "title": "B", "vector_similarity": 0.930},
         ])
         with patch("mnemon.hooks._remote_client.call_tool_sync", return_value=(raw, 0.3)):
             assert is_duplicate_remote("title", "content") is True

--- a/tests/test_integration_remote.py
+++ b/tests/test_integration_remote.py
@@ -203,16 +203,9 @@ def test_wrong_token_is_rejected(monkeypatch, remote_server):
 
 def test_structured_search_parses_real_server_json(remote_env):
     """Client-side JSON parsing must handle the real server's JSON output,
-    not just a mocked shape. Guards against server changing its JSON
+    not just a mocked shape. Guards against the server changing its JSON
     schema but the client's json.loads path still superficially working
     against unit-test fixtures.
-
-    Note: does NOT assert ``is_duplicate_remote`` returns True here —
-    that currently requires ``composite_score > 0.92``, which the
-    composite scoring formula cannot produce in practice (topping out
-    around ~0.75 for a top result). That's a separately-tracked bug in
-    the dedup logic, not a problem with the structured-search plumbing
-    this PR is validating. See audit follow-up.
     """
     import json
 
@@ -240,8 +233,47 @@ def test_structured_search_parses_real_server_json(remote_env):
     # Every result must have the fields the client relies on. Pin the
     # schema so a server-side rename would fail loudly here.
     required = {"doc_id", "title", "content", "content_type",
-                "confidence", "composite_score", "created_at"}
+                "confidence", "composite_score", "vector_similarity",
+                "created_at"}
     for r in results:
         assert required.issubset(r.keys()), f"missing fields in {r}"
         assert isinstance(r["composite_score"], (int, float))
         assert isinstance(r["confidence"], (int, float))
+        # vector_similarity can be None (BM25-only) or a float
+        if r["vector_similarity"] is not None:
+            assert isinstance(r["vector_similarity"], (int, float))
+            assert 0.0 <= r["vector_similarity"] <= 1.0
+
+
+def test_dedup_triggers_on_near_identical_memory(remote_env):
+    """End-to-end dedup: save a memory, then ask is_duplicate_remote
+    whether an identical observation would be a duplicate. The fix for
+    C7 (use vector_similarity instead of composite_score) means this
+    should now reliably return True. Before the fix, the threshold was
+    unreachable and dedup silently never triggered."""
+    from mnemon.hooks._remote_client import call_tool_sync
+    from mnemon.hooks.session_extractor import is_duplicate_remote
+
+    call_tool_sync(
+        "memory_save",
+        {
+            "title": "Dedup end-to-end guard",
+            "content": "A memory saved to verify the dedup cosine-similarity path works end-to-end.",
+            "content_type": "observation",
+            "source_client": "pytest-integration",
+        },
+        timeout=30.0,
+    )
+
+    # Same title + content → very high cosine similarity → dedup triggers.
+    assert is_duplicate_remote(
+        "Dedup end-to-end guard",
+        "A memory saved to verify the dedup cosine-similarity path works end-to-end.",
+    ) is True
+
+    # Unrelated content → low cosine similarity → dedup does NOT trigger,
+    # even if BM25 would catch stray keyword overlap.
+    assert is_duplicate_remote(
+        "Completely unrelated topic about alpine climbing routes in Patagonia",
+        "Nothing to do with any saved memory in this test vault.",
+    ) is False

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -121,3 +121,30 @@ class TestSearch:
     def test_search_empty_returns_empty(self, store):
         results = search(store, "nonexistent term xyz")
         assert len(results) == 0
+
+    def test_search_attaches_vector_similarity_when_vector_match(self, store):
+        """Results that came back from the vector store must carry the
+        raw cosine similarity on ScoredResult.vector_similarity — it's
+        the dedup signal used by is_duplicate_remote."""
+        from unittest.mock import patch
+
+        from mnemon.store import SearchResult
+
+        fake_vector_hit = SearchResult(
+            doc_id=42, title="Foo", content="bar", content_type="note",
+            memory_type="semantic", confidence=0.8, created_at="2026-04-12",
+            score=0.87, source="vector",
+        )
+        with patch.object(store, "search_bm25", return_value=[fake_vector_hit]), \
+             patch.object(store, "search_vector", return_value=[fake_vector_hit]), \
+             patch("mnemon.search.embed", create=True, return_value=[0.0] * 384):
+            results = search(store, "foo")
+        assert len(results) >= 1
+        assert results[0].vector_similarity == 0.87
+
+    def test_search_vector_similarity_is_none_for_bm25_only(self, store):
+        store.save(title="Python", content="Python is great")
+        # Disable vector search so results come only from BM25.
+        results = search(store, "Python", use_vector=False)
+        assert len(results) >= 1
+        assert results[0].vector_similarity is None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -42,6 +42,7 @@ def _make_search_result(**overrides):
         "confidence": 0.80,
         "created_at": "2026-04-01T00:00:00Z",
         "composite_score": 0.75,
+        "vector_similarity": None,
     }
     defaults.update(overrides)
     m = MagicMock()
@@ -220,13 +221,16 @@ class TestMemorySearchStructured:
         import json
         mock_search.return_value = [_make_search_result(
             doc_id=42, title="T", content="C", content_type="decision",
-            confidence=0.9, composite_score=0.5, created_at="2026-04-12T00:00:00Z",
+            confidence=0.9, composite_score=0.5, vector_similarity=0.87,
+            created_at="2026-04-12T00:00:00Z",
         )]
         result = memory_search_structured("q")
         parsed = json.loads(result)[0]
         expected = {"doc_id", "title", "content", "content_type",
-                    "confidence", "composite_score", "created_at"}
+                    "confidence", "composite_score", "vector_similarity",
+                    "created_at"}
         assert expected.issubset(parsed.keys())
+        assert parsed["vector_similarity"] == 0.87
 
     @patch("mnemon.server.search")
     @patch("mnemon.server.Store")


### PR DESCRIPTION
## Summary
Fixes a silent bug exposed by PR #34's integration test: `is_duplicate_remote`'s threshold (`HOOK_DEDUP_SIMILARITY_THRESHOLD = 0.92`) was comparing against `composite_score`, which is a weighted rank-fusion metric that tops out around ~0.75 in practice. The threshold was unreachable, so dedup has been silently disabled since Phase 3 — every LLM-extracted observation has been saved regardless of near-duplicates already in the vault.

## Root cause
`search()` computes per-doc vector cosine similarity via `search_vector`, but RRF fusion replaces those scores with fused rank values. After fusion, there's no way to tell which results were semantically similar vs. BM25-keyword-similar.

## Fix
Preserve the pre-fusion cosine similarity as a side-channel by doc_id, attach it to each final `ScoredResult` as `vector_similarity` (None for BM25-only matches), and expose it in `memory_search_structured` JSON. `is_duplicate_remote` now checks `vector_similarity` (a true cosine bounded 0-1) instead of `composite_score`; the 0.92 threshold is now reachable for near-identical content.

## Changes
- `ScoredResult.vector_similarity: float | None` field
- `search()` snapshots doc_id → cosine before fusion, attaches after
- `memory_search_structured` adds `vector_similarity` to JSON payload
- `is_duplicate_remote` uses `vector_similarity`, ignores null (BM25 matches)
- Guard tests: composite_score alone must NOT trip dedup, null vector_similarity must NOT trip dedup (regression fences)
- Integration test: end-to-end dedup actually triggers on near-identical memory

## Test plan
- [x] All 345 tests pass (6 new)
- [x] Integration `test_dedup_triggers_on_near_identical_memory` proves dedup works against real server

🤖 Generated with [Claude Code](https://claude.com/claude-code)