### PR TITLE
Phase 2 PR #39: resource server verifies self-hosted JWTs when AS enabled

### DIFF
--- a/src/mnemon/auth.py
+++ b/src/mnemon/auth.py
@@ -172,7 +172,7 @@ class OAuthMiddleware:
             return
 
         if path == "/.well-known/oauth-protected-resource":
-            if not self.config.enabled:
+            if not self._prm_enabled():
                 await _send_json(
                     send, 404, {"error": "oauth not configured on this server"}
                 )
@@ -243,9 +243,14 @@ class OAuthMiddleware:
             return
 
         # Unauthenticated mode — pass through only when NEITHER auth method
-        # is configured. If local_token is set but OAuth is not, we still
+        # is configured. If local_token or self-hosted AS is set, we still
         # enforce auth below.
-        if not self.config.enabled and not self.config.local_token:
+        as_enabled = self.as_config is not None and self.as_config.enabled
+        if (
+            not self.config.enabled
+            and not self.config.local_token
+            and not as_enabled
+        ):
             await self.app(scope, receive, send)
             return
 
@@ -276,11 +281,29 @@ class OAuthMiddleware:
             await self.app(scope, receive, send)
             return
 
-        # If only local_token is configured (no OAuth), any non-matching
-        # token is invalid — do not fall through to JWT/userinfo because
-        # neither is configured and _validate_token would raise on missing
-        # jwks_url. This path also covers the self-hosted / Phase 2 world
-        # where the OAuth block may be absent entirely.
+        # Self-hosted AS path: when MNEMON_AS_ENABLED=true, validate the
+        # token against the local JWKS. No network hop. Checked before
+        # the Auth0 path so that after the Phase 2 cutover (PR #40), we
+        # don't waste a PyJWKClient roundtrip on tokens we'll reject
+        # anyway if the Auth0 config ends up unset.
+        if as_enabled:
+            from .oauth_as import verify_self_hosted_token
+
+            try:
+                verify_self_hosted_token(self.as_config, token)
+            except ValueError as e:
+                logger.info("Self-hosted token validation failed: %s", e)
+                await self._send_401(
+                    send, error="invalid_token", description=str(e),
+                )
+                return
+            await self.app(scope, receive, send)
+            return
+
+        # If only local_token is configured (no OAuth, no AS), any non-
+        # matching token is invalid — do not fall through to JWT/userinfo
+        # because neither is configured and _validate_token would raise on
+        # missing jwks_url.
         if not self.config.enabled:
             await self._send_401(
                 send,
@@ -289,7 +312,12 @@ class OAuthMiddleware:
             )
             return
 
-        # Try JWT validation first (spec-compliant path).
+        # Auth0 / external-AS path. Kept alongside the self-hosted path
+        # above so PR #40 can be the config flip (swap env vars on Fly +
+        # reconnect claude.ai) without a code change. Once cutover is
+        # validated and claude.ai is reconnected against the self-hosted
+        # AS, this block becomes dead code and can be deleted in a
+        # follow-up — but keeping it reversible costs us nothing.
         jwt_error: _OAuthError | None = None
         try:
             self._validate_token(token)
@@ -333,12 +361,36 @@ class OAuthMiddleware:
         # Token valid — forward to downstream app.
         await self.app(scope, receive, send)
 
+    def _prm_enabled(self) -> bool:
+        """Whether to serve Protected Resource Metadata at all.
+
+        Served when any OAuth-capable auth path is active — either the
+        external-AS (Auth0) path or the self-hosted AS. Not served when
+        only MNEMON_LOCAL_TOKEN is configured (headless-only auth has
+        no PRM because there's no browser flow to bootstrap)."""
+        if self.config.enabled:
+            return True
+        if self.as_config is not None and self.as_config.enabled:
+            return True
+        return False
+
     def _protected_resource_metadata(self) -> dict[str, Any]:
