### PR TITLE
Phase 2 post-cutover cleanup: remove Auth0 / external-AS code path

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,14 @@ MNEMON_LOCAL_TOKEN=your-secret-token mnemon serve-remote
 PORT=9000 mnemon serve-remote
 ```
 
-For production, deploy to [Fly.io](https://fly.io) with a persistent volume (1GB minimum RAM required for FastEmbed model). See `fly.toml` and `Dockerfile` in the repo. Set `MNEMON_LOCAL_TOKEN` as a Fly secret for hook authentication. OAuth (Auth0 or self-hosted) is supported for browser-based clients like claude.ai.
+For production, deploy to [Fly.io](https://fly.io) with a persistent volume (1GB minimum RAM required for FastEmbed model). See `fly.toml` and `Dockerfile` in the repo. Required Fly secrets:
+
+- `MNEMON_LOCAL_TOKEN` — bearer token for headless clients (Claude Code hooks, Cursor)
+- `MNEMON_AS_ENABLED=true` — enable the self-hosted OAuth Authorization Server
+- `MNEMON_AS_PASSPHRASE` — single-user login passphrase for browser-based clients (claude.ai, Claude Desktop)
+- `MNEMON_PUBLIC_URL` — externally-reachable base URL, e.g. `https://your-mnemon.fly.dev`
+
+Browser clients discover the AS via DCR (RFC 7591) at `POST /oauth/register`, then walk through the PKCE authorization code flow at `/oauth/authorize` + `/oauth/token`. No third-party auth vendor required.
 
 ## S3 Vault Sync
 
@@ -215,12 +222,25 @@ A small set of architectural choices shape the rest of the system. Documented he
 
 ## Configuration
 
+**Client-side (hooks, CLI)**
+
 | Env var | Default | Description |
 |---------|---------|-------------|
 | `MNEMON_REMOTE_URL` | (none) | Remote server URL (or `~/.mnemon/remote_url` file) |
 | `MNEMON_LOCAL_TOKEN` | (none) | Bearer token for remote auth (or `~/.mnemon/local_token` file) |
 | `MNEMON_VAULT_DIR` | `~/.mnemon` | Local vault directory |
 | `MNEMON_MODEL_DIR` | `~/.mnemon/models` | Directory for LLM model files |
+
+**Server-side (`mnemon serve-remote`)**
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `MNEMON_AS_ENABLED` | `false` | Enable the self-hosted OAuth Authorization Server |
+| `MNEMON_AS_PASSPHRASE` | (none) | Single-user login passphrase (required when AS enabled) |
+| `MNEMON_AS_KEY_DIR` | `$MNEMON_VAULT_DIR/oauth_keys` | RSA keypair storage directory |
+| `MNEMON_PUBLIC_URL` | (none) | Externally-reachable base URL (required when AS enabled) |
+| `MNEMON_LOCAL_TOKEN` | (none) | Static bearer for headless clients (hooks, Cursor) |
+| `MNEMON_ALLOWED_HOSTS` | (none) | Comma-separated host allowlist for DNS-rebinding protection |
 | `PORT` | `8502` | Remote server port |
 
 ## Known limitations

--- a/src/mnemon/auth.py
+++ b/src/mnemon/auth.py
@@ -3,17 +3,23 @@
 Implements the MCP authorization specification (2025-06-18) resource-server
 side: serves RFC 9728 Protected Resource Metadata, returns RFC 6750 compliant
 401 responses with WWW-Authenticate header on missing/invalid tokens, and
-validates JWT bearer tokens against an external OAuth 2.1 authorization server.
+validates JWT bearer tokens against mnemon's self-hosted Authorization
+Server (see ``oauth_as.py``).
 
-This is Phase 1 of the mnemon OAuth build — the AS (authorization server) is
-external (e.g., Auth0, Logto). Phase 2 will implement a self-hosted AS inside
-mnemon. See private/mnemon-plan-optimized-260410.md for context.
+Two auth paths:
+
+1. **Self-hosted AS JWTs** — for browser-capable MCP clients (claude.ai
+   web/mobile, Claude Desktop) that complete a DCR + PKCE flow against
+   our own /oauth/authorize + /oauth/token endpoints. Tokens are
+   RS256-signed by our local keypair and verified with no network hop.
+
+2. **Local static bearer** (``MNEMON_LOCAL_TOKEN``) — for headless
+   clients (Claude Code hooks, Cursor, scripts) that cannot complete a
+   browser OAuth flow. Compared constant-time against the env secret.
 
 The middleware is pure ASGI (not Starlette BaseHTTPMiddleware) because
 BaseHTTPMiddleware has known compatibility issues with mounted ASGI sub-apps
-and streaming responses — the original c5828c2 commit's bearer middleware
-had a bug where it did not actually enforce auth for requests reaching the
-mounted FastMCP app.
+and streaming responses.
 """
 
 from __future__ import annotations
@@ -39,46 +45,17 @@ ASGIApp = Callable[[ASGIScope, ASGIReceive, ASGISend], Awaitable[None]]
 class OAuthConfig:
     """Resource-server auth configuration loaded from environment.
 
-    All fields are optional. Two auth paths are supported and can be enabled
-    independently or together:
+    Post–Phase 2 this class only carries the local bearer token used by
+    headless clients. Browser-based OAuth is handled entirely by the
+    self-hosted Authorization Server in ``oauth_as.py`` (wired as a
+    separate ``AuthorizationServerConfig`` passed to the middleware).
 
-    1. **OAuth 2.1 JWT / userinfo** — when ``issuer``, ``jwks_url``, and
-       ``audience`` are set, the server accepts JWT bearer tokens from the
-       configured authorization server. Intended for browser-capable MCP
-       clients (claude.ai web/mobile, Claude Desktop) that can complete a
-       DCR + PKCE flow.
-    2. **Local static bearer** — when ``local_token`` is set, the server
-       accepts a specific bearer token value directly, without any network
-       roundtrip to the authorization server. Intended for headless clients
-       that cannot complete a browser OAuth flow (Claude Code hooks, Cursor,
-       scripts).
-
-    If both are configured, the local token is checked first. If neither is
-    configured, the server runs without auth (intended for local development
-    only — do not expose an unauthenticated server to the public internet).
+    Retained as a distinct config type rather than merged into
+    ``AuthorizationServerConfig`` because the local-token path is
+    orthogonal to OAuth — a deployment can enable one without the other.
     """
 
-    def __init__(
-        self,
-        issuer: str | None = None,
-        jwks_url: str | None = None,
-        audience: str | None = None,
-        public_url: str | None = None,
-        userinfo_url: str | None = None,
-        local_token: str | None = None,
-    ) -> None:
-        self.issuer = issuer
-        self.jwks_url = jwks_url
-        self.audience = audience
-        # public_url is the externally-reachable base URL, used to build the
-        # resource_metadata URL in WWW-Authenticate headers. Falls back to
-        # audience's scheme+host if unset.
-        self.public_url = public_url
-        # userinfo_url is an optional fallback for token introspection when
-        # JWT validation fails. Needed because some OAuth providers issue
-        # opaque tokens for OIDC-only flows instead of JWTs bound to the
-        # requested audience. If unset, no fallback is used.
-        self.userinfo_url = userinfo_url
+    def __init__(self, local_token: str | None = None) -> None:
         # local_token is a static bearer accepted for headless clients that
         # cannot complete a browser OAuth flow. When set, the middleware
         # accepts requests whose bearer matches this value exactly (using a
@@ -88,54 +65,30 @@ class OAuthConfig:
 
     @classmethod
     def from_env(cls) -> OAuthConfig:
-        return cls(
-            issuer=os.environ.get("MNEMON_OAUTH_ISSUER") or None,
-            jwks_url=os.environ.get("MNEMON_OAUTH_JWKS_URL") or None,
-            audience=os.environ.get("MNEMON_OAUTH_AUDIENCE") or None,
-            public_url=os.environ.get("MNEMON_PUBLIC_URL") or None,
-            userinfo_url=os.environ.get("MNEMON_OAUTH_USERINFO_URL") or None,
-            local_token=os.environ.get("MNEMON_LOCAL_TOKEN") or None,
-        )
-
-    @property
-    def enabled(self) -> bool:
-        return bool(self.issuer and self.jwks_url and self.audience)
-
-    @property
-    def resource_metadata_url(self) -> str:
-        """URL of the Protected Resource Metadata endpoint."""
-        base = self.public_url or self._derive_base_from_audience()
-        return f"{base.rstrip('/')}/.well-known/oauth-protected-resource"
-
-    def _derive_base_from_audience(self) -> str:
-        """Fallback: derive scheme+host from audience if public_url unset."""
-        if not self.audience:
-            return ""
-        from urllib.parse import urlparse
-
-        parsed = urlparse(self.audience)
-        return f"{parsed.scheme}://{parsed.netloc}"
+        return cls(local_token=os.environ.get("MNEMON_LOCAL_TOKEN") or None)
 
 
 class OAuthMiddleware:
     """Pure-ASGI OAuth 2.1 resource-server middleware.
 
     Wraps a downstream ASGI application (the FastMCP streamable-http app).
-    Intercepts three categories of requests:
+    Intercepts four categories of requests:
 
     1. ``/health`` — served unauthenticated with ``{"status": "ok"}``.
