### PR TITLE
Phase 2 PR #37: /oauth/authorize + /oauth/token endpoints with PKCE

### DIFF
--- a/src/mnemon/auth.py
+++ b/src/mnemon/auth.py
@@ -206,6 +206,31 @@ class OAuthMiddleware:
             await serve_jwks(self.as_config, send)
             return
 
+        # Self-hosted AS token-issuance endpoints. Served unauthenticated
+        # (the whole point is to bootstrap a token) — request validation
+        # happens inside the handlers themselves (PKCE, passphrase, etc).
+        if path == "/oauth/authorize":
+            from .oauth_as import serve_authorize
+
+            if self.as_config is None:
+                await _send_json(
+                    send, 404, {"error": "authorization server not enabled"}
+                )
+                return
+            await serve_authorize(self.as_config, scope, receive, send)
+            return
+
+        if path == "/oauth/token":
+            from .oauth_as import serve_token
+
+            if self.as_config is None:
+                await _send_json(
+                    send, 404, {"error": "authorization server not enabled"}
+                )
+                return
+            await serve_token(self.as_config, scope, receive, send)
+            return
+
         # Unauthenticated mode — pass through only when NEITHER auth method
         # is configured. If local_token is set but OAuth is not, we still
         # enforce auth below.

--- a/src/mnemon/oauth_as.py
+++ b/src/mnemon/oauth_as.py
@@ -1,30 +1,26 @@
-"""Self-hosted OAuth 2.1 Authorization Server — Phase 2 scaffolding.
+"""Self-hosted OAuth 2.1 Authorization Server.
 
 Removes mnemon's external-AS (Auth0) dependency so self-hosted deployments
 can run as a single process with no third-party auth vendor. This module
 is the AS-side counterpart to ``auth.py`` (which is the Resource Server).
 