-        """Build the RFC 9728 Protected Resource Metadata JSON body."""
-        assert self.config.audience and self.config.issuer
+        """Build the RFC 9728 Protected Resource Metadata JSON body.
+
+        When the self-hosted AS is enabled, the authorization_servers
+        list points at this same server's issuer; otherwise it uses the
+        external-AS (Auth0) config.
+        """
+        if self.as_config is not None and self.as_config.enabled:
+            issuer = self.as_config.issuer
+            resource = f"{issuer}/mcp"
+        else:
+            assert self.config.audience and self.config.issuer
+            issuer = self.config.issuer
+            resource = self.config.audience
         return {
-            "resource": self.config.audience,
-            "authorization_servers": [self.config.issuer],
+            "resource": resource,
+            "authorization_servers": [issuer],
             "bearer_methods_supported": ["header"],
             "resource_documentation": "https://github.com/cipher813/mnemon",
         }
@@ -479,6 +531,21 @@ class OAuthMiddleware:
 
         return profile
 
+    def _resource_metadata_url(self) -> str:
+        """Resolve the PRM URL from whichever AS config is active.
+
+        When the self-hosted AS is enabled and the external-AS (Auth0)
+        config is absent, ``config.resource_metadata_url`` would fail
+        its ``audience``-derivation fallback. Use the AS config's
+        public_url in that case. Both configs share the same Fly app
+        URL in practice, so the result is identical when both are set.
+        """
+        if self.as_config is not None and self.as_config.enabled:
+            base = self.as_config.public_url or ""
+            if base:
+                return f"{base.rstrip('/')}/.well-known/oauth-protected-resource"
+        return self.config.resource_metadata_url
+
     async def _send_401(
         self,
         send: ASGISend,
@@ -489,7 +556,7 @@ class OAuthMiddleware:
         """Return 401 with RFC 6750 + RFC 9728 WWW-Authenticate header."""
         www_auth_parts = [
             'Bearer realm="mnemon"',
-            f'resource_metadata="{self.config.resource_metadata_url}"',
+            f'resource_metadata="{self._resource_metadata_url()}"',
             f'error="{error}"',
         ]
         if description:

--- a/src/mnemon/oauth_as.py
+++ b/src/mnemon/oauth_as.py
@@ -377,6 +377,52 @@ def _new_random_token(nbytes: int = 32) -> str:
     return secrets.token_urlsafe(nbytes)
 
 
+# ── Resource-server verification side ───────────────────────────────────────
+
+
+def verify_self_hosted_token(
+    config: AuthorizationServerConfig, token: str
+) -> dict[str, Any]:
+    """Verify a JWT was issued by this AS and return its claims.
+
+    Used by the resource-server middleware (``auth.py``) when
+    ``MNEMON_AS_ENABLED=true`` to validate bearer tokens without any
+    network hop — keys come from the local filesystem, issuer/audience
+    from the local config. This is the read-path counterpart to
+    ``mint_access_token``; the two must agree on iss/aud/alg.
+
+    Raises:
+        ValueError: on any validation failure (expired, wrong issuer,
+            wrong audience, bad signature, missing required claim).
+            The message is safe to surface in error responses — it
+            describes the class of failure, not the token internals.
+    """
+    import jwt
+
+    jwk_dict = public_key_jwk(config.key_dir)
+    # PyJWK accepts the JWK directly; no PyJWKClient round-trip needed.
+    signing_key = jwt.PyJWK(jwk_dict)
+
+    expected_aud = f"{config.issuer}/mcp"
+    try:
+        return jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=[JWT_ALG],
+            audience=expected_aud,
+            issuer=config.issuer,
+            options={"require": ["exp", "iat", "iss", "aud", "sub"]},
+        )
+    except jwt.ExpiredSignatureError as e:
+        raise ValueError("token expired") from e
+    except jwt.InvalidAudienceError as e:
+        raise ValueError(f"audience mismatch (expected {expected_aud})") from e
+    except jwt.InvalidIssuerError as e:
+        raise ValueError(f"issuer mismatch (expected {config.issuer})") from e
+    except jwt.InvalidTokenError as e:
+        raise ValueError(f"invalid token: {e}") from e
+
+
 def _issue_token_pair(
     config: AuthorizationServerConfig,
     *,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -839,3 +839,136 @@ async def test_as_metadata_404_when_as_disabled_even_if_config_provided(oauth_co
         mw, "/.well-known/oauth-authorization-server"
     )
     assert status == 404
+
+
+# --- Self-hosted AS resource-server verification (Phase 2 PR #39) ----------
+
+
+@pytest.fixture
+def enabled_as_config(tmp_path):
+    from mnemon.oauth_as import AuthorizationServerConfig
+    return AuthorizationServerConfig(
+        enabled=True,
+        public_url="https://mnemon-test.example.com",
+        passphrase="x",
+        key_dir=tmp_path,
+    )
+
+
+@pytest.mark.asyncio
+async def test_self_hosted_token_accepted(enabled_as_config):
+    """A token minted by the local AS must be accepted when AS is enabled,
+    with no Auth0 config present — the hard-cutover path."""
+    from mnemon.oauth_as import mint_access_token
+
+    token = mint_access_token(enabled_as_config, subject="owner", scope="mcp")
+    downstream_called = []
+    app = _stub_downstream_factory(downstream_called)
+    # No external-AS config — only self-hosted.
+    mw = OAuthMiddleware(app, OAuthConfig(), as_config=enabled_as_config)
+
+    status, _, _ = await _call_middleware(
+        mw, "/mcp",
+        headers=[(b"authorization", f"Bearer {token}".encode())],
+    )
+    assert status == 200
+    assert downstream_called == [True]
+
+
+@pytest.mark.asyncio
+async def test_self_hosted_expired_token_returns_401(enabled_as_config):
+    from mnemon.oauth_as import mint_access_token
+
+    token = mint_access_token(
+        enabled_as_config, subject="owner", scope="mcp", ttl_sec=-60
+    )
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, OAuthConfig(), as_config=enabled_as_config)
+
+    status, headers, body = await _call_middleware(
+        mw, "/mcp",
+        headers=[(b"authorization", f"Bearer {token}".encode())],
+    )
+    assert status == 401
+    assert b"expired" in body
+    # WWW-Authenticate header points at the self-hosted PRM URL
+    auth_header = headers.get(b"www-authenticate", b"")
+    assert b"mnemon-test.example.com/.well-known/oauth-protected-resource" in auth_header
+
+
+@pytest.mark.asyncio
+async def test_self_hosted_random_garbage_returns_401(enabled_as_config):
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, OAuthConfig(), as_config=enabled_as_config)
+
+    status, _, _ = await _call_middleware(
+        mw, "/mcp",
+        headers=[(b"authorization", b"Bearer not.a.jwt")],
+    )
+    assert status == 401
+
+
+@pytest.mark.asyncio
+async def test_self_hosted_missing_bearer_returns_401(enabled_as_config):
+    """Even with self-hosted AS as the only auth method, missing bearer
+    must still return 401 (not pass through as unauthenticated)."""
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, OAuthConfig(), as_config=enabled_as_config)
+
+    status, _, _ = await _call_middleware(mw, "/mcp")
+    assert status == 401
+
+
+@pytest.mark.asyncio
+async def test_local_token_still_works_alongside_self_hosted(enabled_as_config):
+    """Claude Code hooks authenticate via MNEMON_LOCAL_TOKEN. That path
+    must keep working when AS is the primary OAuth path — hooks can't
+    do an OAuth flow, so local_token is the only option for them."""
+    app = _stub_downstream_factory([])
+    config = OAuthConfig(local_token="hooks-token-value")
+    mw = OAuthMiddleware(app, config, as_config=enabled_as_config)
+
+    status, _, _ = await _call_middleware(
+        mw, "/mcp",
+        headers=[(b"authorization", b"Bearer hooks-token-value")],
+    )
+    assert status == 200
+
+
+@pytest.mark.asyncio
+async def test_self_hosted_prm_points_at_local_issuer(enabled_as_config):
+    """When AS is enabled, /.well-known/oauth-protected-resource must
+    advertise the local issuer, not some external AS. Without this,
+    clients doing MCP auth discovery would send users back to a dead
+    Auth0 config."""
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, OAuthConfig(), as_config=enabled_as_config)
+
+    status, _, body = await _call_middleware(
+        mw, "/.well-known/oauth-protected-resource"
+    )
+    assert status == 200
+    doc = json.loads(body)
+    assert doc["authorization_servers"] == ["https://mnemon-test.example.com"]
+    assert doc["resource"] == "https://mnemon-test.example.com/mcp"
+
+
+@pytest.mark.asyncio
+async def test_external_as_still_works_when_self_hosted_disabled(
+    oauth_config, rsa_keypair, mock_signing_key
+):
+    """Auth0 path must keep working when MNEMON_AS_ENABLED=false —
+    that's how PR #39 deploys without breaking the live site. The
+    cutover to self-hosted happens by flipping MNEMON_AS_ENABLED on
+    Fly in PR #40, not by merging #39."""
+    token = _mint_token(rsa_keypair["private_key"])
+    downstream_called = []
+    app = _stub_downstream_factory(downstream_called)
+    mw = OAuthMiddleware(app, oauth_config)  # no as_config
+
+    status, _, _ = await _call_middleware(
+        mw, "/mcp",
+        headers=[(b"authorization", f"Bearer {token}".encode())],
+    )
+    assert status == 200
+    assert downstream_called == [True]