-    2. ``/.well-known/oauth-protected-resource`` — served unauthenticated
-       with RFC 9728 Protected Resource Metadata JSON pointing at the
-       configured authorization server.
-    3. Everything else — requires a valid JWT bearer token. The token is
-       validated against the configured JWKS; on failure, returns 401 with
-       an RFC 6750 / RFC 9728 compliant ``WWW-Authenticate`` header.
+    2. Well-known metadata endpoints (``/.well-known/oauth-protected-
+       resource``, ``/.well-known/oauth-authorization-server``,
+       ``/.well-known/jwks.json``) — served unauthenticated.
+    3. OAuth AS endpoints (``/oauth/authorize``, ``/oauth/token``,
+       ``/oauth/register``) — delegated to ``oauth_as.py`` handlers,
+       served unauthenticated (they bootstrap auth).
+    4. Everything else — requires a valid bearer token. Either the
+       static ``MNEMON_LOCAL_TOKEN`` or a JWT issued by the self-hosted
+       AS; on failure returns 401 with WWW-Authenticate header.
 
-    If the OAuth config is not enabled (any of issuer/jwks_url/audience
-    unset), the middleware operates in pass-through mode: all requests go
-    through unauthenticated, /health still works, and the resource metadata
-    endpoint returns 404. This mirrors the pre-c5828c2 behavior of
-    ``mnemon serve-remote`` without env vars.
+    Pass-through mode: if neither ``MNEMON_LOCAL_TOKEN`` nor
+    ``MNEMON_AS_ENABLED=true`` is set, all non-health requests go
+    through unauthenticated. Intended for local development only —
+    never expose an unauthenticated server to the public internet.
     """
 
     def __init__(
@@ -147,14 +100,9 @@ class OAuthMiddleware:
         self.app = app
         self.config = config
         # Optional self-hosted Authorization Server config. When set and
-        # enabled, the middleware serves the AS well-known documents and
-        # (in future PRs) the AS endpoints themselves. Kept as a separate
-        # parameter from ``config`` so the resource-server concerns stay
-        # decoupled from the AS concerns — callers can wire one without
-        # the other.
+        # enabled, the middleware serves the AS endpoints and validates
+        # bearer JWTs against the local keypair.
         self.as_config = as_config
-        self._jwks_client: Any = None  # Lazy-init PyJWKClient
-        self._userinfo_cache: dict[str, float] = {}  # token hash -> expiry ts
 
     async def __call__(
         self, scope: ASGIScope, receive: ASGIReceive, send: ASGISend
@@ -242,15 +190,11 @@ class OAuthMiddleware:
             await serve_register(self.as_config, scope, receive, send)
             return
 
-        # Unauthenticated mode — pass through only when NEITHER auth method
-        # is configured. If local_token or self-hosted AS is set, we still
-        # enforce auth below.
+        # Pass-through mode: no auth configured at all. Health still
+        # works (handled above), but everything else goes straight to
+        # the downstream app. Local-development convenience only.
         as_enabled = self.as_config is not None and self.as_config.enabled
-        if (
-            not self.config.enabled
-            and not self.config.local_token
-            and not as_enabled
-        ):
+        if not self.config.local_token and not as_enabled:
             await self.app(scope, receive, send)
             return
 
@@ -263,11 +207,10 @@ class OAuthMiddleware:
         token = auth_header[7:].decode("ascii", errors="replace").strip()
 
         # Local-token fast path: static bearer validated directly against
-        # MNEMON_LOCAL_TOKEN with a constant-time comparison. Used by clients
-        # that cannot complete a browser OAuth flow (Claude Code hooks,
-        # Cursor, headless scripts). Skips JWT and userinfo entirely — no
-        # network hop, no external AS dependency. Checked first so local
-        # clients don't pay the network cost of a failed JWT validation.
+        # MNEMON_LOCAL_TOKEN with a constant-time comparison. Used by
+        # headless clients (Claude Code hooks, Cursor, scripts) that
+        # cannot complete a browser OAuth flow. Checked first — no
+        # key-loading cost for the common case.
         if self.config.local_token and hmac.compare_digest(
             token, self.config.local_token
         ):
@@ -281,11 +224,9 @@ class OAuthMiddleware:
             await self.app(scope, receive, send)
             return
 
-        # Self-hosted AS path: when MNEMON_AS_ENABLED=true, validate the
-        # token against the local JWKS. No network hop. Checked before
-        # the Auth0 path so that after the Phase 2 cutover (PR #40), we
-        # don't waste a PyJWKClient roundtrip on tokens we'll reject
-        # anyway if the Auth0 config ends up unset.
+        # Self-hosted AS path: validate the JWT against the local JWKS.
+        # No network hop — keys loaded from the same Fly volume that
+        # signs them.
         if as_enabled:
             from .oauth_as import verify_self_hosted_token
 
@@ -300,251 +241,50 @@ class OAuthMiddleware:
             await self.app(scope, receive, send)
             return
 
-        # If only local_token is configured (no OAuth, no AS), any non-
-        # matching token is invalid — do not fall through to JWT/userinfo
-        # because neither is configured and _validate_token would raise on
-        # missing jwks_url.
-        if not self.config.enabled:
-            await self._send_401(
-                send,
-                error="invalid_token",
-                description="bearer token did not match local token",
-            )
-            return
-
-        # Auth0 / external-AS path. Kept alongside the self-hosted path
-        # above so PR #40 can be the config flip (swap env vars on Fly +
-        # reconnect claude.ai) without a code change. Once cutover is
-        # validated and claude.ai is reconnected against the self-hosted
-        # AS, this block becomes dead code and can be deleted in a
-        # follow-up — but keeping it reversible costs us nothing.
-        jwt_error: _OAuthError | None = None
-        try:
-            self._validate_token(token)
-        except _OAuthError as e:
-            jwt_error = e
-        except Exception as e:  # noqa: BLE001
-            logger.exception("Unexpected error during JWT validation")
-            jwt_error = _OAuthError(
-                "invalid_token", f"validation error: {e}"
-            )
-
-        if jwt_error is not None:
-            # JWT validation failed. If a userinfo URL is configured, try
-            # opaque-token introspection as a fallback. This works around
-            # OAuth providers (notably Auth0) that issue opaque /userinfo
-            # tokens instead of audience-bound JWTs for OIDC-only flows.
-            if self.config.userinfo_url:
-                try:
-                    await self._validate_via_userinfo(token)
-                except _OAuthError as ue:
-                    logger.info(
-                        "Both JWT and userinfo validation failed: jwt=%s userinfo=%s",
-                        jwt_error,
-                        ue,
-                    )
-                    await self._send_401(
-                        send,
-                        error=ue.code,
-                        description=f"jwt: {jwt_error.description}; userinfo: {ue.description}",
-                    )
-                    return
-                # Userinfo fallback succeeded — fall through.
-                logger.info("Token validated via userinfo fallback (JWT failed)")
-            else:
-                logger.info("JWT validation failed: %s", jwt_error)
-                await self._send_401(
-                    send, error=jwt_error.code, description=jwt_error.description
-                )
-                return
-
-        # Token valid — forward to downstream app.
-        await self.app(scope, receive, send)
+        # Only local_token was configured and the bearer didn't match —
+        # reject. Token validation against an AS is not possible.
+        await self._send_401(
+            send,
+            error="invalid_token",
+            description="bearer token did not match local token",
+        )
 
     def _prm_enabled(self) -> bool:
         """Whether to serve Protected Resource Metadata at all.
 
