### PR TITLE
Post-cutover followups: design decisions doc, doctor dedup fix, Fly grace period

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,20 @@ Requires the AWS CLI (`aws`) on your PATH with valid credentials.
 - **Intelligence** (optional): Local 1.7B LLM (QMD-query-expansion) for query expansion, contradiction detection, session extraction — zero API cost
 - **Transport**: MCP stdio (local) and Streamable HTTP (remote)
 
+## Design decisions
+
+A small set of architectural choices shape the rest of the system. Documented here so self-host users know what they're signing up for and reviewers can evaluate the trade-offs.
+
+**Why SQLite + FTS5 (not Postgres, not a vector DB).** A single-file embedded database means no operational surface area — no connection pools, no migrations against a live DB, no standalone vector store to keep in sync. FTS5 gives production-grade BM25 without a separate Elasticsearch. A numpy-backed vector store sits alongside the SQLite file; brute-force cosine over a few thousand memories is faster than any network hop to a hosted vector DB. The single-file design also makes vault portability trivial — copy one file and you've moved your entire memory.
+
+**Why hybrid BM25 + vector (not pure semantic).** Pure vector search misses exact-identifier lookups; pure keyword misses paraphrase. Reciprocal Rank Fusion combines both rankings, then composite scoring folds in recency and confidence. In practice this catches both "find my note about bge-small-en-v1.5" (keyword wins) and "memory about embedding models" (vector wins) without tuning.
+
+**Why Fly.io (not AWS / GCP).** mnemon is designed to idle cheaply and wake on demand. Fly's `auto_stop_machines` + `min_machines_running=0` costs ~$0.50–0.90/mo for a personal vault; the closest AWS equivalent (ECS Fargate or App Runner) can't scale to zero and starts at ~$10/mo. Fly volumes are local-attached SSD, which matches SQLite's access pattern — AWS's equivalent (EFS) is slower and pricier. Deploy is one `fly.toml` and one command, vs. the VPC + ALB + ECS + IAM setup AWS requires — which matters for any future self-host user.
+
+**Why self-hosted OAuth 2.1 + PKCE + DCR (not Auth0 / Clerk / Logto).** Requiring users to register an Auth0 tenant before they can try mnemon is a near-guaranteed bounce. mnemon ships with its own Authorization Server (well-known endpoints, `/oauth/authorize`, `/oauth/token` with PKCE, `/oauth/register` per RFC 7591, JWT issuance) — anyone can `fly deploy` and have a working OAuth-protected MCP endpoint with no third-party signup. The trade-off is less battle-tested auth code; the mitigation is that browser clients are the only OAuth consumers, and headless clients (Claude Code, Cursor) use a simple static bearer.
+
+**Why MCP + a separate memory server (not Claude's native memory).** Claude's native memory is account-scoped and only reaches Anthropic products (claude.ai web/mobile/desktop). It doesn't reach Claude Code, Cursor, or any other MCP-speaking client. mnemon serves the cross-client case: a single vault that Claude Code hooks, Cursor, and claude.ai can all read and write. It's also self-hosted, exportable, and programmatically introspectable — the opposite of Anthropic's closed-box model. These systems are complementary, not competing.
+
 ## Configuration
 
 | Env var | Default | Description |

--- a/fly.toml
+++ b/fly.toml
@@ -19,6 +19,17 @@ primary_region = "sjc"
   auto_start_machines = true
   min_machines_running = 0
 
+  # First request after a cold start loads the FastEmbed bge-small-en-v1.5
+  # ONNX model (~15–25s). grace_period must be longer than that to avoid
+  # false-positive "app not listening on 0.0.0.0:8080" warnings during
+  # rolling deploys and `fly secrets set` restarts.
+  [[http_service.checks]]
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "40s"
+    method = "GET"
+    path = "/health"
+
 [mounts]
   source = "mnemon_data"
   destination = "/data"

--- a/src/mnemon/doctor.py
+++ b/src/mnemon/doctor.py
@@ -191,8 +191,13 @@ def check_round_trip() -> CheckResult:
     """
     import uuid
 
-    title = f"mnemon-doctor-probe-{uuid.uuid4().hex[:8]}"
-    content = "Probe memory created by `mnemon doctor`. Safe to delete."
+    # Use the UUID in both title AND content. store.save() dedups by SHA-256
+    # of content, so identical content across runs would return the original
+    # doc_id without actually inserting a new row — and the search for the
+    # run-specific title would then miss.
+    probe_id = uuid.uuid4().hex[:8]
+    title = f"mnemon-doctor-probe-{probe_id}"
+    content = f"Probe memory created by `mnemon doctor` (run {probe_id}). Safe to delete."
 
     # 1. Save
     try:


### PR DESCRIPTION
## Summary

Three independent cleanups surfaced by yesterday's Phase 2 cutover, bundled because each one is small and the context is fresh.

### 1. `docs`: Add Design decisions section to README

New subsection between Architecture and Configuration. Explains the five architectural choices in ~5 paragraphs:
- Why SQLite + FTS5 (not Postgres, not a vector DB)
- Why hybrid BM25 + vector (not pure semantic)
- Why Fly.io (not AWS / GCP)
- Why self-hosted OAuth 2.1 + PKCE + DCR (not Auth0 / Clerk / Logto)
- Why MCP + separate memory server (not Claude's native memory)

Motivated by the Phase 2 cutover — self-hosters now have a working auth path that doesn't require a third-party tenant, so the README should explain *why* the stack is what it is before someone tries to deploy their own.

### 2. `fix`: `mnemon doctor` round-trip dedup hit

`doctor.py`'s round-trip probe used identical content across runs, so `store.save()` dedup-ed by SHA-256 content hash and returned the original `doc_id` without inserting a new row. Subsequent search for the run-specific UUID title then missed, because the stored memory's title was from a prior run.

Surfaced during the cutover — doctor kept reporting `doc_id=40` on every run despite the vault growing past 40 total memories. Include the UUID in the content body too, making every run's hash unique.

### 3. `chore`: Add Fly health check with grace period for FastEmbed cold start

FastEmbed's bge-small-en-v1.5 ONNX model loads eagerly on server start (15–25s). During that window, `fly secrets set` and rolling deploys printed a false-positive "app not listening on 0.0.0.0:8080" warning. Adding an explicit `[[http_service.checks]]` block with a 40s `grace_period` gives Fly correct visibility into startup and suppresses the misleading warning. Also improves auto-stop/auto-start readiness signal.

## Test plan

- [x] `pytest tests/test_doctor.py` — 26 passing (no assertion changes needed; tests mock at the `call_tool_sync` level)
- [x] Full suite still green (run pre-PR)
- [ ] Post-merge: observe next `fly deploy` or `fly secrets set` — warning should be gone
- [ ] Post-merge: `mnemon doctor` should pass 6/6 checks (round-trip included)

## Known followup (not in this PR)

**MCP session resilience.** After a Fly restart (triggered by secret updates), Claude Code's MCP session to mnemon breaks with `Session not found`. Claude Code's MCP client doesn't auto-reinitialize gracefully. Client-side concern, likely worth a follow-up in Claude Code rather than mnemon, but worth tracking since self-host audiences will hit it every time they update secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)