--- a/tests/test_oauth_as.py
+++ b/tests/test_oauth_as.py
@@ -1080,3 +1080,112 @@ class TestRegisterRouting:
 
         status = next(m for m in sent if m["type"] == "http.response.start")["status"]
         assert status == 201
+
+
+# ── verify_self_hosted_token (resource-server side) ─────────────────────────
+
+
+class TestVerifySelfHostedToken:
+    def test_accepts_token_minted_by_this_as(self, as_config):
+        from mnemon.oauth_as import mint_access_token, verify_self_hosted_token
+
+        token = mint_access_token(as_config, subject="owner", scope="mcp")
+        claims = verify_self_hosted_token(as_config, token)
+        assert claims["sub"] == "owner"
+        assert claims["scope"] == "mcp"
+        assert claims["iss"] == as_config.issuer
+        assert claims["aud"] == f"{as_config.issuer}/mcp"
+
+    def test_rejects_expired_token(self, as_config):
+        from mnemon.oauth_as import mint_access_token, verify_self_hosted_token
+
+        token = mint_access_token(
+            as_config, subject="owner", scope="mcp", ttl_sec=-60
+        )
+        with pytest.raises(ValueError, match="expired"):
+            verify_self_hosted_token(as_config, token)
+
+    def test_rejects_wrong_audience(self, as_config):
+        from mnemon.oauth_as import mint_access_token, verify_self_hosted_token
+
+        token = mint_access_token(
+            as_config, subject="owner", scope="mcp",
+            audience="https://some-other-resource.example",
+        )
+        with pytest.raises(ValueError, match="audience"):
+            verify_self_hosted_token(as_config, token)
+
+    def test_rejects_token_signed_by_different_key(self, as_config, tmp_path):
+        """A token minted against a different keypair must fail — the
+        resource server must not accept tokens from any RS256 issuer,
+        only ours."""
+        import jwt
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        from mnemon.oauth_as import verify_self_hosted_token
+
+        foreign_priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        foreign_pem = foreign_priv.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        import time as _time
+        payload = {
+            "iss": as_config.issuer,
+            "aud": f"{as_config.issuer}/mcp",
+            "sub": "owner",
+            "iat": int(_time.time()),
+            "exp": int(_time.time()) + 60,
+            "scope": "mcp",
+        }
+        fake_token = jwt.encode(payload, foreign_pem, algorithm="RS256")
+        with pytest.raises(ValueError):
+            verify_self_hosted_token(as_config, fake_token)
+
+    def test_rejects_token_with_wrong_issuer(self, as_config):
+        """Token signed by our key but claiming a different issuer —
+        the jwt library must catch the iss mismatch."""
+        import jwt
+        from mnemon.oauth_as import ensure_keypair, verify_self_hosted_token
+
+        private_pem, _ = ensure_keypair(as_config.key_dir)
+        import time as _time
+        payload = {
+            "iss": "https://someone-else.example",
+            "aud": f"{as_config.issuer}/mcp",
+            "sub": "owner",
+            "iat": int(_time.time()),
+            "exp": int(_time.time()) + 60,
+            "scope": "mcp",
+        }
+        token = jwt.encode(payload, private_pem, algorithm="RS256")
+        with pytest.raises(ValueError, match="issuer"):
+            verify_self_hosted_token(as_config, token)
+
+    def test_rejects_malformed_token(self, as_config):
+        from mnemon.oauth_as import verify_self_hosted_token
+
+        with pytest.raises(ValueError):
+            verify_self_hosted_token(as_config, "not.a.jwt")
+
+    def test_requires_sub_claim(self, as_config):
+        """All minted tokens include sub=owner. A token missing sub —
+        maliciously or from a bug — must be rejected, not silently
+        forwarded as anonymous."""
+        import jwt
+        from mnemon.oauth_as import ensure_keypair, verify_self_hosted_token
+
+        private_pem, _ = ensure_keypair(as_config.key_dir)
+        import time as _time
+        payload = {
+            "iss": as_config.issuer,
+            "aud": f"{as_config.issuer}/mcp",
+            "iat": int(_time.time()),
+            "exp": int(_time.time()) + 60,
+            # sub intentionally omitted
+        }
+        token = jwt.encode(payload, private_pem, algorithm="RS256")
+        with pytest.raises(ValueError):
+            verify_self_hosted_token(as_config, token)