-        Served when any OAuth-capable auth path is active — either the
-        external-AS (Auth0) path or the self-hosted AS. Not served when
-        only MNEMON_LOCAL_TOKEN is configured (headless-only auth has
-        no PRM because there's no browser flow to bootstrap)."""
-        if self.config.enabled:
-            return True
-        if self.as_config is not None and self.as_config.enabled:
-            return True
-        return False
+        Served only when the self-hosted AS is enabled. Not served when
+        only ``MNEMON_LOCAL_TOKEN`` is configured — headless clients
+        don't need PRM because there's no browser flow to bootstrap.
+        """
+        return self.as_config is not None and self.as_config.enabled
 
     def _protected_resource_metadata(self) -> dict[str, Any]:
         """Build the RFC 9728 Protected Resource Metadata JSON body.
 
-        When the self-hosted AS is enabled, the authorization_servers
-        list points at this same server's issuer; otherwise it uses the
-        external-AS (Auth0) config.
+        ``_prm_enabled()`` must be True before calling this — otherwise
+        ``as_config`` may be None or disabled and the assertion fails.
         """
-        if self.as_config is not None and self.as_config.enabled:
-            issuer = self.as_config.issuer
-            resource = f"{issuer}/mcp"
-        else:
-            assert self.config.audience and self.config.issuer
-            issuer = self.config.issuer
-            resource = self.config.audience
+        assert self.as_config is not None and self.as_config.enabled
+        issuer = self.as_config.issuer
         return {
-            "resource": resource,
+            "resource": f"{issuer}/mcp",
             "authorization_servers": [issuer],
             "bearer_methods_supported": ["header"],
             "resource_documentation": "https://github.com/cipher813/mnemon",
         }
 
-    def _validate_token(self, token: str) -> dict[str, Any]:
-        """Validate JWT signature, issuer, audience, and expiry.
-
-        Raises :class:`_OAuthError` on validation failure.
-        """
-        try:
-            import jwt
-            from jwt import PyJWKClient
-        except ImportError as e:
-            raise _OAuthError(
-                "server_error",
-                "pyjwt not installed — install mnemon-memory[server]",
-            ) from e
-
-        if self._jwks_client is None:
-            assert self.config.jwks_url
-            self._jwks_client = PyJWKClient(
-                self.config.jwks_url, cache_keys=True, lifespan=3600
-            )
-
-        try:
-            signing_key = self._jwks_client.get_signing_key_from_jwt(token)
-        except jwt.PyJWKClientError as e:
-            raise _OAuthError(
-                "invalid_token", f"could not fetch signing key: {e}"
-            ) from e
-        except jwt.DecodeError as e:
-            raise _OAuthError("invalid_token", f"malformed token: {e}") from e
-
-        try:
-            return jwt.decode(
-                token,
-                signing_key.key,
-                algorithms=["RS256"],
-                audience=self.config.audience,
-                issuer=self.config.issuer,
-                options={"require": ["exp", "iat", "iss", "aud"]},
-            )
-        except jwt.ExpiredSignatureError as e:
-            raise _OAuthError("invalid_token", "token expired") from e
-        except jwt.InvalidAudienceError as e:
-            raise _OAuthError(
-                "invalid_token", f"audience mismatch (expected {self.config.audience})"
-            ) from e
-        except jwt.InvalidIssuerError as e:
-            raise _OAuthError(
-                "invalid_token", f"issuer mismatch (expected {self.config.issuer})"
-            ) from e
-        except jwt.InvalidTokenError as e:
-            raise _OAuthError("invalid_token", str(e)) from e
-
-    async def _validate_via_userinfo(self, token: str) -> dict[str, Any]:
-        """Fallback: validate an opaque token by calling the OAuth provider's
-        userinfo endpoint (OIDC Core section 5.3).
-
-        Used when JWT decode fails — typically because the provider issued
-        an opaque access token scoped to /userinfo rather than an audience-
-        bound JWT. If the userinfo endpoint returns 200 with a user profile,
-        the token is valid and we extract identity claims.
-
-        Uses a small in-memory cache keyed by token hash to avoid repeat
-        network calls within a short window. Returns the decoded userinfo
-        payload on success. Raises :class:`_OAuthError` on failure.
-
-        This is less strict than JWT audience validation — any token that
-        the provider's /userinfo endpoint accepts will be allowed through,
-        regardless of whether it was specifically issued for mnemon. That's
-        acceptable for Phase 1 / single-user deployments. Phase 2's self-
-        hosted AS will enforce proper audience binding.
-        """
-        import hashlib
-        import time
-
-        assert self.config.userinfo_url
-
-        # Simple TTL cache: token_hash -> expiry_ts (accept until).
-        now = time.time()
-        token_hash = hashlib.sha256(token.encode("ascii", errors="replace")).hexdigest()
-        cached_until = self._userinfo_cache.get(token_hash, 0)
-        if cached_until > now:
-            return {"sub": "cached"}
-
-        try:
-            import httpx
-        except ImportError as e:
-            raise _OAuthError(
-                "server_error", "httpx not installed (required for userinfo fallback)"
-            ) from e
-
-        try:
-            async with httpx.AsyncClient(timeout=5.0) as client:
-                resp = await client.get(
-                    self.config.userinfo_url,
-                    headers={"Authorization": f"Bearer {token}"},
-                )
-        except httpx.TimeoutException as e:
-            raise _OAuthError(
-                "server_error", f"userinfo endpoint timeout: {e}"
-            ) from e
-        except httpx.HTTPError as e:
-            raise _OAuthError(
-                "server_error", f"userinfo endpoint error: {e}"
-            ) from e
-
-        if resp.status_code == 401 or resp.status_code == 403:
-            raise _OAuthError(
-                "invalid_token", "userinfo rejected token"
-            )
-        if resp.status_code != 200:
-            raise _OAuthError(
-                "invalid_token",
-                f"userinfo returned {resp.status_code}",
-            )
-
-        try:
-            profile = resp.json()
-        except ValueError as e:
-            raise _OAuthError(
-                "invalid_token", f"userinfo returned non-JSON: {e}"
-            ) from e
-
-        if not isinstance(profile, dict) or "sub" not in profile:
-            raise _OAuthError(
-                "invalid_token", "userinfo response missing 'sub' claim"
-            )
-
-        # Cache for 5 minutes to avoid hammering the provider.
-        self._userinfo_cache[token_hash] = now + 300
-        # Opportunistic cache eviction to prevent unbounded growth.
-        if len(self._userinfo_cache) > 256:
-            expired = [k for k, v in self._userinfo_cache.items() if v <= now]
-            for k in expired:
-                self._userinfo_cache.pop(k, None)
-
-        return profile
-
     def _resource_metadata_url(self) -> str:
-        """Resolve the PRM URL from whichever AS config is active.
+        """Build the PRM URL for 401 WWW-Authenticate headers.
 
-        When the self-hosted AS is enabled and the external-AS (Auth0)
-        config is absent, ``config.resource_metadata_url`` would fail
-        its ``audience``-derivation fallback. Use the AS config's
-        public_url in that case. Both configs share the same Fly app
-        URL in practice, so the result is identical when both are set.
+        Uses the AS public_url when available. Falls back to an empty
+        string when no AS is configured (local_token-only deployments
+        don't publish a PRM — the header points nowhere useful, but
+        that's fine because headless clients don't read it anyway).
         """
-        if self.as_config is not None and self.as_config.enabled:
-            base = self.as_config.public_url or ""
-            if base:
-                return f"{base.rstrip('/')}/.well-known/oauth-protected-resource"
-        return self.config.resource_metadata_url
+        if self.as_config is not None and self.as_config.public_url:
+            base = self.as_config.public_url.rstrip("/")
+            return f"{base}/.well-known/oauth-protected-resource"
+        return ""
 
     async def _send_401(
         self,
@@ -582,15 +322,6 @@ class OAuthMiddleware:
             }
         )
         await send({"type": "http.response.body", "body": body, "more_body": False})
-
-
-class _OAuthError(Exception):
-    """Internal OAuth validation error — carries an RFC 6750 error code."""
-
-    def __init__(self, code: str, description: str) -> None:
-        super().__init__(f"{code}: {description}")
-        self.code = code
-        self.description = description
 
 
 def _get_header(scope: ASGIScope, name: bytes) -> bytes | None:

--- a/src/mnemon/server_remote.py
+++ b/src/mnemon/server_remote.py
@@ -7,21 +7,19 @@ Desktop, Claude mobile apps via custom connectors, Claude Code via
 
 Authentication
 --------------
-When ``MNEMON_OAUTH_ISSUER``, ``MNEMON_OAUTH_JWKS_URL``, and
-``MNEMON_OAUTH_AUDIENCE`` are set, the server operates as an OAuth 2.1
-resource server per the MCP authorization spec (2025-06-18): it validates
-JWT bearer tokens from an external authorization server and serves RFC 9728
-Protected Resource Metadata for client discovery.
+When ``MNEMON_AS_ENABLED=true`` (with ``MNEMON_AS_PASSPHRASE`` and
+``MNEMON_PUBLIC_URL``), the server runs a self-hosted OAuth 2.1
+Authorization Server (see ``oauth_as.py``) alongside the Resource Server
+and verifies bearer JWTs against the local keypair. No external auth
+vendor required.
 
 ``MNEMON_LOCAL_TOKEN`` enables a secondary static-bearer auth path for
-headless clients (Claude Code hooks, Cursor, scripts) that cannot complete
-a browser OAuth flow. The value must match exactly — the middleware does
-a constant-time comparison and skips JWT/userinfo validation on match.
-Can be combined with OAuth or used alone.
+headless clients (Claude Code hooks, Cursor, scripts) that cannot
+complete a browser OAuth flow. Constant-time compared, no network hop.
+Can be combined with the self-hosted AS or used alone.
 
-When none of these env vars are set, the server runs without auth (local
-development only — do NOT expose an unauthenticated server to the public
-internet).
+When neither is set, the server runs without auth (local development
+only — do NOT expose an unauthenticated server to the public internet).
 
 Usage
 -----
@@ -29,12 +27,12 @@ Local, no auth::
 
     mnemon serve-remote
 
-Cloud, with external AS (e.g., Auth0)::
+Production (self-hosted AS)::
 
-    export MNEMON_OAUTH_ISSUER=https://your-tenant.us.auth0.com/
-    export MNEMON_OAUTH_JWKS_URL=https://your-tenant.us.auth0.com/.well-known/jwks.json
-    export MNEMON_OAUTH_AUDIENCE=https://your-mnemon.fly.dev/mcp
+    export MNEMON_AS_ENABLED=true
+    export MNEMON_AS_PASSPHRASE=<your-passphrase>
     export MNEMON_PUBLIC_URL=https://your-mnemon.fly.dev
+    export MNEMON_LOCAL_TOKEN=<random-bearer-for-hooks>
     mnemon serve-remote
 """
 
@@ -100,12 +98,6 @@ def run_remote() -> None:
         f"mnemon remote server starting on http://0.0.0.0:{PORT}/mcp",
         file=sys.stderr,
     )
-    if config.enabled:
-        print(
-            f"Auth: OAuth 2.1 resource server (issuer={config.issuer}, "
-            f"audience={config.audience})",
-            file=sys.stderr,
-        )
     if as_config.enabled:
         print(
             f"Auth: self-hosted Authorization Server enabled "
@@ -117,12 +109,12 @@ def run_remote() -> None:
             "Auth: local static bearer token enabled (MNEMON_LOCAL_TOKEN set)",
             file=sys.stderr,
         )
-    if not config.enabled and not config.local_token:
+    if not as_config.enabled and not config.local_token:
         print(
             "Auth: DISABLED — do not expose this server to the public internet. "
-            "Set MNEMON_OAUTH_ISSUER, MNEMON_OAUTH_JWKS_URL, and "
-            "MNEMON_OAUTH_AUDIENCE to enable OAuth, or MNEMON_LOCAL_TOKEN "
-            "to enable local static bearer auth.",
+            "Set MNEMON_AS_ENABLED=true (with MNEMON_AS_PASSPHRASE + "
+            "MNEMON_PUBLIC_URL) to enable the self-hosted Authorization "
+            "Server, or MNEMON_LOCAL_TOKEN for headless bearer auth.",
             file=sys.stderr,
         )
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,95 +1,31 @@
 """Tests for OAuth 2.1 resource-server middleware.
 