-Current scope (PR #36 — scaffolding only)
------------------------------------------
-This PR lays the groundwork for the AS endpoints to follow in subsequent
-PRs. What ships here:
-
+What's implemented
+------------------
 - RSA keypair management: generated on first run, persisted to the Fly
   volume, loaded on subsequent starts. Private key never leaves the
   server; public key is published at ``/.well-known/jwks.json``.
-- ``/.well-known/oauth-authorization-server`` metadata (RFC 8414). Some
-  endpoint URLs point at routes that don't exist yet — clients will get
-  404s if they try to use them, which is fine while this is scaffolding.
-- ``/.well-known/jwks.json`` — the public key in JWKS format for any
-  future resource server (mnemon itself, in Phase 2) to verify tokens.
-- Feature flag ``MNEMON_AS_ENABLED``. Off by default so this PR is a
-  no-op on the live deployment; turn it on in a later PR when the
-  endpoints are implemented.
+- ``/.well-known/oauth-authorization-server`` metadata (RFC 8414).
+- ``/.well-known/jwks.json`` — the public key in JWKS format.
+- ``/oauth/authorize`` — HTML passphrase login form (GET) and code
+  issuance after successful login (POST). PKCE code_challenge stored
+  server-side for later verification.
+- ``/oauth/token`` — authorization_code and refresh_token grants. RS256
+  JWT access tokens, opaque refresh tokens with rotation.
+- Feature flag ``MNEMON_AS_ENABLED``. Off by default.
 
 Out of scope (future PRs)
 -------------------------
-- ``/authorize`` + ``/token`` endpoints + PKCE — PR #37
-- ``/register`` (DCR, RFC 7591) + refresh rotation — PR #38
+- ``/register`` (DCR, RFC 7591) — PR #38
 - Switch resource-server middleware to verify self-hosted tokens — PR #39
 - Remove Auth0 env vars from production config — PR #40
 
@@ -283,3 +279,471 @@ async def serve_as_metadata(config: AuthorizationServerConfig, send) -> None:
         await _send_json(send, 404, {"error": "authorization server not enabled"})
         return
     await _send_json(send, 200, authorization_server_metadata(config))
+
+
+# ── Authorization codes + refresh tokens (in-memory storage) ────────────────
+#
+# In-memory storage is deliberate: auth codes live for 10 minutes and
+# refresh tokens are bound to a single user. A server restart invalidates
+# all outstanding codes (forces a re-login — acceptable friction for a
+# personal-use AS) and refresh tokens (forces re-auth on next use —
+# same). If you need durability across restarts, swap these dicts for
+# SQLite-backed tables in the Fly volume; the interface stays the same.
+
+_AUTH_CODE_TTL_SEC = 600          # 10 min — RFC recommends ≤ 10 min
+_ACCESS_TOKEN_TTL_SEC = 3600      # 1 hour
+_REFRESH_TOKEN_TTL_SEC = 30 * 24 * 3600  # 30 days
+
+# auth_codes: code_value → {client_id, redirect_uri, code_challenge, scope,
+#                           subject, expires_at}
+_auth_codes: dict[str, dict[str, Any]] = {}
+
+# refresh_tokens: refresh_token_value → {subject, scope, client_id, expires_at}
+_refresh_tokens: dict[str, dict[str, Any]] = {}
+
+
+def _reset_state_for_tests() -> None:
+    """Clear module-level state. Test-only helper — prevents cross-test
+    leakage since auth codes and refresh tokens live in module globals."""
+    _auth_codes.clear()
+    _refresh_tokens.clear()
+
+
+def _now() -> int:
+    import time
+    return int(time.time())
+
+
+# ── PKCE ────────────────────────────────────────────────────────────────────
+
+
+def _verify_pkce_s256(code_verifier: str, code_challenge: str) -> bool:
+    """Return True if BASE64URL(SHA256(code_verifier)) == code_challenge.
+
+    Per RFC 7636. Constant-time comparison to avoid timing leaks.
+    """
+    import base64
+    import hashlib
+    import hmac
+
+    digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+    expected = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return hmac.compare_digest(expected, code_challenge)
+
+
+# ── Token minting ───────────────────────────────────────────────────────────
+
+
+def mint_access_token(
+    config: AuthorizationServerConfig,
+    *,
+    subject: str,
+    scope: str,
+    audience: str | None = None,
+    ttl_sec: int = _ACCESS_TOKEN_TTL_SEC,
+) -> str:
+    """Mint an RS256 JWT access token signed with the AS's private key.
+
+    The ``aud`` claim defaults to ``{issuer}/mcp`` — matching the Resource
+    Server's audience convention so the existing OAuthMiddleware JWKS
+    validation path will accept these tokens once PR #39 points it at
+    the AS's own JWKS.
+    """
+    import jwt
+
+    private_pem, _ = ensure_keypair(config.key_dir)
+    now = _now()
+    aud = audience or f"{config.issuer}/mcp"
+    payload = {
+        "iss": config.issuer,
+        "aud": aud,
+        "sub": subject,
+        "iat": now,
+        "exp": now + ttl_sec,
+        "scope": scope,
+        # jti makes each token unique even when minted in the same second
+        # (back-to-back refreshes) and enables future revocation by
+        # blocklisting specific jti values.
+        "jti": _new_random_token(16),
+    }
+    return jwt.encode(
+        payload, private_pem, algorithm=JWT_ALG, headers={"kid": KEY_ID}
+    )
+
+
+def _new_random_token(nbytes: int = 32) -> str:
+    import secrets
+    return secrets.token_urlsafe(nbytes)
+
+
+def _issue_token_pair(
+    config: AuthorizationServerConfig,
+    *,
+    subject: str,
+    scope: str,
+    client_id: str,
+) -> dict[str, Any]:
+    """Mint an access token + refresh token and persist the refresh token
+    so it can be exchanged later via the refresh_token grant."""
+    access_token = mint_access_token(config, subject=subject, scope=scope)
+    refresh_token = _new_random_token()
+    _refresh_tokens[refresh_token] = {
+        "subject": subject,
+        "scope": scope,
+        "client_id": client_id,
+        "expires_at": _now() + _REFRESH_TOKEN_TTL_SEC,
+    }
+    return {
+        "access_token": access_token,
+        "token_type": "Bearer",
+        "expires_in": _ACCESS_TOKEN_TTL_SEC,
+        "refresh_token": refresh_token,
+        "scope": scope,
+    }
+
+
+# ── Request helpers ─────────────────────────────────────────────────────────
+
+
+async def _read_body(receive) -> bytes:
+    """Read the full request body from an ASGI receive callable."""
+    body = b""
+    more_body = True
+    while more_body:
+        message = await receive()
+        if message["type"] == "http.request":
+            body += message.get("body", b"")
+            more_body = message.get("more_body", False)
+        else:
+            break
+    return body
+
+
+def _parse_query_or_form(raw: bytes) -> dict[str, str]:
+    """Parse URL-encoded form or query-string bytes to a dict. Last
+    value wins for repeated keys (matches stdlib parse_qs behavior)."""
+    from urllib.parse import parse_qs
+
+    parsed = parse_qs(raw.decode("utf-8", errors="replace"), keep_blank_values=True)
+    return {k: v[-1] for k, v in parsed.items()}
+
+
+def _scope_query(scope: dict[str, Any]) -> dict[str, str]:
+    qs = scope.get("query_string", b"")
+    return _parse_query_or_form(qs)
+
+
+# ── Login form ──────────────────────────────────────────────────────────────
+
+
+_LOGIN_FORM_HTML = """<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>mnemon — sign in</title>
+<style>
+body {{ font-family: -apple-system, sans-serif; max-width: 400px; margin: 5em auto; padding: 0 1em; }}
+h1 {{ font-size: 1.2em; }}
+.error {{ color: #b00020; margin: 1em 0; }}
+input[type=password] {{ width: 100%; padding: 0.5em; font-size: 1em; box-sizing: border-box; }}
+button {{ margin-top: 1em; padding: 0.5em 1em; font-size: 1em; }}
+.meta {{ color: #666; font-size: 0.9em; margin-top: 2em; }}
+</style>
+</head>
+<body>
+<h1>mnemon — sign in</h1>
+{error_html}
+<form method="post" action="/oauth/authorize">
+{hidden_inputs}
+<label for="passphrase">Passphrase</label>
+<input id="passphrase" type="password" name="passphrase" autofocus required>
+<button type="submit">Sign in</button>
+</form>
+<p class="meta">Signing in as client <code>{client_id}</code>.</p>
+</body>
+</html>
+"""
+
+
+def _render_login_form(params: dict[str, str], error: str | None = None) -> bytes:
+    """Render the passphrase login page with the original authorize params
+    as hidden inputs so POST can round-trip them.
+
+    All values HTML-escaped — these are untrusted client inputs (state,
+    redirect_uri) and even one unescaped field would be an XSS vector."""
+    import html
+
+    hidden = "\n".join(
+        f'<input type="hidden" name="{html.escape(k)}" value="{html.escape(v)}">'
+        for k, v in params.items()
+    )
+    error_html = (
+        f'<p class="error">{html.escape(error)}</p>' if error else ""
+    )
+    client_id = html.escape(params.get("client_id", "(unknown)"))
+    body = _LOGIN_FORM_HTML.format(
+        hidden_inputs=hidden,
+        error_html=error_html,
+        client_id=client_id,
+    ).encode("utf-8")
+    return body
+
+
+async def _send_html(send, status: int, body: bytes) -> None:
+    await send({
+        "type": "http.response.start",
+        "status": status,
+        "headers": [
+            (b"content-type", b"text/html; charset=utf-8"),
+            (b"content-length", str(len(body)).encode("ascii")),
+            (b"cache-control", b"no-store"),
+        ],
+    })
+    await send({"type": "http.response.body", "body": body, "more_body": False})
+
+
+async def _redirect(send, location: str) -> None:
+    await send({
+        "type": "http.response.start",
+        "status": 302,
+        "headers": [
+            (b"location", location.encode("utf-8")),
+            (b"content-length", b"0"),
+            (b"cache-control", b"no-store"),
+        ],
+    })
+    await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+
+# ── /oauth/authorize ────────────────────────────────────────────────────────
+
+
+_REQUIRED_AUTHORIZE_PARAMS = (
+    "client_id", "redirect_uri", "response_type",
+    "code_challenge", "code_challenge_method",
+)
+
+
+def _validate_authorize_params(params: dict[str, str]) -> str | None:
+    """Return an error message if the authorize params are malformed,
+    else None. Intentionally strict — we reject anything not matching
+    OAuth 2.1 + PKCE S256 up front rather than silently falling back."""
+    missing = [p for p in _REQUIRED_AUTHORIZE_PARAMS if not params.get(p)]
+    if missing:
+        return f"missing required parameter(s): {', '.join(missing)}"
+    if params["response_type"] != "code":
+        return "only response_type=code is supported (OAuth 2.1)"
+    if params["code_challenge_method"] != "S256":
+        return "only code_challenge_method=S256 is supported (OAuth 2.1 requires PKCE)"
+    return None
+
+
+async def serve_authorize(
+    config: AuthorizationServerConfig, scope: dict, receive, send
+) -> None:
+    """ASGI handler: GET serves the login form, POST validates the
+    passphrase and issues an authorization code via redirect."""
+    from .auth import _send_json
+
+    if not config.enabled:
+        await _send_json(send, 404, {"error": "authorization server not enabled"})
+        return
+
+    method = scope.get("method", "GET").upper()
+
+    if method == "GET":
+        params = _scope_query(scope)
+        err = _validate_authorize_params(params)
+        if err:
+            await _send_json(send, 400, {"error": "invalid_request", "error_description": err})
+            return
+        await _send_html(send, 200, _render_login_form(params))
+        return
+
+    if method != "POST":
+        await _send_json(send, 405, {"error": "method_not_allowed"})
+        return
+
+    # POST — login attempt
+    body = await _read_body(receive)
+    params = _parse_query_or_form(body)
+    err = _validate_authorize_params(params)
+    if err:
+        await _send_json(send, 400, {"error": "invalid_request", "error_description": err})
+        return
+
+    passphrase = params.get("passphrase", "")
+    if not _verify_passphrase(passphrase, config.passphrase or ""):
+        # Re-render form with error — don't redirect back to client with
+        # an error code, because that would leak "this URL is a valid
+        # OAuth init" to anyone who can read network logs. A re-rendered
+        # form keeps the failure contained.
+        form_params = {k: v for k, v in params.items() if k != "passphrase"}
+        await _send_html(
+            send, 401,
+            _render_login_form(form_params, error="Invalid passphrase.")
+        )
+        return
+
+    # Issue auth code and redirect to client's redirect_uri.
+    code = _new_random_token()
+    _auth_codes[code] = {
+        "client_id": params["client_id"],
+        "redirect_uri": params["redirect_uri"],
+        "code_challenge": params["code_challenge"],
+        "code_challenge_method": params["code_challenge_method"],
+        "scope": params.get("scope", "mcp"),
+        "subject": "owner",  # single-user AS
+        "expires_at": _now() + _AUTH_CODE_TTL_SEC,
+    }
+
+    from urllib.parse import urlencode
+    redirect_params = {"code": code}
+    if "state" in params:
+        redirect_params["state"] = params["state"]
+    sep = "&" if "?" in params["redirect_uri"] else "?"
+    location = f"{params['redirect_uri']}{sep}{urlencode(redirect_params)}"
+    await _redirect(send, location)
+
+
+def _verify_passphrase(submitted: str, configured: str) -> bool:
+    """Constant-time passphrase comparison. Rejects empty configured
+    values outright — prevents a misconfiguration where an unset
+    passphrase accidentally matches an empty submission."""
+    import hmac
+    if not configured:
+        return False
+    return hmac.compare_digest(submitted, configured)
+
+
+# ── /oauth/token ────────────────────────────────────────────────────────────
+
+
+async def serve_token(
+    config: AuthorizationServerConfig, scope: dict, receive, send
+) -> None:
+    """ASGI handler: POST /oauth/token. Supports authorization_code and
+    refresh_token grants."""
+    from .auth import _send_json
+
+    if not config.enabled:
+        await _send_json(send, 404, {"error": "authorization server not enabled"})
+        return
+    if scope.get("method", "GET").upper() != "POST":
+        await _send_json(send, 405, {"error": "method_not_allowed"})
+        return
+
+    body = await _read_body(receive)
+    params = _parse_query_or_form(body)
+    grant_type = params.get("grant_type", "")
+
+    if grant_type == "authorization_code":
+        await _token_authorization_code(config, params, send)
+        return
+    if grant_type == "refresh_token":
+        await _token_refresh(config, params, send)
+        return
+    await _send_json(send, 400, {
+        "error": "unsupported_grant_type",
+        "error_description": (
+            f"grant_type={grant_type!r} not supported; use "
+            "authorization_code or refresh_token"
+        ),
+    })
+
+
+async def _token_authorization_code(
+    config: AuthorizationServerConfig, params: dict[str, str], send
+) -> None:
+    from .auth import _send_json
+
+    code = params.get("code", "")
+    redirect_uri = params.get("redirect_uri", "")
+    client_id = params.get("client_id", "")
+    code_verifier = params.get("code_verifier", "")
+
+    for required in ("code", "redirect_uri", "client_id", "code_verifier"):
+        if not params.get(required):
+            await _send_json(send, 400, {
+                "error": "invalid_request",
+                "error_description": f"missing {required}",
+            })
+            return
+
+    record = _auth_codes.pop(code, None)  # one-time use — consume on lookup
+    if record is None:
+        await _send_json(send, 400, {
+            "error": "invalid_grant",
+            "error_description": "unknown, expired, or already-used code",
+        })
+        return
+    if record["expires_at"] < _now():
+        await _send_json(send, 400, {
+            "error": "invalid_grant",
+            "error_description": "code expired",
+        })
+        return
+    if record["client_id"] != client_id:
+        await _send_json(send, 400, {
+            "error": "invalid_grant",
+            "error_description": "client_id mismatch",
+        })
+        return
+    if record["redirect_uri"] != redirect_uri:
+        await _send_json(send, 400, {
+            "error": "invalid_grant",
+            "error_description": "redirect_uri mismatch",
+        })
+        return
+    if not _verify_pkce_s256(code_verifier, record["code_challenge"]):
+        await _send_json(send, 400, {
+            "error": "invalid_grant",
+            "error_description": "PKCE verification failed",
+        })
+        return
+
+    tokens = _issue_token_pair(
+        config,
+        subject=record["subject"],
+        scope=record["scope"],
+        client_id=client_id,
+    )
+    await _send_json(send, 200, tokens)
+
+
+async def _token_refresh(
+    config: AuthorizationServerConfig, params: dict[str, str], send
+) -> None:
+    from .auth import _send_json
+
+    refresh_token = params.get("refresh_token", "")
+    if not refresh_token:
+        await _send_json(send, 400, {
+            "error": "invalid_request",
+            "error_description": "missing refresh_token",
+        })
+        return
+
+    # Rotation: consume the old refresh token regardless of outcome so a
+    # leaked token can only be used once.
+    record = _refresh_tokens.pop(refresh_token, None)
+    if record is None:
+        await _send_json(send, 400, {
+            "error": "invalid_grant",
+            "error_description": "unknown, expired, or already-rotated refresh token",
+        })
+        return
+    if record["expires_at"] < _now():
+        await _send_json(send, 400, {
+            "error": "invalid_grant",
+            "error_description": "refresh token expired",
+        })
+        return
+
+    tokens = _issue_token_pair(
+        config,
+        subject=record["subject"],
+        scope=record["scope"],
+        client_id=record["client_id"],
+    )
+    await _send_json(send, 200, tokens)

--- a/tests/test_oauth_as.py
+++ b/tests/test_oauth_as.py
@@ -270,3 +270,542 @@ class TestServeAsMetadata:
         status, body = await _capture_response(serve_as_metadata, config)
         assert status == 200
         assert body["issuer"] == "https://example.fly.dev"
+
+
+# ── /oauth/authorize ────────────────────────────────────────────────────────
+
+
+import base64
+import hashlib
+from urllib.parse import parse_qs, urlparse
+
+
+@pytest.fixture
+def as_config(tmp_path):
+    return AuthorizationServerConfig(
+        enabled=True,
+        public_url="https://example.fly.dev",
+        passphrase="correct-horse-battery",
+        key_dir=tmp_path,
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_oauth_state():
+    from mnemon.oauth_as import _reset_state_for_tests
+    _reset_state_for_tests()
+    yield
+    _reset_state_for_tests()
+
+
+def _pkce_pair():
+    """Generate a PKCE (code_verifier, code_challenge) pair matching RFC 7636."""
+    import secrets
+    verifier = secrets.token_urlsafe(64)[:64]
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+async def _run_asgi(handler, config, method="GET", query=b"", body=b""):
+    """Invoke an AS ASGI handler and return (status, headers_dict, body_bytes)."""
+    scope = {"type": "http", "method": method, "path": "/oauth/test",
+             "query_string": query, "headers": []}
+    sent = []
+
+    async def send(msg):
+        sent.append(msg)
+
+    body_sent = {"done": False}
+
+    async def receive():
+        if body_sent["done"]:
+            return {"type": "http.disconnect"}
+        body_sent["done"] = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    # Handlers take different arg shapes depending on whether they need receive.
+    import inspect
+    sig = inspect.signature(handler)
+    if "receive" in sig.parameters:
+        await handler(config, scope, receive, send)
+    else:
+        await handler(config, send)
+
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    body_msgs = [m for m in sent if m["type"] == "http.response.body"]
+    body_bytes = b"".join(m.get("body", b"") for m in body_msgs)
+    headers = {k.decode(): v.decode() for k, v in start.get("headers", [])}
+    return start["status"], headers, body_bytes
+
+
+class TestServeAuthorizeGet:
+    @pytest.mark.asyncio
+    async def test_404_when_as_disabled(self):
+        from mnemon.oauth_as import serve_authorize
+
+        config = AuthorizationServerConfig(enabled=False)
+        status, _, _ = await _run_asgi(serve_authorize, config, method="GET")
+        assert status == 404
+
+    @pytest.mark.asyncio
+    async def test_rejects_missing_params(self, as_config):
+        from mnemon.oauth_as import serve_authorize
+
+        status, _, body = await _run_asgi(
+            serve_authorize, as_config, method="GET",
+            query=b"client_id=x",  # everything else missing
+        )
+        assert status == 400
+        assert b"missing required parameter" in body
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_s256_pkce(self, as_config):
+        from mnemon.oauth_as import serve_authorize
+
+        query = (
+            b"client_id=c&redirect_uri=https://x/cb&response_type=code&"
+            b"code_challenge=abc&code_challenge_method=plain"
+        )
+        status, _, body = await _run_asgi(
+            serve_authorize, as_config, method="GET", query=query
+        )
+        assert status == 400
+        assert b"S256" in body
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_code_response_type(self, as_config):
+        """OAuth 2.1 removes implicit grant — only response_type=code."""
+        from mnemon.oauth_as import serve_authorize
+
+        query = (
+            b"client_id=c&redirect_uri=https://x/cb&response_type=token&"
+            b"code_challenge=abc&code_challenge_method=S256"
+        )
+        status, _, _ = await _run_asgi(
+            serve_authorize, as_config, method="GET", query=query
+        )
+        assert status == 400
+
+    @pytest.mark.asyncio
+    async def test_renders_login_form_with_valid_params(self, as_config):
+        from mnemon.oauth_as import serve_authorize
+
+        _, challenge = _pkce_pair()
+        query = (
+            f"client_id=test-client&redirect_uri=https://client.example/cb&"
+            f"response_type=code&code_challenge={challenge}&"
+            f"code_challenge_method=S256&state=abc123"
+        ).encode()
+        status, headers, body = await _run_asgi(
+            serve_authorize, as_config, method="GET", query=query
+        )
+        assert status == 200
+        assert "text/html" in headers.get("content-type", "")
+        # Hidden fields round-trip the authorize params back on POST
+        assert b'name="client_id"' in body
+        assert b'value="test-client"' in body
+        assert b'name="state"' in body
+        assert b'value="abc123"' in body
+        # Never echo the passphrase field as a value
+        assert b'name="passphrase"' in body
+
+    @pytest.mark.asyncio
+    async def test_escapes_html_in_params(self, as_config):
+        """state and redirect_uri are untrusted — must be HTML-escaped to
+        avoid XSS via the login form."""
+        from mnemon.oauth_as import serve_authorize
+
+        _, challenge = _pkce_pair()
+        query = (
+            f"client_id=<script>&redirect_uri=https://x/cb&response_type=code&"
+            f"code_challenge={challenge}&code_challenge_method=S256&"
+            f"state=<img src=x>"
+        ).encode()
+        _, _, body = await _run_asgi(
+            serve_authorize, as_config, method="GET", query=query
+        )
+        assert b"<script>" not in body
+        assert b"<img src=x>" not in body
+
+
+class TestServeAuthorizePost:
+    @pytest.mark.asyncio
+    async def test_rejects_wrong_passphrase(self, as_config):
+        from mnemon.oauth_as import serve_authorize
+
+        _, challenge = _pkce_pair()
+        form = (
+            f"client_id=c&redirect_uri=https://x/cb&response_type=code&"
+            f"code_challenge={challenge}&code_challenge_method=S256&"
+            f"passphrase=wrong"
+        ).encode()
+        status, headers, body = await _run_asgi(
+            serve_authorize, as_config, method="POST", body=form
+        )
+        assert status == 401
+        assert "text/html" in headers.get("content-type", "")
+        # Must NOT redirect back to client with a code on failure —
+        # keeps the client from logging invalid-attempt URLs.
+        assert "location" not in headers
+        assert b"Invalid passphrase" in body
+
+    @pytest.mark.asyncio
+    async def test_empty_configured_passphrase_never_matches(self, tmp_path):
+        """If AS is somehow enabled without a passphrase set, an empty
+        submission must NOT match — guards the misconfig case."""
+        from mnemon.oauth_as import serve_authorize
+
+        # Directly construct config without validation to simulate boot
+        # skipping the validate() call.
+        config = AuthorizationServerConfig(
+            enabled=True,
+            public_url="https://example.fly.dev",
+            passphrase="",  # misconfigured
+            key_dir=tmp_path,
+        )
+        _, challenge = _pkce_pair()
+        form = (
+            f"client_id=c&redirect_uri=https://x/cb&response_type=code&"
+            f"code_challenge={challenge}&code_challenge_method=S256&"
+            f"passphrase="
+        ).encode()
+        status, _, _ = await _run_asgi(
+            serve_authorize, config, method="POST", body=form
+        )
+        assert status == 401
+
+    @pytest.mark.asyncio
+    async def test_correct_passphrase_redirects_with_code(self, as_config):
+        from mnemon.oauth_as import _auth_codes, serve_authorize
+
+        _, challenge = _pkce_pair()
+        form = (
+            f"client_id=test-client&redirect_uri=https://client/cb&"
+            f"response_type=code&code_challenge={challenge}&"
+            f"code_challenge_method=S256&state=xyz&passphrase=correct-horse-battery"
+        ).encode()
+        status, headers, _ = await _run_asgi(
+            serve_authorize, as_config, method="POST", body=form
+        )
+        assert status == 302
+        location = headers["location"]
+        parsed = urlparse(location)
+        assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == "https://client/cb"
+        qs = parse_qs(parsed.query)
+        assert "code" in qs
+        assert qs["state"] == ["xyz"]
+        # Code stored server-side for later exchange
+        assert qs["code"][0] in _auth_codes
+
+
+# ── /oauth/token ────────────────────────────────────────────────────────────
+
+
+async def _issue_code(as_config, **overrides):
+    """Helper: run an authorize POST with correct passphrase, return (code,
+    code_verifier, params-used-for-issuance)."""
+    from mnemon.oauth_as import serve_authorize
+
+    verifier, challenge = _pkce_pair()
+    params = {
+        "client_id": "test-client",
+        "redirect_uri": "https://client/cb",
+        "response_type": "code",
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "scope": "mcp",
+        "passphrase": "correct-horse-battery",
+    }
+    params.update(overrides)
+    from urllib.parse import urlencode
+    form = urlencode(params).encode()
+    _, headers, _ = await _run_asgi(
+        serve_authorize, as_config, method="POST", body=form
+    )
+    location = headers["location"]
+    parsed = urlparse(location)
+    code = parse_qs(parsed.query)["code"][0]
+    return code, verifier, params
+
+
+class TestServeTokenAuthorizationCode:
+    @pytest.mark.asyncio
+    async def test_404_when_as_disabled(self):
+        from mnemon.oauth_as import serve_token
+
+        config = AuthorizationServerConfig(enabled=False)
+        status, _, _ = await _run_asgi(serve_token, config, method="POST")
+        assert status == 404
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_post(self, as_config):
+        from mnemon.oauth_as import serve_token
+
+        status, _, _ = await _run_asgi(serve_token, as_config, method="GET")
+        assert status == 405
+
+    @pytest.mark.asyncio
+    async def test_rejects_unsupported_grant_type(self, as_config):
+        from mnemon.oauth_as import serve_token
+
+        form = b"grant_type=password"
+        status, _, body = await _run_asgi(
+            serve_token, as_config, method="POST", body=form
+        )
+        assert status == 400
+        assert b"unsupported_grant_type" in body
+
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_tokens(self, as_config):
+        from mnemon.oauth_as import serve_token
+
+        code, verifier, params = await _issue_code(as_config)
+        from urllib.parse import urlencode
+        form = urlencode({
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": params["redirect_uri"],
+            "client_id": params["client_id"],
+            "code_verifier": verifier,
+        }).encode()
+        status, _, body_bytes = await _run_asgi(
+            serve_token, as_config, method="POST", body=form
+        )
+        assert status == 200
+        doc = json.loads(body_bytes)
+        assert doc["token_type"] == "Bearer"
+        assert doc["access_token"]
+        assert doc["refresh_token"]
+        assert doc["expires_in"] == 3600
+        assert doc["scope"] == "mcp"
+
+    @pytest.mark.asyncio
+    async def test_access_token_verifies_against_jwks(self, as_config):
+        """Minted access token must be verifiable with the public key
+        published at /.well-known/jwks.json — the contract the future
+        resource-server swap (PR #39) relies on."""
+        import jwt
+        from mnemon.oauth_as import jwks_document, serve_token
+
+        code, verifier, params = await _issue_code(as_config)
+        from urllib.parse import urlencode
+        form = urlencode({
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": params["redirect_uri"],
+            "client_id": params["client_id"],
+            "code_verifier": verifier,
+        }).encode()
+        _, _, body_bytes = await _run_asgi(
+            serve_token, as_config, method="POST", body=form
+        )
+        token = json.loads(body_bytes)["access_token"]
+
+        jwks = jwks_document(as_config.key_dir)
+        signing_key = jwt.PyJWK(jwks["keys"][0])
+        payload = jwt.decode(
+            token, signing_key.key, algorithms=["RS256"],
+            audience=f"{as_config.issuer}/mcp",
+            issuer=as_config.issuer,
+        )
+        assert payload["sub"] == "owner"
+        assert payload["scope"] == "mcp"
+
+    @pytest.mark.asyncio
+    async def test_code_is_single_use(self, as_config):
+        from mnemon.oauth_as import serve_token
+
+        code, verifier, params = await _issue_code(as_config)
+        from urllib.parse import urlencode
+        form = urlencode({
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": params["redirect_uri"],
+            "client_id": params["client_id"],
+            "code_verifier": verifier,
+        }).encode()
+
+        # First exchange succeeds...
+        status1, _, _ = await _run_asgi(serve_token, as_config, method="POST", body=form)
+        assert status1 == 200
+        # ...second with the same code fails.
+        status2, _, body2 = await _run_asgi(serve_token, as_config, method="POST", body=form)
+        assert status2 == 400
+        assert b"invalid_grant" in body2
+
+    @pytest.mark.asyncio
+    async def test_wrong_code_verifier_rejected(self, as_config):
+        from mnemon.oauth_as import serve_token
+
+        code, _, params = await _issue_code(as_config)
+        from urllib.parse import urlencode
+        form = urlencode({
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": params["redirect_uri"],
+            "client_id": params["client_id"],
+            "code_verifier": "a-different-verifier-than-the-one-used",
+        }).encode()
+        status, _, body = await _run_asgi(
+            serve_token, as_config, method="POST", body=form
+        )
+        assert status == 400
+        assert b"PKCE verification failed" in body
+
+    @pytest.mark.asyncio
+    async def test_wrong_redirect_uri_rejected(self, as_config):
+        from mnemon.oauth_as import serve_token
+
+        code, verifier, params = await _issue_code(as_config)
+        from urllib.parse import urlencode
+        form = urlencode({
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": "https://attacker.example/cb",  # different
+            "client_id": params["client_id"],
+            "code_verifier": verifier,
+        }).encode()
+        status, _, body = await _run_asgi(
+            serve_token, as_config, method="POST", body=form
+        )
+        assert status == 400
+        assert b"redirect_uri" in body
+
+    @pytest.mark.asyncio
+    async def test_wrong_client_id_rejected(self, as_config):
+        from mnemon.oauth_as import serve_token
+
+        code, verifier, params = await _issue_code(as_config)
+        from urllib.parse import urlencode
+        form = urlencode({
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": params["redirect_uri"],
+            "client_id": "different-client",
+            "code_verifier": verifier,
+        }).encode()
+        status, _, body = await _run_asgi(
+            serve_token, as_config, method="POST", body=form
+        )
+        assert status == 400
+        assert b"client_id" in body
+
+    @pytest.mark.asyncio
+    async def test_unknown_code_rejected(self, as_config):
+        from mnemon.oauth_as import serve_token
+
+        form = (
+            b"grant_type=authorization_code&code=nope&redirect_uri=https://x/cb&"
+            b"client_id=c&code_verifier=v"
+        )
+        status, _, body = await _run_asgi(
+            serve_token, as_config, method="POST", body=form
+        )
+        assert status == 400
+        assert b"invalid_grant" in body
+
+
+class TestServeTokenRefreshGrant:
+    @pytest.mark.asyncio
+    async def test_refresh_token_rotates(self, as_config):
+        """Rotating refresh tokens means each refresh consumes the old
+        one and issues a new one. A leaked refresh token only works once."""
+        from mnemon.oauth_as import serve_token
+
+        # Get an initial pair.
+        code, verifier, params = await _issue_code(as_config)
+        from urllib.parse import urlencode
+        code_form = urlencode({
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": params["redirect_uri"],
+            "client_id": params["client_id"],
+            "code_verifier": verifier,
+        }).encode()
+        _, _, body1 = await _run_asgi(serve_token, as_config, method="POST", body=code_form)
+        first = json.loads(body1)
+
+        # Refresh → new pair.
+        refresh_form = urlencode({
+            "grant_type": "refresh_token",
+            "refresh_token": first["refresh_token"],
+        }).encode()
+        status, _, body2 = await _run_asgi(
+            serve_token, as_config, method="POST", body=refresh_form
+        )
+        assert status == 200
+        second = json.loads(body2)
+        assert second["access_token"] != first["access_token"]
+        assert second["refresh_token"] != first["refresh_token"]
+
+        # Old refresh token is now invalid.
+        status3, _, body3 = await _run_asgi(
+            serve_token, as_config, method="POST", body=refresh_form
+        )
+        assert status3 == 400
+        assert b"invalid_grant" in body3
+
+    @pytest.mark.asyncio
+    async def test_unknown_refresh_token_rejected(self, as_config):
+        from mnemon.oauth_as import serve_token
+
+        form = b"grant_type=refresh_token&refresh_token=nope"
+        status, _, body = await _run_asgi(
+            serve_token, as_config, method="POST", body=form
+        )
+        assert status == 400
+        assert b"invalid_grant" in body
+
+    @pytest.mark.asyncio
+    async def test_missing_refresh_token_rejected(self, as_config):
+        from mnemon.oauth_as import serve_token
+
+        form = b"grant_type=refresh_token"
+        status, _, body = await _run_asgi(
+            serve_token, as_config, method="POST", body=form
+        )
+        assert status == 400
+        assert b"invalid_request" in body
+
+
+class TestPKCEVerification:
+    def test_correct_verifier_validates(self):
+        from mnemon.oauth_as import _verify_pkce_s256
+        verifier, challenge = _pkce_pair()
+        assert _verify_pkce_s256(verifier, challenge) is True
+
+    def test_wrong_verifier_fails(self):
+        from mnemon.oauth_as import _verify_pkce_s256
+        _, challenge = _pkce_pair()
+        assert _verify_pkce_s256("not-the-verifier", challenge) is False
+
+
+class TestMintAccessToken:
+    def test_token_decodes_to_expected_claims(self, as_config):
+        import jwt
+        from mnemon.oauth_as import mint_access_token, public_key_jwk
+
+        token = mint_access_token(
+            as_config, subject="owner", scope="mcp", ttl_sec=60
+        )
+        jwk = public_key_jwk(as_config.key_dir)
+        signing_key = jwt.PyJWK(jwk)
+        payload = jwt.decode(
+            token, signing_key.key, algorithms=["RS256"],
+            audience=f"{as_config.issuer}/mcp",
+            issuer=as_config.issuer,
+        )
+        assert payload["sub"] == "owner"
+        assert payload["scope"] == "mcp"
+        assert payload["iss"] == as_config.issuer
+        assert payload["aud"] == f"{as_config.issuer}/mcp"
+
+    def test_token_header_includes_kid(self, as_config):
+        import jwt
+        from mnemon.oauth_as import mint_access_token
+
+        token = mint_access_token(as_config, subject="owner", scope="mcp")
+        header = jwt.get_unverified_header(token)
+        assert header["kid"] == "mnemon-as-1"
+        assert header["alg"] == "RS256"


### PR DESCRIPTION
## Summary
Second of five Phase 2 PRs. Implements the OAuth 2.1 token-issuance flow for self-hosted auth. Still gated behind `MNEMON_AS_ENABLED=false` — no runtime behavior change until PR #39 flips the resource server to verify self-hosted tokens.

## Endpoints
- `GET /oauth/authorize` — HTML passphrase login form with authorize params as hidden inputs. All untrusted input HTML-escaped (XSS defense).
- `POST /oauth/authorize` — validates PKCE params + passphrase, issues a 32-byte random code, redirects to `redirect_uri` with `code` + `state`.
- `POST /oauth/token`
  - `grant_type=authorization_code` — validates code existence/expiry/client_id/redirect_uri + PKCE S256, consumes code (one-time use), returns access + refresh tokens
  - `grant_type=refresh_token` — **rotating** refresh tokens. Old token consumed even on success — leaked token only works once.

## Token format
- **Access**: RS256 JWT, signed with AS RSA key from PR #36. Claims: `iss`, `aud = {issuer}/mcp`, `sub`, `iat`, `exp`, `scope`, `jti`. `jti` makes each token unique + enables future per-token revocation.
- **Refresh**: opaque 32-byte secrets.token_urlsafe, 30-day TTL.

## Security
- PKCE S256 only (plain explicitly rejected — OAuth 2.1 compliance)
- `response_type=code` only (implicit flow removed in 2.1)
- Passphrase verified with `hmac.compare_digest`; empty configured passphrase never matches (guards misconfig)
- Wrong passphrase re-renders form rather than redirecting with error — keeps attempted-URL patterns out of network logs
- Auth code consume-on-lookup (one-time use)
- Refresh token rotation — every use invalidates the old

## Storage
Auth codes + refresh tokens in module-level dicts. Server restart invalidates both (forces re-login) — acceptable for personal-use AS. Swap for SQLite-backed tables if persistence needed; interface stays the same.

## Test plan
- [x] 399 tests pass (26 new covering PKCE, passphrase rejection, wrong client_id/redirect_uri/verifier, code reuse, refresh rotation, JWKS verification of minted tokens, HTML escape)

## Next
- PR #38: `/oauth/register` (DCR, RFC 7591)
- PR #39: swap resource server to verify self-hosted tokens
- PR #40: reconnect claude.ai, remove Auth0 secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)