### PR TITLE
Add `mnemon doctor` CLI subcommand

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,10 @@
+# False positives allowlisted by fingerprint (commit:file:rule:line).
+# Each entry should have a comment explaining why it's not a real secret.
+
+# Fake test token literal in mnemon doctor test. The value
+# "abcd1234efgh5678" is 16 alphanumeric chars, which matches gitleaks'
+# generic-api-key heuristic because the surrounding variable name
+# contains MNEMON_LOCAL_TOKEN. Replaced in commit 176b367 with a
+# hyphenated obviously-fake value, but the finding on the original
+# commit 458a442 still shows up in PR-range scans.
+458a4428d6372339f942d1b2b14701c892cddde5:tests/test_doctor.py:generic-api-key:45

--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -150,6 +150,10 @@ def main() -> None:
         from .setup import run_setup
         print(run_setup(target, args[2:]))
 
+    elif command == "doctor":
+        from .doctor import run_doctor
+        sys.exit(run_doctor())
+
     else:
         print(f"Unknown command: {command}", file=sys.stderr)
         _print_usage()
@@ -161,6 +165,7 @@ def _print_usage() -> None:
 
 Setup (configure clients to use remote vault):
   mnemon setup <target>     Configure integration [--remote-url URL] [--token TOKEN]
+  mnemon doctor             Run diagnostics against the configured remote vault
 
 Server:
   mnemon serve              Start MCP server (stdio, local development)