-Exercises the OAuthMiddleware class with locally-minted RSA-signed JWTs,
-mocking the JWKS fetch so the tests are offline and deterministic.
+Post–Phase 2 cleanup: the external-AS (Auth0) verification path and
+userinfo fallback have been removed. This file covers:
+
+- ``/health`` passes through unauthenticated
+- Well-known metadata routing
+- Pass-through mode when no auth is configured
+- Local-token (MNEMON_LOCAL_TOKEN) accept/reject/logging
+- Self-hosted AS JWT accept/reject (see also test_oauth_as.py)
 """
 
 from __future__ import annotations
 
 import json
-import time
+import logging as _logging
 from typing import Any
-from unittest.mock import patch
 
 import pytest
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
-import jwt
 
 from mnemon.auth import OAuthConfig, OAuthMiddleware
+from mnemon.oauth_as import AuthorizationServerConfig, mint_access_token
 
 
-# --- Test fixtures ---------------------------------------------------------
+LOCAL_TOKEN_VALUE = "test-local-token-value-12345678"
 
 
-@pytest.fixture(scope="module")
-def rsa_keypair() -> dict[str, Any]:
-    """Generate an RSA keypair once per module for signing test JWTs."""
-    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    public_key = private_key.public_key()
-
-    private_pem = private_key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-    public_pem = public_key.public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-    return {
-        "private_key": private_key,
-        "public_key": public_key,
-        "private_pem": private_pem,
-        "public_pem": public_pem,
-    }
-
-
-@pytest.fixture
-def oauth_config() -> OAuthConfig:
-    return OAuthConfig(
-        issuer="https://test-issuer.example.com/",
-        jwks_url="https://test-issuer.example.com/.well-known/jwks.json",
-        audience="https://mnemon-test.example.com/mcp",
-        public_url="https://mnemon-test.example.com",
-    )
-
-
-@pytest.fixture
-def mock_signing_key(rsa_keypair):
-    """Patch PyJWKClient.get_signing_key_from_jwt to return our test key."""
-
-    class _FakeSigningKey:
-        def __init__(self, key):
-            self.key = key
-
-    def _get_key(self, _token):
-        return _FakeSigningKey(rsa_keypair["public_pem"])
-
-    with patch(
-        "jwt.PyJWKClient.get_signing_key_from_jwt", _get_key
-    ):
-        yield
-
-
-def _mint_token(
-    private_key: Any,
-    *,
-    issuer: str = "https://test-issuer.example.com/",
-    audience: str = "https://mnemon-test.example.com/mcp",
-    subject: str = "user-123",
-    expires_in: int = 300,
-    issued_at_offset: int = 0,
-) -> str:
-    now = int(time.time()) + issued_at_offset
-    payload = {
-        "iss": issuer,
-        "aud": audience,
-        "sub": subject,
-        "iat": now,
-        "exp": now + expires_in,
-    }
-    return jwt.encode(payload, private_key, algorithm="RS256")
+# --- Test helpers ----------------------------------------------------------
 
 
 async def _call_middleware(
@@ -97,12 +33,8 @@ async def _call_middleware(
     path: str,
     *,
     headers: list[tuple[bytes, bytes]] | None = None,
-    downstream_called: list[bool] | None = None,
 ) -> tuple[int, dict[bytes, bytes], bytes]:
-    """Invoke the middleware synchronously and collect the response.
-
-    Returns ``(status, headers_dict, body)``.
-    """
+    """Invoke the middleware with a simulated HTTP request."""
     scope = {
         "type": "http",
         "method": "POST",
@@ -131,722 +63,37 @@ def _stub_downstream_factory(called_flag: list[bool]):
 
     async def app(scope, receive, send):
         called_flag.append(True)
-        await send(
-            {
-                "type": "http.response.start",
-                "status": 200,
-                "headers": [(b"content-type", b"application/json")],
-            }
-        )
-        await send(
-            {"type": "http.response.body", "body": b'{"ok": true}', "more_body": False}
-        )
+        await send({
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"application/json")],
+        })
+        await send({
+            "type": "http.response.body",
+            "body": b'{"ok": true}',
+            "more_body": False,
+        })
 
     return app
 
 
-# --- Health endpoint -------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_health_endpoint_unauthenticated(oauth_config):
-    downstream_called: list[bool] = []
-    app = _stub_downstream_factory(downstream_called)
-    mw = OAuthMiddleware(app, oauth_config)
-
-    status, headers, body = await _call_middleware(mw, "/health")
-
-    assert status == 200
-    assert json.loads(body) == {"status": "ok"}
-    assert downstream_called == []  # Did not forward to downstream
-
-
-@pytest.mark.asyncio
-async def test_health_endpoint_works_when_oauth_disabled():
-    downstream_called: list[bool] = []
-    app = _stub_downstream_factory(downstream_called)
-    mw = OAuthMiddleware(app, OAuthConfig())
-
-    status, _, body = await _call_middleware(mw, "/health")
-
-    assert status == 200
-    assert json.loads(body) == {"status": "ok"}
-    assert downstream_called == []
-
-
-# --- Protected Resource Metadata -------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_protected_resource_metadata_returns_rfc9728_json(oauth_config):
-    downstream_called: list[bool] = []
-    app = _stub_downstream_factory(downstream_called)
-    mw = OAuthMiddleware(app, oauth_config)
-
-    status, headers, body = await _call_middleware(
-        mw, "/.well-known/oauth-protected-resource"
-    )
-
-    assert status == 200
-    assert headers[b"content-type"] == b"application/json"
-    data = json.loads(body)
-    assert data["resource"] == oauth_config.audience
-    assert data["authorization_servers"] == [oauth_config.issuer]
-    assert data["bearer_methods_supported"] == ["header"]
-    assert downstream_called == []
-
-
-@pytest.mark.asyncio
-async def test_protected_resource_metadata_404_when_oauth_disabled():
-    app = _stub_downstream_factory([])
-    mw = OAuthMiddleware(app, OAuthConfig())
-
-    status, _, body = await _call_middleware(
-        mw, "/.well-known/oauth-protected-resource"
-    )
-
-    assert status == 404
-    assert "error" in json.loads(body)
-
-
-# --- Authenticated paths — unauth mode passes through ---------------------
-
-
-@pytest.mark.asyncio
-async def test_oauth_disabled_passes_through_all_requests():
-    downstream_called: list[bool] = []
-    app = _stub_downstream_factory(downstream_called)
-    mw = OAuthMiddleware(app, OAuthConfig())
-
-    status, _, body = await _call_middleware(mw, "/mcp")
-
-    assert status == 200
-    assert json.loads(body) == {"ok": True}
-    assert downstream_called == [True]
-
-
-# --- Missing / malformed Authorization header -----------------------------
-
-
-@pytest.mark.asyncio
-async def test_missing_authorization_header_returns_401(oauth_config):
-    app = _stub_downstream_factory([])
-    mw = OAuthMiddleware(app, oauth_config)
-
-    status, headers, body = await _call_middleware(mw, "/mcp")
-
-    assert status == 401
-    www_auth = headers[b"www-authenticate"].decode()
-    assert "Bearer" in www_auth
-    assert "resource_metadata=" in www_auth
-    assert oauth_config.resource_metadata_url in www_auth
-    assert json.loads(body)["error"] == "missing_token"
-
-
-@pytest.mark.asyncio
-async def test_non_bearer_authorization_returns_401(oauth_config):
-    app = _stub_downstream_factory([])
-    mw = OAuthMiddleware(app, oauth_config)
-
-    status, _, _ = await _call_middleware(
-        mw, "/mcp", headers=[(b"authorization", b"Basic dXNlcjpwYXNz")]
-    )
-
-    assert status == 401
-
-
-# --- Valid JWT flow -------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_valid_jwt_passes_through(oauth_config, rsa_keypair, mock_signing_key):
-    downstream_called: list[bool] = []
-    app = _stub_downstream_factory(downstream_called)
-    mw = OAuthMiddleware(app, oauth_config)
-
-    token = _mint_token(rsa_keypair["private_pem"])
-    status, _, body = await _call_middleware(
-        mw,
-        "/mcp",
-        headers=[(b"authorization", f"Bearer {token}".encode())],
-    )
-
-    assert status == 200
-    assert json.loads(body) == {"ok": True}
-    assert downstream_called == [True]
-
-
-# --- Invalid JWT variants -------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_expired_jwt_returns_401(oauth_config, rsa_keypair, mock_signing_key):
-    app = _stub_downstream_factory([])
-    mw = OAuthMiddleware(app, oauth_config)
-
-    # issued 10 minutes ago, expires in 1 minute → expired 9 minutes ago
-    token = _mint_token(
-        rsa_keypair["private_pem"], expires_in=60, issued_at_offset=-600
-    )
-    status, headers, body = await _call_middleware(
-        mw,
-        "/mcp",
-        headers=[(b"authorization", f"Bearer {token}".encode())],
-    )
-
-    assert status == 401
-    assert b"error=" in headers[b"www-authenticate"]
-    assert "expired" in json.loads(body).get("error_description", "")
-
-
-@pytest.mark.asyncio
-async def test_wrong_audience_returns_401(oauth_config, rsa_keypair, mock_signing_key):
-    app = _stub_downstream_factory([])
-    mw = OAuthMiddleware(app, oauth_config)
-
-    token = _mint_token(
-        rsa_keypair["private_pem"], audience="https://some-other-server.example.com/mcp"
-    )
-    status, _, body = await _call_middleware(
-        mw,
-        "/mcp",
-        headers=[(b"authorization", f"Bearer {token}".encode())],
-    )
-
-    assert status == 401
-    assert "audience" in json.loads(body).get("error_description", "").lower()
-
-
-@pytest.mark.asyncio
-async def test_wrong_issuer_returns_401(oauth_config, rsa_keypair, mock_signing_key):
-    app = _stub_downstream_factory([])
-    mw = OAuthMiddleware(app, oauth_config)
-
-    token = _mint_token(
-        rsa_keypair["private_pem"], issuer="https://evil-issuer.example.com/"
-    )
-    status, _, body = await _call_middleware(
-        mw,
-        "/mcp",
-        headers=[(b"authorization", f"Bearer {token}".encode())],
-    )
-
-    assert status == 401
-    assert "issuer" in json.loads(body).get("error_description", "").lower()
-
-
-@pytest.mark.asyncio
-async def test_malformed_jwt_returns_401(oauth_config):
-    app = _stub_downstream_factory([])
-    mw = OAuthMiddleware(app, oauth_config)
-
-    status, _, _ = await _call_middleware(
-        mw,
-        "/mcp",
-        headers=[(b"authorization", b"Bearer not.a.valid.jwt.token")],
-    )
-
-    assert status == 401
-
-
-# --- Config loading -------------------------------------------------------
-
-
-def test_oauth_config_disabled_by_default(monkeypatch):
-    for var in (
-        "MNEMON_OAUTH_ISSUER",
-        "MNEMON_OAUTH_JWKS_URL",
-        "MNEMON_OAUTH_AUDIENCE",
-        "MNEMON_PUBLIC_URL",
-    ):
-        monkeypatch.delenv(var, raising=False)
-    config = OAuthConfig.from_env()
-    assert not config.enabled
-
-
-def test_oauth_config_enabled_from_env(monkeypatch):
-    monkeypatch.setenv("MNEMON_OAUTH_ISSUER", "https://issuer.example.com/")
-    monkeypatch.setenv(
-        "MNEMON_OAUTH_JWKS_URL", "https://issuer.example.com/.well-known/jwks.json"
-    )
-    monkeypatch.setenv("MNEMON_OAUTH_AUDIENCE", "https://mnemon.example.com/mcp")
-    monkeypatch.setenv("MNEMON_PUBLIC_URL", "https://mnemon.example.com")
-    config = OAuthConfig.from_env()
-    assert config.enabled
-    assert config.issuer == "https://issuer.example.com/"
-    assert (
-        config.resource_metadata_url
-        == "https://mnemon.example.com/.well-known/oauth-protected-resource"
-    )
-
-
-def test_oauth_config_public_url_derived_from_audience():
-    config = OAuthConfig(
-        issuer="https://issuer.example.com/",
-        jwks_url="https://issuer.example.com/jwks",
-        audience="https://mnemon.example.com/mcp",
-        public_url=None,
-    )
-    assert (
-        config.resource_metadata_url
-        == "https://mnemon.example.com/.well-known/oauth-protected-resource"
-    )
-
-
-# --- Userinfo fallback --------------------------------------------------
+# --- Fixtures ---------------------------------------------------------------
 
 
 @pytest.fixture
-def oauth_config_with_userinfo() -> OAuthConfig:
-    return OAuthConfig(
-        issuer="https://test-issuer.example.com/",
-        jwks_url="https://test-issuer.example.com/.well-known/jwks.json",
-        audience="https://mnemon-test.example.com/mcp",
-        public_url="https://mnemon-test.example.com",
-        userinfo_url="https://test-issuer.example.com/userinfo",
-    )
-
-
-@pytest.mark.asyncio
-async def test_userinfo_fallback_accepts_opaque_token(
-    oauth_config_with_userinfo, monkeypatch
-):
-    """When JWT decode fails and userinfo returns 200, token is accepted."""
-    import httpx
-
-    class _FakeResponse:
-        status_code = 200
-
-        def json(self):
-            return {"sub": "auth0|user123", "email": "test@example.com"}
-
-    class _FakeAsyncClient:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *args):
-            return None
-
-        async def get(self, url, headers=None):
-            assert "Authorization" in headers
-            assert headers["Authorization"].startswith("Bearer ")
-            return _FakeResponse()
-
-    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
-
-    downstream_called: list[bool] = []
-    app = _stub_downstream_factory(downstream_called)
-    mw = OAuthMiddleware(app, oauth_config_with_userinfo)
-
-    status, _, body = await _call_middleware(
-        mw,
-        "/mcp",
-        headers=[(b"authorization", b"Bearer opaque-token-not-a-jwt")],
-    )
-
-    assert status == 200
-    assert json.loads(body) == {"ok": True}
-    assert downstream_called == [True]
-
-
-@pytest.mark.asyncio
-async def test_userinfo_fallback_rejects_when_userinfo_returns_401(
-    oauth_config_with_userinfo, monkeypatch
-):
-    import httpx
-
-    class _FakeResponse:
-        status_code = 401
-
-        def json(self):
-            return {"error": "invalid_token"}
-
-    class _FakeAsyncClient:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *args):
-            return None
-
-        async def get(self, url, headers=None):
-            return _FakeResponse()
-
-    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
-
-    app = _stub_downstream_factory([])
-    mw = OAuthMiddleware(app, oauth_config_with_userinfo)
-
-    status, _, body = await _call_middleware(
-        mw,
-        "/mcp",
-        headers=[(b"authorization", b"Bearer opaque-bad-token")],
-    )
-
-    assert status == 401
-    assert "userinfo rejected" in json.loads(body).get("error_description", "")
-
-
-@pytest.mark.asyncio
-async def test_no_userinfo_fallback_when_not_configured(oauth_config):
-    """When userinfo_url is unset, JWT failures produce immediate 401."""
-    app = _stub_downstream_factory([])
-    mw = OAuthMiddleware(app, oauth_config)  # no userinfo_url
-
-    status, _, body = await _call_middleware(
-        mw,
-        "/mcp",
-        headers=[(b"authorization", b"Bearer opaque-token")],
-    )
-
-    assert status == 401
-    # Description should only mention JWT failure, not userinfo
-    desc = json.loads(body).get("error_description", "")
-    assert "userinfo" not in desc
-
-
-# --- Local static bearer token path ---------------------------------------
-#
-# These tests cover the MNEMON_LOCAL_TOKEN auth path used by headless
-# clients (Claude Code hooks, Cursor, scripts) that cannot complete a
-# browser OAuth flow. The local token is checked before JWT/userinfo and
-# bypasses both on match.
-
-
-LOCAL_TOKEN_VALUE = "test-local-token-abcdef123456"
+def no_auth_config() -> OAuthConfig:
+    """OAuthConfig with no local token — pass-through mode when AS also
+    absent."""
+    return OAuthConfig()
 
 
 @pytest.fixture
-def oauth_config_with_local_token(oauth_config) -> OAuthConfig:
-    """OAuth config with BOTH OAuth and local_token set."""
-    return OAuthConfig(
-        issuer=oauth_config.issuer,
-        jwks_url=oauth_config.jwks_url,
-        audience=oauth_config.audience,
-        public_url=oauth_config.public_url,
-        local_token=LOCAL_TOKEN_VALUE,
-    )
-
-
-@pytest.fixture
-def local_token_only_config() -> OAuthConfig:
-    """Config with ONLY local_token set — OAuth disabled entirely.
-
-    This previews the Phase 2 world where Auth0 is gone. If any middleware
-    code path silently requires OAuth env vars, tests using this fixture
-    will fail loudly.
-    """
+def local_token_config() -> OAuthConfig:
     return OAuthConfig(local_token=LOCAL_TOKEN_VALUE)
 
 
-@pytest.mark.asyncio
-async def test_local_token_accepted(oauth_config_with_local_token):
-    """Correct local token bypasses JWT validation and reaches downstream."""
-    downstream_called: list[bool] = []
-    app = _stub_downstream_factory(downstream_called)
-    mw = OAuthMiddleware(app, oauth_config_with_local_token)
-
-    status, _, body = await _call_middleware(
-        mw,
-        "/mcp",
-        headers=[(b"authorization", f"Bearer {LOCAL_TOKEN_VALUE}".encode())],
-    )
-
-    assert status == 200
-    assert json.loads(body) == {"ok": True}
-    assert downstream_called == [True]
-    # JWT client must NOT have been initialized — the local-token path
-    # should have short-circuited before _validate_token ran.
-    assert mw._jwks_client is None
-
-
-@pytest.mark.asyncio
-async def test_local_token_wrong_value_returns_401_when_oauth_enabled(
-    oauth_config_with_local_token, rsa_keypair, mock_signing_key
-):
-    """When OAuth is also configured, a wrong token falls through to JWT
-    validation (which also fails here because the wrong value isn't a JWT).
-    The downstream response must be a 401 with a proper WWW-Authenticate
-    header — never a 200, never a silent pass-through."""
-    app = _stub_downstream_factory([])
-    mw = OAuthMiddleware(app, oauth_config_with_local_token)
-
-    status, headers, body = await _call_middleware(
-        mw,
-        "/mcp",
-        headers=[(b"authorization", b"Bearer definitely-not-the-local-token")],
-    )
-
-    assert status == 401
-    assert b"www-authenticate" in headers
-    assert b"Bearer" in headers[b"www-authenticate"]
-    assert json.loads(body)["error"] == "invalid_token"
-
-
-@pytest.mark.asyncio
-async def test_local_token_precedence_over_oauth(
-    oauth_config_with_local_token,
-):
-    """When both auth methods are enabled and the token matches the local
-    token, the JWT path must not run at all. Verified by inspecting that
-    ``_jwks_client`` was never lazily initialized.
-
-    This test deliberately does NOT use the ``mock_signing_key`` fixture —
-    if the middleware incorrectly falls into the JWT path, PyJWKClient
-    would attempt a real network fetch against the fake JWKS URL and the
-    test would fail loudly rather than silently pass.
-    """
-    downstream_called: list[bool] = []
-    app = _stub_downstream_factory(downstream_called)
-    mw = OAuthMiddleware(app, oauth_config_with_local_token)
-
-    status, _, _ = await _call_middleware(
-        mw,
-        "/mcp",
-        headers=[(b"authorization", f"Bearer {LOCAL_TOKEN_VALUE}".encode())],
-    )
-
-    assert status == 200
-    assert downstream_called == [True]
-    assert mw._jwks_client is None
-
-
-@pytest.mark.asyncio
-async def test_local_token_works_without_oauth_config(local_token_only_config):
-    """Local token auth must work with OAuth entirely unconfigured.
-
-    This is a guardrail test for the Phase 2 / self-hosted-AS future: when
-    ``MNEMON_OAUTH_*`` env vars are all unset, the middleware should still
-    enforce auth via the local token path. Any regression here means a
-    hidden Auth0/OAuth dependency has crept in.
-    """
-    downstream_called: list[bool] = []
-    app = _stub_downstream_factory(downstream_called)
-    mw = OAuthMiddleware(app, local_token_only_config)
-
-    # Correct token → accepted, downstream called.
-    status, _, body = await _call_middleware(
-        mw,
-        "/mcp",
-        headers=[(b"authorization", f"Bearer {LOCAL_TOKEN_VALUE}".encode())],
-    )
-    assert status == 200
-    assert json.loads(body) == {"ok": True}
-    assert downstream_called == [True]
-    assert mw._jwks_client is None
-
-
-@pytest.mark.asyncio
-async def test_local_token_only_rejects_wrong_token(local_token_only_config):
-    """With only local token configured, wrong tokens must return 401 —
-    not fall through to a JWT path that would raise on missing jwks_url."""
-    app = _stub_downstream_factory([])
-    mw = OAuthMiddleware(app, local_token_only_config)
-
-    status, headers, body = await _call_middleware(
-        mw,
-        "/mcp",
-        headers=[(b"authorization", b"Bearer wrong-token-value")],
-    )
-
-    assert status == 401
-    assert b"www-authenticate" in headers
-    assert json.loads(body)["error"] == "invalid_token"
-    # JWT path must NOT have been entered — no jwks_url to fetch.
-    assert mw._jwks_client is None
-
-
-@pytest.mark.asyncio
-async def test_local_token_only_missing_auth_header_returns_401(
-    local_token_only_config,
-):
-    """Missing Authorization header returns 401 even when only local token
-    is configured — auth is still required, just via a different path."""
-    app = _stub_downstream_factory([])
-    mw = OAuthMiddleware(app, local_token_only_config)
-
-    status, _, body = await _call_middleware(mw, "/mcp")
-
-    assert status == 401
-    assert json.loads(body)["error"] == "missing_token"
-
-
-@pytest.mark.asyncio
-async def test_local_token_logs_client_header(
-    oauth_config_with_local_token, caplog
-):
-    """The X-Mnemon-Client header value should appear in the accept log
-    line for attribution. The token value itself must NEVER be logged."""
-    import logging as _logging
-
-    app = _stub_downstream_factory([])
-    mw = OAuthMiddleware(app, oauth_config_with_local_token)
-
-    with caplog.at_level(_logging.INFO, logger="mnemon.auth"):
-        status, _, _ = await _call_middleware(
-            mw,
-            "/mcp",
-            headers=[
-                (b"authorization", f"Bearer {LOCAL_TOKEN_VALUE}".encode()),
-                (b"x-mnemon-client", b"claude-code"),
-            ],
-        )
-
-    assert status == 200
-    # Client label surfaced in logs.
-    assert any("claude-code" in record.message for record in caplog.records)
-    # Token value must not appear anywhere in log output.
-    for record in caplog.records:
-        assert LOCAL_TOKEN_VALUE not in record.message
-
-
-@pytest.mark.asyncio
-async def test_local_token_logs_unknown_when_header_missing(
-    oauth_config_with_local_token, caplog
-):
-    """When no X-Mnemon-Client header is sent, the accept log records
-    the client as 'unknown' rather than crashing or omitting the field."""
-    import logging as _logging
-
-    app = _stub_downstream_factory([])
-    mw = OAuthMiddleware(app, oauth_config_with_local_token)
-
-    with caplog.at_level(_logging.INFO, logger="mnemon.auth"):
-        status, _, _ = await _call_middleware(
-            mw,
-            "/mcp",
-            headers=[(b"authorization", f"Bearer {LOCAL_TOKEN_VALUE}".encode())],
-        )
-
-    assert status == 200
-    assert any("unknown" in record.message for record in caplog.records)
-
-
-# --- Config loading — local token path -----------------------------------
-
-
-def test_oauth_config_local_token_none_by_default(monkeypatch):
-    monkeypatch.delenv("MNEMON_LOCAL_TOKEN", raising=False)
-    config = OAuthConfig.from_env()
-    assert config.local_token is None
-
-
-def test_oauth_config_loads_local_token_from_env(monkeypatch):
-    monkeypatch.setenv("MNEMON_LOCAL_TOKEN", "env-loaded-token-value")
-    config = OAuthConfig.from_env()
-    assert config.local_token == "env-loaded-token-value"
-
-
-def test_oauth_config_empty_local_token_coerced_to_none(monkeypatch):
-    """Empty string env var is treated as unset (matches other env fields)."""
-    monkeypatch.setenv("MNEMON_LOCAL_TOKEN", "")
-    config = OAuthConfig.from_env()
-    assert config.local_token is None
-
-
-# --- Self-hosted AS well-known routing (Phase 2 PR #36) -------------------
-
-
-@pytest.mark.asyncio
-async def test_as_metadata_404_when_as_config_not_provided(oauth_config):
-    """If the middleware wasn't given an AS config, /.well-known/
-    oauth-authorization-server must 404 — don't claim to be an AS we're
-    not running."""
-    downstream_called: list[bool] = []
-    app = _stub_downstream_factory(downstream_called)
-    mw = OAuthMiddleware(app, oauth_config)  # no as_config
-
-    status, _, body = await _call_middleware(
-        mw, "/.well-known/oauth-authorization-server"
-    )
-    assert status == 404
-    assert downstream_called == []
-
-
-@pytest.mark.asyncio
-async def test_as_metadata_returns_rfc8414_document_when_enabled(
-    oauth_config, tmp_path
-):
-    from mnemon.oauth_as import AuthorizationServerConfig
-
-    as_config = AuthorizationServerConfig(
-        enabled=True,
-        public_url="https://example.fly.dev",
-        passphrase="x",
-        key_dir=tmp_path,
-    )
-    downstream_called: list[bool] = []
-    app = _stub_downstream_factory(downstream_called)
-    mw = OAuthMiddleware(app, oauth_config, as_config=as_config)
-
-    status, _, body = await _call_middleware(
-        mw, "/.well-known/oauth-authorization-server"
-    )
-    assert status == 200
-    doc = json.loads(body)
-    assert doc["issuer"] == "https://example.fly.dev"
-    assert doc["token_endpoint_auth_methods_supported"] == ["none"]
-    assert downstream_called == []
-
-
-@pytest.mark.asyncio
-async def test_jwks_404_when_as_config_not_provided(oauth_config):
-    downstream_called: list[bool] = []
-    app = _stub_downstream_factory(downstream_called)
-    mw = OAuthMiddleware(app, oauth_config)
-
-    status, _, body = await _call_middleware(mw, "/.well-known/jwks.json")
-    assert status == 404
-
-
-@pytest.mark.asyncio
-async def test_jwks_returns_public_key_when_enabled(oauth_config, tmp_path):
-    from mnemon.oauth_as import AuthorizationServerConfig
-
-    as_config = AuthorizationServerConfig(
-        enabled=True,
-        public_url="https://example.fly.dev",
-        passphrase="x",
-        key_dir=tmp_path,
-    )
-    app = _stub_downstream_factory([])
-    mw = OAuthMiddleware(app, oauth_config, as_config=as_config)
-
-    status, _, body = await _call_middleware(mw, "/.well-known/jwks.json")
-    assert status == 200
-    doc = json.loads(body)
-    assert "keys" in doc
-    assert doc["keys"][0]["kty"] == "RSA"
-    assert doc["keys"][0]["alg"] == "RS256"
-
-
-@pytest.mark.asyncio
-async def test_as_metadata_404_when_as_disabled_even_if_config_provided(oauth_config):
-    """AS config present but enabled=False still 404s — don't leak a
-    half-configured AS to clients."""
-    from mnemon.oauth_as import AuthorizationServerConfig
-
-    as_config = AuthorizationServerConfig(enabled=False)
-    app = _stub_downstream_factory([])
-    mw = OAuthMiddleware(app, oauth_config, as_config=as_config)
-
-    status, _, _ = await _call_middleware(
-        mw, "/.well-known/oauth-authorization-server"
-    )
-    assert status == 404
-
-
-# --- Self-hosted AS resource-server verification (Phase 2 PR #39) ----------
-
-
 @pytest.fixture
-def enabled_as_config(tmp_path):
-    from mnemon.oauth_as import AuthorizationServerConfig
+def enabled_as_config(tmp_path) -> AuthorizationServerConfig:
     return AuthorizationServerConfig(
         enabled=True,
         public_url="https://mnemon-test.example.com",
@@ -855,16 +102,207 @@ def enabled_as_config(tmp_path):
     )
 
 
+# --- /health endpoint -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_unauthenticated(local_token_config):
+    """Health must always respond 200 without auth, regardless of config."""
+    downstream_called: list[bool] = []
+    app = _stub_downstream_factory(downstream_called)
+    mw = OAuthMiddleware(app, local_token_config)
+
+    status, _, body = await _call_middleware(mw, "/health")
+    assert status == 200
+    assert json.loads(body) == {"status": "ok"}
+    assert downstream_called == []  # never forwarded
+
+
+@pytest.mark.asyncio
+async def test_health_works_with_no_auth_configured(no_auth_config):
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, no_auth_config)
+
+    status, _, _ = await _call_middleware(mw, "/health")
+    assert status == 200
+
+
+# --- Pass-through mode (no auth configured) --------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_auth_configured_passes_through(no_auth_config):
+    """With no local_token and no AS, all non-health requests go to the
+    downstream app unauthenticated. Dev-only convenience."""
+    downstream_called: list[bool] = []
+    app = _stub_downstream_factory(downstream_called)
+    mw = OAuthMiddleware(app, no_auth_config)
+
+    status, _, _ = await _call_middleware(mw, "/mcp")
+    assert status == 200
+    assert downstream_called == [True]
+
+
+# --- /.well-known/oauth-protected-resource ---------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prm_404_when_as_not_configured(local_token_config):
+    """With only local_token configured (no AS), the PRM endpoint 404s —
+    headless clients don't read PRM, so there's nothing to publish."""
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, local_token_config)
+
+    status, _, _ = await _call_middleware(mw, "/.well-known/oauth-protected-resource")
+    assert status == 404
+
+
+@pytest.mark.asyncio
+async def test_prm_points_at_self_hosted_issuer(local_token_config, enabled_as_config):
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, local_token_config, as_config=enabled_as_config)
+
+    status, _, body = await _call_middleware(
+        mw, "/.well-known/oauth-protected-resource"
+    )
+    assert status == 200
+    doc = json.loads(body)
+    assert doc["authorization_servers"] == ["https://mnemon-test.example.com"]
+    assert doc["resource"] == "https://mnemon-test.example.com/mcp"
+
+
+@pytest.mark.asyncio
+async def test_prm_404_when_as_config_disabled(local_token_config, tmp_path):
+    """AS config supplied but enabled=False still 404s — don't leak a
+    half-configured AS to clients."""
+    as_config = AuthorizationServerConfig(enabled=False, key_dir=tmp_path)
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, local_token_config, as_config=as_config)
+
+    status, _, _ = await _call_middleware(mw, "/.well-known/oauth-protected-resource")
+    assert status == 404
+
+
+# --- Local-token auth path --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_local_token_accepted(local_token_config):
+    downstream_called: list[bool] = []
+    app = _stub_downstream_factory(downstream_called)
+    mw = OAuthMiddleware(app, local_token_config)
+
+    status, _, body = await _call_middleware(
+        mw, "/mcp",
+        headers=[(b"authorization", f"Bearer {LOCAL_TOKEN_VALUE}".encode())],
+    )
+    assert status == 200
+    assert json.loads(body) == {"ok": True}
+    assert downstream_called == [True]
+
+
+@pytest.mark.asyncio
+async def test_local_token_wrong_value_returns_401(local_token_config):
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, local_token_config)
+
+    status, headers, body = await _call_middleware(
+        mw, "/mcp",
+        headers=[(b"authorization", b"Bearer wrong-value")],
+    )
+    assert status == 401
+    assert b"www-authenticate" in headers
+    assert json.loads(body)["error"] == "invalid_token"
+
+
+@pytest.mark.asyncio
+async def test_local_token_missing_auth_header_returns_401(local_token_config):
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, local_token_config)
+
+    status, _, body = await _call_middleware(mw, "/mcp")
+    assert status == 401
+    assert json.loads(body)["error"] == "missing_token"
+
+
+@pytest.mark.asyncio
+async def test_local_token_non_bearer_scheme_returns_401(local_token_config):
+    """Non-Bearer auth schemes (Basic, Digest, etc.) must be rejected
+    regardless of the credential value — we only accept RFC 6750 Bearer."""
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, local_token_config)
+
+    status, _, _ = await _call_middleware(
+        mw, "/mcp",
+        headers=[(b"authorization", b"Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==")],
+    )
+    assert status == 401
+
+
+@pytest.mark.asyncio
+async def test_local_token_constant_time_compare(local_token_config):
+    """Guard against a timing-side-channel regression. hmac.compare_digest
+    is used internally; this test just confirms correct vs. wrong tokens
+    both produce deterministic results, relying on pytest to run without
+    flakes if the comparison is constant-time."""
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, local_token_config)
+
+    # A token with the same length but wrong value must be rejected.
+    status, _, _ = await _call_middleware(
+        mw, "/mcp",
+        headers=[(b"authorization", f"Bearer {'X' * len(LOCAL_TOKEN_VALUE)}".encode())],
+    )
+    assert status == 401
+
+
+@pytest.mark.asyncio
+async def test_local_token_logs_client_header(local_token_config, caplog):
+    """X-Mnemon-Client header appears in the accept log for attribution.
+    Token value itself must NEVER be logged."""
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, local_token_config)
+
+    with caplog.at_level(_logging.INFO, logger="mnemon.auth"):
+        status, _, _ = await _call_middleware(
+            mw, "/mcp",
+            headers=[
+                (b"authorization", f"Bearer {LOCAL_TOKEN_VALUE}".encode()),
+                (b"x-mnemon-client", b"claude-code"),
+            ],
+        )
+
+    assert status == 200
+    log_text = " ".join(record.message for record in caplog.records)
+    assert "claude-code" in log_text
+    assert LOCAL_TOKEN_VALUE not in log_text
+
+
+@pytest.mark.asyncio
+async def test_local_token_logs_unknown_when_header_missing(local_token_config, caplog):
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, local_token_config)
+
+    with caplog.at_level(_logging.INFO, logger="mnemon.auth"):
+        status, _, _ = await _call_middleware(
+            mw, "/mcp",
+            headers=[(b"authorization", f"Bearer {LOCAL_TOKEN_VALUE}".encode())],
+        )
+
+    assert status == 200
+    log_text = " ".join(record.message for record in caplog.records)
+    assert "unknown" in log_text
+
+
+# --- Self-hosted AS JWT auth path ------------------------------------------
+
+
 @pytest.mark.asyncio
 async def test_self_hosted_token_accepted(enabled_as_config):
-    """A token minted by the local AS must be accepted when AS is enabled,
-    with no Auth0 config present — the hard-cutover path."""
-    from mnemon.oauth_as import mint_access_token
-
+    """A JWT minted by the local AS is accepted when AS is enabled."""
     token = mint_access_token(enabled_as_config, subject="owner", scope="mcp")
-    downstream_called = []
+    downstream_called: list[bool] = []
     app = _stub_downstream_factory(downstream_called)
-    # No external-AS config — only self-hosted.
     mw = OAuthMiddleware(app, OAuthConfig(), as_config=enabled_as_config)
 
     status, _, _ = await _call_middleware(
@@ -877,10 +315,8 @@ async def test_self_hosted_token_accepted(enabled_as_config):
 
 @pytest.mark.asyncio
 async def test_self_hosted_expired_token_returns_401(enabled_as_config):
-    from mnemon.oauth_as import mint_access_token
-
     token = mint_access_token(
-        enabled_as_config, subject="owner", scope="mcp", ttl_sec=-60
+        enabled_as_config, subject="owner", scope="mcp", ttl_sec=-60,
     )
     app = _stub_downstream_factory([])
     mw = OAuthMiddleware(app, OAuthConfig(), as_config=enabled_as_config)
@@ -891,13 +327,13 @@ async def test_self_hosted_expired_token_returns_401(enabled_as_config):
     )
     assert status == 401
     assert b"expired" in body
-    # WWW-Authenticate header points at the self-hosted PRM URL
+    # WWW-Authenticate points at the self-hosted PRM URL
     auth_header = headers.get(b"www-authenticate", b"")
     assert b"mnemon-test.example.com/.well-known/oauth-protected-resource" in auth_header
 
 
 @pytest.mark.asyncio
-async def test_self_hosted_random_garbage_returns_401(enabled_as_config):
+async def test_self_hosted_garbage_token_returns_401(enabled_as_config):
     app = _stub_downstream_factory([])
     mw = OAuthMiddleware(app, OAuthConfig(), as_config=enabled_as_config)
 
@@ -920,55 +356,113 @@ async def test_self_hosted_missing_bearer_returns_401(enabled_as_config):
 
 
 @pytest.mark.asyncio
-async def test_local_token_still_works_alongside_self_hosted(enabled_as_config):
-    """Claude Code hooks authenticate via MNEMON_LOCAL_TOKEN. That path
-    must keep working when AS is the primary OAuth path — hooks can't
-    do an OAuth flow, so local_token is the only option for them."""
+async def test_local_token_and_as_coexist(local_token_config, enabled_as_config):
+    """Claude Code hooks (local_token) and claude.ai (AS JWT) must both
+    work against the same server."""
     app = _stub_downstream_factory([])
-    config = OAuthConfig(local_token="hooks-token-value")
-    mw = OAuthMiddleware(app, config, as_config=enabled_as_config)
+    mw = OAuthMiddleware(app, local_token_config, as_config=enabled_as_config)
 
-    status, _, _ = await _call_middleware(
+    # Local token accepted.
+    status_local, _, _ = await _call_middleware(
         mw, "/mcp",
-        headers=[(b"authorization", b"Bearer hooks-token-value")],
+        headers=[(b"authorization", f"Bearer {LOCAL_TOKEN_VALUE}".encode())],
     )
-    assert status == 200
+    assert status_local == 200
 
-
-@pytest.mark.asyncio
-async def test_self_hosted_prm_points_at_local_issuer(enabled_as_config):
-    """When AS is enabled, /.well-known/oauth-protected-resource must
-    advertise the local issuer, not some external AS. Without this,
-    clients doing MCP auth discovery would send users back to a dead
-    Auth0 config."""
-    app = _stub_downstream_factory([])
-    mw = OAuthMiddleware(app, OAuthConfig(), as_config=enabled_as_config)
-
-    status, _, body = await _call_middleware(
-        mw, "/.well-known/oauth-protected-resource"
-    )
-    assert status == 200
-    doc = json.loads(body)
-    assert doc["authorization_servers"] == ["https://mnemon-test.example.com"]
-    assert doc["resource"] == "https://mnemon-test.example.com/mcp"
-
-
-@pytest.mark.asyncio
-async def test_external_as_still_works_when_self_hosted_disabled(
-    oauth_config, rsa_keypair, mock_signing_key
-):
-    """Auth0 path must keep working when MNEMON_AS_ENABLED=false —
-    that's how PR #39 deploys without breaking the live site. The
-    cutover to self-hosted happens by flipping MNEMON_AS_ENABLED on
-    Fly in PR #40, not by merging #39."""
-    token = _mint_token(rsa_keypair["private_key"])
-    downstream_called = []
-    app = _stub_downstream_factory(downstream_called)
-    mw = OAuthMiddleware(app, oauth_config)  # no as_config
-
-    status, _, _ = await _call_middleware(
+    # AS-minted JWT accepted.
+    token = mint_access_token(enabled_as_config, subject="owner", scope="mcp")
+    status_jwt, _, _ = await _call_middleware(
         mw, "/mcp",
         headers=[(b"authorization", f"Bearer {token}".encode())],
     )
+    assert status_jwt == 200
+
+
+@pytest.mark.asyncio
+async def test_local_token_checked_before_jwt_verification(
+    local_token_config, enabled_as_config
+):
+    """Local token path is a simple string compare — must be attempted
+    before JWT verification so common hook calls don't pay key-loading
+    cost. Verified indirectly: a matching local token is accepted even
+    when it's clearly not a JWT."""
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, local_token_config, as_config=enabled_as_config)
+
+    status, _, _ = await _call_middleware(
+        mw, "/mcp",
+        headers=[(b"authorization", f"Bearer {LOCAL_TOKEN_VALUE}".encode())],
+    )
     assert status == 200
-    assert downstream_called == [True]
+
+
+# --- OAuthConfig env loading ------------------------------------------------
+
+
+def test_oauth_config_local_token_none_by_default(monkeypatch):
+    monkeypatch.delenv("MNEMON_LOCAL_TOKEN", raising=False)
+    config = OAuthConfig.from_env()
+    assert config.local_token is None
+
+
+def test_oauth_config_loads_local_token_from_env(monkeypatch):
+    monkeypatch.setenv("MNEMON_LOCAL_TOKEN", "env-loaded-value")
+    config = OAuthConfig.from_env()
+    assert config.local_token == "env-loaded-value"
+
+
+def test_oauth_config_empty_local_token_coerced_to_none(monkeypatch):
+    monkeypatch.setenv("MNEMON_LOCAL_TOKEN", "")
+    config = OAuthConfig.from_env()
+    assert config.local_token is None
+
+
+def test_oauth_config_no_auth0_fields():
+    """Guard against accidentally re-adding the external-AS fields.
+    If Phase 2 cutover regressed and someone re-added issuer/jwks_url/
+    audience/userinfo_url to OAuthConfig, this test catches it. The
+    Phase 2 plan is explicit: no external AS dependency."""
+    config = OAuthConfig()
+    for field in ("issuer", "jwks_url", "audience", "userinfo_url"):
+        assert not hasattr(config, field), (
+            f"OAuthConfig should not have '{field}' after Phase 2 — "
+            "that's external-AS config which has been removed."
+        )
+
+
+# --- AS well-known routing (routes to oauth_as.py handlers) ----------------
+
+
+@pytest.mark.asyncio
+async def test_as_metadata_404_without_as_config(local_token_config):
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, local_token_config)
+
+    status, _, _ = await _call_middleware(
+        mw, "/.well-known/oauth-authorization-server",
+    )
+    assert status == 404
+
+
+@pytest.mark.asyncio
+async def test_as_metadata_200_with_as_config(local_token_config, enabled_as_config):
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, local_token_config, as_config=enabled_as_config)
+
+    status, _, body = await _call_middleware(
+        mw, "/.well-known/oauth-authorization-server",
+    )
+    assert status == 200
+    doc = json.loads(body)
+    assert doc["issuer"] == "https://mnemon-test.example.com"
+
+
+@pytest.mark.asyncio
+async def test_jwks_200_with_as_config(local_token_config, enabled_as_config):
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(app, local_token_config, as_config=enabled_as_config)
+
+    status, _, body = await _call_middleware(mw, "/.well-known/jwks.json")
+    assert status == 200
+    doc = json.loads(body)
+    assert doc["keys"][0]["kty"] == "RSA"