### PR DESCRIPTION
## Summary
Fourth of five Phase 2 PRs. Adds a self-hosted-AS token verification path to the OAuth middleware, gated by `MNEMON_AS_ENABLED`. **Safe to deploy** — the Auth0 path stays as default when the flag is off. PR #40 flips the flag on Fly and reconnects claude.ai.

## What ships
- **`oauth_as.verify_self_hosted_token()`** — validates a JWT against the local JWKS (no PyJWKClient network hop), enforces `issuer = config.issuer`, `audience = {issuer}/mcp`, requires `exp/iat/iss/aud/sub` claims. RS256 only.
- **`OAuthMiddleware` updates**
  - Self-hosted code path: when `as_config.enabled`, tokens go through `verify_self_hosted_token`. Failure → 401. No fallback to Auth0 — hard-cutover semantics once flag is on.
  - `_prm_enabled()` gates `/.well-known/oauth-protected-resource` — served when either AS is active, 404 when only `local_token` is configured.
  - `_protected_resource_metadata` advertises the self-hosted issuer when AS enabled.
  - `_resource_metadata_url` falls back to `as_config.public_url` for 401 WWW-Authenticate headers in self-hosted-only deployments.
  - Auth enforcement gate includes `as_enabled` — previously a server with only AS configured would pass through unauthenticated.

## Test plan
- [x] 428 tests pass
- [x] 14 new tests: self-hosted accept/reject, expired, wrong audience, wrong issuer, foreign-key signature, missing sub, local_token alongside AS, PRM targeting, Auth0 no-regression fence

## Next
- **PR #40**: flip `MNEMON_AS_ENABLED` on Fly, reconnect claude.ai, remove Auth0 Fly secrets. No code change — operational PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)