--- a/src/mnemon/doctor.py
+++ b/src/mnemon/doctor.py
@@ -1,0 +1,329 @@
+"""Self-diagnostic for mnemon remote deployments.
+
+Runs an ordered series of checks against the configured remote vault and
+prints pass/fail per check. Designed as a validator for the Phase 2
+cutover (``MNEMON_AS_ENABLED=true`` on Fly) and for anyone self-hosting
+their own mnemon instance who wants a quick health signal after
+``fly deploy``.
+
+Checks run top-down and short-circuit only on hard config failures — the
+rest run independently so a single broken piece does not hide others.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import stat
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Callable
+
+from .hooks._remote_client import (
+    LOCAL_TOKEN_FILE,
+    REMOTE_URL_FILE,
+    RemoteClientConfigError,
+    call_tool_sync,
+    get_local_token,
+    get_remote_url,
+)
+
+PASS = "✓"
+FAIL = "✗"
+WARN = "⚠"
+
+HEALTH_TIMEOUT_SEC = 5.0
+MCP_TIMEOUT_SEC = 15.0
+
+
+@dataclass
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str
+    warn: bool = False  # ok=True + warn=True renders as a ⚠ non-fatal note
+
+
+# ── Individual checks ──────────────────────────────────────────────────────
+
+
+def check_remote_url() -> CheckResult:
+    try:
+        url = get_remote_url()
+    except RemoteClientConfigError as exc:
+        return CheckResult("Remote URL configured", False, str(exc))
+    source = "env" if os.environ.get("MNEMON_REMOTE_URL") else f"file {REMOTE_URL_FILE}"
+    return CheckResult("Remote URL configured", True, f"{url} (from {source})")
+
+
+def check_local_token() -> CheckResult:
+    try:
+        token = get_local_token()
+    except RemoteClientConfigError as exc:
+        return CheckResult("Local token configured", False, str(exc))
+
+    from_env = bool(os.environ.get("MNEMON_LOCAL_TOKEN"))
+    source = "env" if from_env else f"file {LOCAL_TOKEN_FILE}"
+    return CheckResult(
+        "Local token configured",
+        True,
+        f"{len(token)} bytes (from {source})",
+    )
+
+
+def check_token_file_perms() -> CheckResult:
+    """Warn if the token is coming from a file that is group/world readable."""
+    if os.environ.get("MNEMON_LOCAL_TOKEN"):
+        return CheckResult(
+            "Token file permissions",
+            True,
+            "skipped (token from env var)",
+            warn=False,
+        )
+    if not LOCAL_TOKEN_FILE.exists():
+        return CheckResult(
+            "Token file permissions",
+            True,
+            "skipped (no token file)",
+            warn=False,
+        )
+    mode = LOCAL_TOKEN_FILE.stat().st_mode
+    perms = stat.S_IMODE(mode)
+    if perms & (stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH):
+        return CheckResult(
+            "Token file permissions",
+            True,
+            f"{LOCAL_TOKEN_FILE} is {oct(perms)} — should be 0600 (chmod 600)",
+            warn=True,
+        )
+    return CheckResult(
+        "Token file permissions",
+        True,
+        f"{oct(perms)} (0600 as expected)",
+    )
+
+
+def check_health_endpoint() -> CheckResult:
+    """GET /health on the deployment base. Works without auth."""
+    try:
+        url = get_remote_url()
+    except RemoteClientConfigError as exc:
+        return CheckResult("Health endpoint reachable", False, str(exc))
+
+    base = url.rstrip("/")
+    if base.endswith("/mcp"):
+        base = base[: -len("/mcp")]
+    health_url = f"{base}/health"
+
+    t0 = time.monotonic()
+    try:
+        with urllib.request.urlopen(health_url, timeout=HEALTH_TIMEOUT_SEC) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            if resp.status != 200:
+                return CheckResult(
+                    "Health endpoint reachable",
+                    False,
+                    f"HTTP {resp.status} from {health_url}",
+                )
+            try:
+                payload = json.loads(body)
+            except json.JSONDecodeError:
+                return CheckResult(
+                    "Health endpoint reachable",
+                    False,
+                    f"non-JSON body from {health_url}: {body[:80]}",
+                )
+            if payload.get("status") != "ok":
+                return CheckResult(
+                    "Health endpoint reachable",
+                    False,
+                    f"status={payload.get('status')!r} (expected 'ok')",
+                )
+            return CheckResult(
+                "Health endpoint reachable",
+                True,
+                f"{health_url} ({elapsed_ms:.0f}ms)",
+            )
+    except (urllib.error.URLError, socket.timeout, TimeoutError) as exc:
+        return CheckResult(
+            "Health endpoint reachable",
+            False,
+            f"{health_url}: {exc}",
+        )
+
+
+def check_auth_and_tool_call() -> CheckResult:
+    """Full MCP handshake + memory_search call. Exercises auth end-to-end."""
+    try:
+        result, elapsed = call_tool_sync(
+            "memory_search",
+            {"query": "__mnemon_doctor_probe__", "limit": 1},
+            timeout=MCP_TIMEOUT_SEC,
+            client_label="mnemon-doctor",
+        )
+    except RemoteClientConfigError as exc:
+        return CheckResult("Auth + MCP tool call", False, str(exc))
+    except TimeoutError:
+        return CheckResult(
+            "Auth + MCP tool call",
+            False,
+            f"timed out after {MCP_TIMEOUT_SEC:.0f}s (cold start? run again)",
+        )
+    except Exception as exc:  # noqa: BLE001 — surface any SDK-level failure
+        return CheckResult("Auth + MCP tool call", False, f"{type(exc).__name__}: {exc}")
+
+    return CheckResult(
+        "Auth + MCP tool call",
+        True,
+        f"memory_search returned {len(result)} bytes ({elapsed * 1000:.0f}ms)",
+    )
+
+
+def check_round_trip() -> CheckResult:
+    """Save a throwaway memory, search for it by exact title, then forget it.
+
+    Uses a UUID-suffixed title so concurrent doctor runs cannot collide.
+    """
+    import uuid
+
+    title = f"mnemon-doctor-probe-{uuid.uuid4().hex[:8]}"
+    content = "Probe memory created by `mnemon doctor`. Safe to delete."
+
+    # 1. Save
+    try:
+        save_result, _ = call_tool_sync(
+            "memory_save",
+            {"title": title, "content": content, "content_type": "note"},
+            timeout=MCP_TIMEOUT_SEC,
+            client_label="mnemon-doctor",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return CheckResult(
+            "Round-trip (save + search + forget)",
+            False,
+            f"save failed: {type(exc).__name__}: {exc}",
+        )
+
+    # Server response looks like: 'Saved memory #123: "..."'
+    doc_id: int | None = None
+    for token in save_result.split():
+        if token.startswith("#"):
+            try:
+                doc_id = int(token.lstrip("#").rstrip(":"))
+                break
+            except ValueError:
+                continue
+
+    if doc_id is None:
+        return CheckResult(
+            "Round-trip (save + search + forget)",
+            False,
+            f"could not parse doc_id from save response: {save_result[:120]}",
+        )
+
+    # 2. Search
+    try:
+        search_result, _ = call_tool_sync(
+            "memory_search",
+            {"query": title, "limit": 5},
+            timeout=MCP_TIMEOUT_SEC,
+            client_label="mnemon-doctor",
+        )
+    except Exception as exc:  # noqa: BLE001
+        _best_effort_forget(doc_id)
+        return CheckResult(
+            "Round-trip (save + search + forget)",
+            False,
+            f"search failed: {type(exc).__name__}: {exc}",
+        )
+
+    if title not in search_result:
+        _best_effort_forget(doc_id)
+        return CheckResult(
+            "Round-trip (save + search + forget)",
+            False,
+            f"saved memory not found by search for its own title (doc_id={doc_id})",
+        )
+
+    # 3. Forget
+    try:
+        call_tool_sync(
+            "memory_forget",
+            {"document_id": doc_id},
+            timeout=MCP_TIMEOUT_SEC,
+            client_label="mnemon-doctor",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return CheckResult(
+            "Round-trip (save + search + forget)",
+            True,
+            f"save+search ok but forget failed: {exc} (doc_id={doc_id} leaked)",
+            warn=True,
+        )
+
+    return CheckResult(
+        "Round-trip (save + search + forget)",
+        True,
+        f"doc_id={doc_id} saved, found, and forgotten",
+    )
+
+
+def _best_effort_forget(doc_id: int) -> None:
+    """Try to clean up a probe memory; swallow errors — caller already failed."""
+    try:
+        call_tool_sync(
+            "memory_forget",
+            {"document_id": doc_id},
+            timeout=MCP_TIMEOUT_SEC,
+            client_label="mnemon-doctor",
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ── Runner ─────────────────────────────────────────────────────────────────
+
+CHECKS: list[Callable[[], CheckResult]] = [
+    check_remote_url,
+    check_local_token,
+    check_token_file_perms,
+    check_health_endpoint,
+    check_auth_and_tool_call,
+    check_round_trip,
+]
+
+
+def run_doctor(out=sys.stdout) -> int:
+    """Run all checks, print results, return exit code (0 = all pass)."""
+    print("mnemon doctor — running diagnostics...\n", file=out)
+
+    results: list[CheckResult] = []
+    for check in CHECKS:
+        result = check()
+        results.append(result)
+        prefix = PASS if result.ok and not result.warn else (WARN if result.warn else FAIL)
+        print(f"  {prefix} {result.name}: {result.detail}", file=out)
+
+    failed = [r for r in results if not r.ok]
+    warned = [r for r in results if r.ok and r.warn]
+
+    print("", file=out)
+    if failed:
+        print(
+            f"{FAIL} {len(failed)}/{len(results)} checks failed.",
+            file=out,
+        )
+        return 1
+    if warned:
+        print(
+            f"{WARN} All checks passed with {len(warned)} warning(s).",
+            file=out,
+        )
+        return 0
+    print(f"{PASS} All {len(results)} checks passed.", file=out)
+    return 0

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,353 @@
+"""Tests for mnemon doctor — the remote-vault self-diagnostic."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import socket
+import stat
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from mnemon import doctor
+from mnemon.hooks._remote_client import RemoteClientConfigError
+
+
+# ── check_remote_url ────────────────────────────────────────────────────────
+
+
+class TestCheckRemoteUrl:
+    def test_passes_when_env_var_set(self, monkeypatch):
+        monkeypatch.setenv("MNEMON_REMOTE_URL", "https://example.fly.dev/mcp")
+        result = doctor.check_remote_url()
+        assert result.ok
+        assert "example.fly.dev" in result.detail
+        assert "env" in result.detail
+
+    def test_fails_when_unset(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MNEMON_REMOTE_URL", raising=False)
+        # Redirect the file lookup to a non-existent path
+        monkeypatch.setattr(doctor, "REMOTE_URL_FILE", tmp_path / "does-not-exist")
+        with patch("mnemon.doctor.get_remote_url",
+                   side_effect=RemoteClientConfigError("not configured")):
+            result = doctor.check_remote_url()
+        assert not result.ok
+        assert "not configured" in result.detail
+
+
+# ── check_local_token ───────────────────────────────────────────────────────
+
+
+class TestCheckLocalToken:
+    def test_passes_when_env_var_set(self, monkeypatch):
+        monkeypatch.setenv("MNEMON_LOCAL_TOKEN", "abcd1234efgh5678")
+        result = doctor.check_local_token()
+        assert result.ok
+        assert "16 bytes" in result.detail
+        assert "env" in result.detail
+
+    def test_fails_when_unset(self, monkeypatch):
+        monkeypatch.delenv("MNEMON_LOCAL_TOKEN", raising=False)
+        with patch("mnemon.doctor.get_local_token",
+                   side_effect=RemoteClientConfigError("no token")):
+            result = doctor.check_local_token()
+        assert not result.ok
+        assert "no token" in result.detail
+
+
+# ── check_token_file_perms ──────────────────────────────────────────────────
+
+
+class TestCheckTokenFilePerms:
+    def test_skipped_when_env_var_used(self, monkeypatch):
+        monkeypatch.setenv("MNEMON_LOCAL_TOKEN", "fromenv")
+        result = doctor.check_token_file_perms()
+        assert result.ok
+        assert not result.warn
+        assert "env" in result.detail
+
+    def test_skipped_when_no_token_file(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MNEMON_LOCAL_TOKEN", raising=False)
+        monkeypatch.setattr(doctor, "LOCAL_TOKEN_FILE", tmp_path / "nope")
+        result = doctor.check_token_file_perms()
+        assert result.ok
+        assert not result.warn
+
+    def test_warns_on_group_readable(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MNEMON_LOCAL_TOKEN", raising=False)
+        token_file = tmp_path / "local_token"
+        token_file.write_text("secret")
+        token_file.chmod(0o640)  # group-readable — not safe
+        monkeypatch.setattr(doctor, "LOCAL_TOKEN_FILE", token_file)
+        result = doctor.check_token_file_perms()
+        assert result.ok
+        assert result.warn
+        assert "chmod 600" in result.detail
+
+    def test_passes_on_0600(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MNEMON_LOCAL_TOKEN", raising=False)
+        token_file = tmp_path / "local_token"
+        token_file.write_text("secret")
+        token_file.chmod(0o600)
+        monkeypatch.setattr(doctor, "LOCAL_TOKEN_FILE", token_file)
+        result = doctor.check_token_file_perms()
+        assert result.ok
+        assert not result.warn
+        assert "0600" in result.detail
+
+
+# ── check_health_endpoint ───────────────────────────────────────────────────
+
+
+class TestCheckHealthEndpoint:
+    def test_passes_on_ok_response(self, monkeypatch):
+        monkeypatch.setenv("MNEMON_REMOTE_URL", "https://example.fly.dev/mcp")
+
+        fake_resp = MagicMock()
+        fake_resp.status = 200
+        fake_resp.read.return_value = json.dumps({"status": "ok"}).encode()
+        fake_resp.__enter__.return_value = fake_resp
+        fake_resp.__exit__.return_value = False
+
+        with patch("urllib.request.urlopen", return_value=fake_resp) as m:
+            result = doctor.check_health_endpoint()
+
+        assert result.ok
+        # Should have stripped the /mcp suffix before hitting /health
+        called_url = m.call_args[0][0]
+        assert called_url == "https://example.fly.dev/health"
+
+    def test_fails_on_non_200(self, monkeypatch):
+        monkeypatch.setenv("MNEMON_REMOTE_URL", "https://example.fly.dev/mcp")
+
+        fake_resp = MagicMock()
+        fake_resp.status = 503
+        fake_resp.read.return_value = b"{}"
+        fake_resp.__enter__.return_value = fake_resp
+        fake_resp.__exit__.return_value = False
+
+        with patch("urllib.request.urlopen", return_value=fake_resp):
+            result = doctor.check_health_endpoint()
+
+        assert not result.ok
+        assert "503" in result.detail
+
+    def test_fails_on_connection_error(self, monkeypatch):
+        monkeypatch.setenv("MNEMON_REMOTE_URL", "https://example.fly.dev/mcp")
+        import urllib.error
+        with patch("urllib.request.urlopen",
+                   side_effect=urllib.error.URLError("connection refused")):
+            result = doctor.check_health_endpoint()
+        assert not result.ok
+        assert "connection refused" in result.detail
+
+    def test_fails_on_non_ok_status_payload(self, monkeypatch):
+        monkeypatch.setenv("MNEMON_REMOTE_URL", "https://example.fly.dev/mcp")
+
+        fake_resp = MagicMock()
+        fake_resp.status = 200
+        fake_resp.read.return_value = json.dumps({"status": "degraded"}).encode()
+        fake_resp.__enter__.return_value = fake_resp
+        fake_resp.__exit__.return_value = False
+
+        with patch("urllib.request.urlopen", return_value=fake_resp):
+            result = doctor.check_health_endpoint()
+
+        assert not result.ok
+        assert "degraded" in result.detail
+
+
+# ── check_auth_and_tool_call ────────────────────────────────────────────────
+
+
+class TestCheckAuthAndToolCall:
+    def test_passes_on_successful_call(self):
+        with patch("mnemon.doctor.call_tool_sync",
+                   return_value=("some text result", 0.123)) as m:
+            result = doctor.check_auth_and_tool_call()
+        assert result.ok
+        assert "memory_search" in result.detail
+        # Ensure we passed a recognizable client label
+        assert m.call_args.kwargs["client_label"] == "mnemon-doctor"
+
+    def test_fails_on_timeout(self):
+        with patch("mnemon.doctor.call_tool_sync",
+                   side_effect=TimeoutError()):
+            result = doctor.check_auth_and_tool_call()
+        assert not result.ok
+        assert "timed out" in result.detail
+
+    def test_fails_on_auth_error(self):
+        with patch("mnemon.doctor.call_tool_sync",
+                   side_effect=RuntimeError("401 Unauthorized")):
+            result = doctor.check_auth_and_tool_call()
+        assert not result.ok
+        assert "401" in result.detail
+
+
+# ── check_round_trip ────────────────────────────────────────────────────────
+
+
+class TestCheckRoundTrip:
+    def test_full_round_trip_passes(self):
+        save_response = 'Saved memory #999: "mnemon-doctor-probe-abcd1234"'
+        # The search response must contain the probe title
+        def fake_call(tool, args, **kwargs):
+            if tool == "memory_save":
+                return (save_response, 0.1)
+            if tool == "memory_search":
+                return (f"1. {args['query']} (some metadata)", 0.1)
+            if tool == "memory_forget":
+                return ("Forgot memory #999.", 0.05)
+            raise AssertionError(f"unexpected tool: {tool}")
+
+        with patch("mnemon.doctor.call_tool_sync", side_effect=fake_call):
+            result = doctor.check_round_trip()
+
+        assert result.ok
+        assert not result.warn
+        assert "999" in result.detail
+
+    def test_save_failure_short_circuits(self):
+        with patch("mnemon.doctor.call_tool_sync",
+                   side_effect=RuntimeError("save exploded")):
+            result = doctor.check_round_trip()
+        assert not result.ok
+        assert "save failed" in result.detail
+
+    def test_unparseable_save_response_fails(self):
+        with patch("mnemon.doctor.call_tool_sync",
+                   return_value=("no doc id anywhere here", 0.1)):
+            result = doctor.check_round_trip()
+        assert not result.ok
+        assert "could not parse" in result.detail
+
+    def test_search_failure_cleans_up(self):
+        save_response = 'Saved memory #999: "mnemon-doctor-probe-xx"'
+        forget_calls: list = []
+
+        def fake_call(tool, args, **kwargs):
+            if tool == "memory_save":
+                return (save_response, 0.1)
+            if tool == "memory_search":
+                raise RuntimeError("search exploded")
+            if tool == "memory_forget":
+                forget_calls.append(args)
+                return ("Forgot memory #999.", 0.05)
+            raise AssertionError(tool)
+
+        with patch("mnemon.doctor.call_tool_sync", side_effect=fake_call):
+            result = doctor.check_round_trip()
+
+        assert not result.ok
+        assert "search failed" in result.detail
+        # Best-effort cleanup should still have fired
+        assert forget_calls == [{"document_id": 999}]
+
+    def test_forget_failure_warns_but_passes(self):
+        save_response = 'Saved memory #999: "mnemon-doctor-probe-xx"'
+
+        def fake_call(tool, args, **kwargs):
+            if tool == "memory_save":
+                return (save_response, 0.1)
+            if tool == "memory_search":
+                return (f"found: {args['query']}", 0.1)
+            if tool == "memory_forget":
+                raise RuntimeError("forget exploded")
+            raise AssertionError(tool)
+
+        with patch("mnemon.doctor.call_tool_sync", side_effect=fake_call):
+            result = doctor.check_round_trip()
+
+        assert result.ok
+        assert result.warn
+        assert "leaked" in result.detail
+
+    def test_saved_memory_not_found_fails(self):
+        save_response = 'Saved memory #999: "mnemon-doctor-probe-xx"'
+        forget_calls: list = []
+
+        def fake_call(tool, args, **kwargs):
+            if tool == "memory_save":
+                return (save_response, 0.1)
+            if tool == "memory_search":
+                return ("some other unrelated result", 0.1)
+            if tool == "memory_forget":
+                forget_calls.append(args)
+                return ("ok", 0.05)
+            raise AssertionError(tool)
+
+        with patch("mnemon.doctor.call_tool_sync", side_effect=fake_call):
+            result = doctor.check_round_trip()
+
+        assert not result.ok
+        assert "not found by search" in result.detail
+        assert forget_calls == [{"document_id": 999}]
+
+
+# ── run_doctor end-to-end ───────────────────────────────────────────────────
+
+
+class TestRunDoctor:
+    def test_all_pass_returns_zero(self):
+        def ok(name: str) -> doctor.CheckResult:
+            return doctor.CheckResult(name, True, "fine")
+
+        fake_checks = [
+            lambda: ok("A"),
+            lambda: ok("B"),
+        ]
+        buf = io.StringIO()
+        with patch("mnemon.doctor.CHECKS", fake_checks):
+            code = doctor.run_doctor(out=buf)
+        assert code == 0
+        output = buf.getvalue()
+        assert "All 2 checks passed" in output
+        assert doctor.PASS in output
+
+    def test_any_fail_returns_one(self):
+        fake_checks = [
+            lambda: doctor.CheckResult("A", True, "ok"),
+            lambda: doctor.CheckResult("B", False, "broken"),
+        ]
+        buf = io.StringIO()
+        with patch("mnemon.doctor.CHECKS", fake_checks):
+            code = doctor.run_doctor(out=buf)
+        assert code == 1
+        output = buf.getvalue()
+        assert "1/2 checks failed" in output
+        assert doctor.FAIL in output
+
+    def test_warn_only_returns_zero_with_note(self):
+        fake_checks = [
+            lambda: doctor.CheckResult("A", True, "ok"),
+            lambda: doctor.CheckResult("B", True, "heads-up", warn=True),
+        ]
+        buf = io.StringIO()
+        with patch("mnemon.doctor.CHECKS", fake_checks):
+            code = doctor.run_doctor(out=buf)
+        assert code == 0
+        output = buf.getvalue()
+        assert "1 warning" in output
+
+    def test_cli_dispatches_to_doctor(self, monkeypatch):
+        """`mnemon doctor` on the CLI should call run_doctor and exit with its code."""
+        from mnemon.cli import main
+
+        monkeypatch.setattr("sys.argv", ["mnemon", "doctor"])
+        with patch("mnemon.doctor.run_doctor", return_value=0) as mock_run:
+            with pytest.raises(SystemExit) as excinfo:
+                main()
+        mock_run.assert_called_once()
+        assert excinfo.value.code == 0
+
+    def test_cli_propagates_nonzero_exit(self, monkeypatch):
+        from mnemon.cli import main
+
+        monkeypatch.setattr("sys.argv", ["mnemon", "doctor"])
+        with patch("mnemon.doctor.run_doctor", return_value=1):
+            with pytest.raises(SystemExit) as excinfo:
+                main()
+        assert excinfo.value.code == 1

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -42,10 +42,11 @@ class TestCheckRemoteUrl:
 
 class TestCheckLocalToken:
     def test_passes_when_env_var_set(self, monkeypatch):
-        monkeypatch.setenv("MNEMON_LOCAL_TOKEN", "abcd1234efgh5678")
+        fake_token = "fake-test-token"  # 15 bytes, hyphenated to dodge secret scanners
+        monkeypatch.setenv("MNEMON_LOCAL_TOKEN", fake_token)
         result = doctor.check_local_token()
         assert result.ok
-        assert "16 bytes" in result.detail
+        assert f"{len(fake_token)} bytes" in result.detail
         assert "env" in result.detail
 
     def test_fails_when_unset(self, monkeypatch):


### PR DESCRIPTION
## Summary

Adds `mnemon doctor` — a self-diagnostic subcommand that runs six ordered checks against the configured remote vault and reports pass/fail per check.

Primary motivation: this will be the validator I run during the Phase 2 self-hosted AS cutover (see `private/mnemon-phase2-pr40-runbook.md`) to confirm the new auth path is healthy before removing the Auth0 fallback. Secondary: anyone self-hosting mnemon gets a quick post-deploy "is this healthy" signal.

## Checks

1. `MNEMON_REMOTE_URL` resolvable (env var or `~/.mnemon/remote_url`)
2. `MNEMON_LOCAL_TOKEN` resolvable (env var or `~/.mnemon/local_token`)
3. Token file permissions — warn (non-fatal) if a token file is group/world-readable
4. `/health` endpoint reachable and returns `{"status": "ok"}`
5. Full MCP handshake + `memory_search` tool call (exercises auth end-to-end)
6. Round-trip: `memory_save` a uuid-suffixed probe → `memory_search` for it by title → `memory_forget`. Best-effort cleanup if search fails.

## Behavior

- Checks run independently so a single failure doesn't hide others.
- Exit code 0 when all checks pass (warnings are non-fatal); 1 if any hard check fails.
- Output uses `✓` / `✗` / `⚠` prefixes with per-check detail lines.
- Round-trip uses a UUID-suffixed probe title so concurrent doctor runs cannot collide, and always attempts to clean up the probe memory even on failure.

## Test plan

- [x] 26 new unit tests in `tests/test_doctor.py` cover pass/warn/fail paths for every check plus end-to-end `run_doctor` dispatch and CLI wiring.
- [x] Full suite green: 450 passed, 0 failures (excluding integration-marked tests).
- [x] Smoke-tested `python -m mnemon doctor` with no config → fails loud with clear action, exit code 1.
- [ ] Will smoke-test against production `mnemon-memory.fly.dev` after merge (current Auth0 path) and again after the Phase 2 cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)