--- a/tests/test_server_remote.py
+++ b/tests/test_server_remote.py
@@ -23,28 +23,29 @@ class TestRemoteConfig:
             importlib.reload(sr)
             assert sr.PORT == 9000
 
-    def test_oauth_config_enabled_from_env(self):
+    def test_as_config_enabled_from_env(self, tmp_path):
         env = {
-            "MNEMON_OAUTH_ISSUER": "https://issuer.example.com/",
-            "MNEMON_OAUTH_JWKS_URL": "https://issuer.example.com/.well-known/jwks.json",
-            "MNEMON_OAUTH_AUDIENCE": "https://mnemon.example.com/mcp",
+            "MNEMON_AS_ENABLED": "true",
+            "MNEMON_PUBLIC_URL": "https://mnemon.example.com",
+            "MNEMON_AS_PASSPHRASE": "x",
+            "MNEMON_AS_KEY_DIR": str(tmp_path),
         }
         with patch.dict(os.environ, env):
-            from mnemon.auth import OAuthConfig
-            config = OAuthConfig.from_env()
+            from mnemon.oauth_as import AuthorizationServerConfig
+            config = AuthorizationServerConfig.from_env()
             assert config.enabled
-            assert config.issuer == "https://issuer.example.com/"
+            assert config.issuer == "https://mnemon.example.com"
 
-    def test_oauth_config_disabled_by_default(self):
+    def test_as_config_disabled_by_default(self):
         with patch.dict(os.environ, {}, clear=False):
             for var in (
-                "MNEMON_OAUTH_ISSUER",
-                "MNEMON_OAUTH_JWKS_URL",
-                "MNEMON_OAUTH_AUDIENCE",
+                "MNEMON_AS_ENABLED",
+                "MNEMON_AS_PASSPHRASE",
+                "MNEMON_PUBLIC_URL",
             ):
                 os.environ.pop(var, None)
-            from mnemon.auth import OAuthConfig
-            config = OAuthConfig.from_env()
+            from mnemon.oauth_as import AuthorizationServerConfig
+            config = AuthorizationServerConfig.from_env()
             assert not config.enabled
 
 


### PR DESCRIPTION
## ⚠️ DO NOT MERGE YET

**Prerequisite:** PR #40 cutover must be executed per `private/mnemon-phase2-pr40-runbook.md`, then run stably for 1-2 weeks with the self-hosted AS. This PR removes the Auth0 fallback code — merging before cutover validates would require a rollback through the Auth0 path that no longer exists in code.

---

## Summary
Final Phase 2 cleanup. Removes the external-AS (Auth0) code path now that the self-hosted AS in `oauth_as.py` has replaced it.

## Removed from `auth.py`
- `OAuthConfig` fields: `issuer`, `jwks_url`, `audience`, `public_url`, `userinfo_url`. Class now carries only `local_token`.
- `OAuthConfig.from_env` parsing of `MNEMON_OAUTH_*` env vars.
- `OAuthConfig.enabled` property and `resource_metadata_url` derivation.
- `OAuthMiddleware._validate_token` (PyJWKClient remote-fetch path)
- `OAuthMiddleware._validate_via_userinfo` (opaque-token fallback)
- `OAuthMiddleware._jwks_client` and `_userinfo_cache` fields
- `_OAuthError` exception class (only used by removed paths)

## What stays
- Local-token bearer path (`MNEMON_LOCAL_TOKEN`) — used by Claude Code hooks, Cursor, any headless client
- Self-hosted AS JWT verification via `oauth_as.verify_self_hosted_token`
- All `/.well-known/*` and `/oauth/*` endpoints

## Test plan
- [x] 413 tests pass (pre-cleanup: also 413 — removed Auth0 tests, added guard test)
- [x] `test_auth.py` shrunk from 974 LOC → ~410, focused on local_token + AS paths
- [x] Regression-guard test: `OAuthConfig` no longer has issuer/jwks_url/audience/userinfo_url attributes

## Post-merge
Phase 2 is complete. A follow-up can bump to v0.4.0 and publish to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)