### PR TITLE
Persist OAuth auth codes + refresh tokens across restarts

### DIFF
--- a/src/mnemon/oauth_as.py
+++ b/src/mnemon/oauth_as.py
@@ -281,33 +281,89 @@ async def serve_as_metadata(config: AuthorizationServerConfig, send) -> None:
     await _send_json(send, 200, authorization_server_metadata(config))
 
 
-# ── Authorization codes + refresh tokens (in-memory storage) ────────────────
+# ── Authorization codes + refresh tokens (volume-backed storage) ────────────
 #
-# In-memory storage is deliberate: auth codes live for 10 minutes and
-# refresh tokens are bound to a single user. A server restart invalidates
-# all outstanding codes (forces a re-login — acceptable friction for a
-# personal-use AS) and refresh tokens (forces re-auth on next use —
-# same). If you need durability across restarts, swap these dicts for
-# SQLite-backed tables in the Fly volume; the interface stays the same.
+# Persisted to JSON files in ``key_dir`` so Fly restarts (deploys,
+# autostop wake, secret rotation) don't invalidate outstanding refresh
+# tokens — which would force every connected MCP client to re-auth via
+# passphrase on every wake. Auth codes are persisted too for symmetry
+# and to cover the edge case of the machine idling during a 10-minute
+# OAuth flow.
+#
+# Files are mode 0600 (same as the AS private key). Writes go through
+# tmp + atomic rename so a crash mid-write can't corrupt the files.
+# Expired entries are dropped on load so the files don't grow forever.
 
 _AUTH_CODE_TTL_SEC = 600          # 10 min — RFC recommends ≤ 10 min
 _ACCESS_TOKEN_TTL_SEC = 3600      # 1 hour
 _REFRESH_TOKEN_TTL_SEC = 30 * 24 * 3600  # 30 days
 
-# auth_codes: code_value → {client_id, redirect_uri, code_challenge, scope,
-#                           subject, expires_at}
-_auth_codes: dict[str, dict[str, Any]] = {}
+_AUTH_CODES_FILENAME = "auth_codes.json"
+_REFRESH_TOKENS_FILENAME = "refresh_tokens.json"
 
-# refresh_tokens: refresh_token_value → {subject, scope, client_id, expires_at}
-_refresh_tokens: dict[str, dict[str, Any]] = {}
+
+def _load_token_file(path: Path, label: str) -> dict[str, dict[str, Any]]:
+    """Load a token JSON file, pruning expired entries. Returns {} on any
+    error — the cost is that clients re-auth, which is the same fallback
+    as losing the in-memory dict before this was persisted."""
+    if not path.exists():
+        return {}
+    try:
+        entries: dict[str, dict[str, Any]] = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning(
+            "oauth_as: %s unreadable (%s); treating as empty. "
+            "Affected clients will need to re-auth.",
+            label, e,
+        )
+        return {}
+    now = _now()
+    return {k: v for k, v in entries.items() if v.get("expires_at", 0) > now}
+
+
+def _save_token_file(path: Path, entries: dict[str, dict[str, Any]]) -> None:
+    """Atomic-rename write of a token JSON file at mode 0600. These files
+    contain bearer-equivalent secrets, so perms must be as tight as the
+    AS private key."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(entries, indent=2))
+    tmp.chmod(0o600)
+    tmp.replace(path)
+
+
+def _auth_codes_path(config: AuthorizationServerConfig) -> Path:
+    return config.key_dir / _AUTH_CODES_FILENAME
+
+
+def _refresh_tokens_path(config: AuthorizationServerConfig) -> Path:
+    return config.key_dir / _REFRESH_TOKENS_FILENAME
+
+
+def _load_auth_codes(config: AuthorizationServerConfig) -> dict[str, dict[str, Any]]:
+    return _load_token_file(_auth_codes_path(config), "auth_codes.json")
+
+
+def _save_auth_codes(
+    config: AuthorizationServerConfig, codes: dict[str, dict[str, Any]]
+) -> None:
+    _save_token_file(_auth_codes_path(config), codes)
+
+
+def _load_refresh_tokens(config: AuthorizationServerConfig) -> dict[str, dict[str, Any]]:
+    return _load_token_file(_refresh_tokens_path(config), "refresh_tokens.json")
+
+
+def _save_refresh_tokens(
+    config: AuthorizationServerConfig, tokens: dict[str, dict[str, Any]]
+) -> None:
+    _save_token_file(_refresh_tokens_path(config), tokens)
 
 
 def _reset_state_for_tests() -> None:
-    """Clear module-level state. Test-only helper — prevents cross-test
-    leakage since auth codes and refresh tokens live in module globals.
-    Does NOT touch clients.json (that's per-tmp-path in tests)."""
-    _auth_codes.clear()
-    _refresh_tokens.clear()
+    """No-op — kept for backward compat with existing test fixtures.
+    State now lives per-``key_dir`` on disk, so each test's ``tmp_path``
+    fixture provides natural isolation."""
 
 
 def _now() -> int:
@@ -434,12 +490,14 @@ def _issue_token_pair(
     so it can be exchanged later via the refresh_token grant."""
     access_token = mint_access_token(config, subject=subject, scope=scope)
     refresh_token = _new_random_token()
-    _refresh_tokens[refresh_token] = {
+    tokens = _load_refresh_tokens(config)
+    tokens[refresh_token] = {
         "subject": subject,
         "scope": scope,
         "client_id": client_id,
         "expires_at": _now() + _REFRESH_TOKEN_TTL_SEC,
     }
+    _save_refresh_tokens(config, tokens)
     return {
         "access_token": access_token,
         "token_type": "Bearer",
@@ -676,7 +734,8 @@ async def serve_authorize(
 
     # Issue auth code and redirect to client's redirect_uri.
     code = _new_random_token()
-    _auth_codes[code] = {
+    codes = _load_auth_codes(config)
+    codes[code] = {
         "client_id": params["client_id"],
         "redirect_uri": params["redirect_uri"],
         "code_challenge": params["code_challenge"],
@@ -685,6 +744,7 @@ async def serve_authorize(
         "subject": "owner",  # single-user AS
         "expires_at": _now() + _AUTH_CODE_TTL_SEC,
     }
+    _save_auth_codes(config, codes)
 
     from urllib.parse import urlencode
     redirect_params = {"code": code}
@@ -759,13 +819,16 @@ async def _token_authorization_code(
             })
             return
 
-    record = _auth_codes.pop(code, None)  # one-time use — consume on lookup
+    # One-time use — consume on lookup.
+    codes = _load_auth_codes(config)
+    record = codes.pop(code, None)
     if record is None:
         await _send_json(send, 400, {
             "error": "invalid_grant",
             "error_description": "unknown, expired, or already-used code",
         })
         return
+    _save_auth_codes(config, codes)
     if record["expires_at"] < _now():
         await _send_json(send, 400, {
             "error": "invalid_grant",
@@ -815,13 +878,15 @@ async def _token_refresh(
 
     # Rotation: consume the old refresh token regardless of outcome so a
     # leaked token can only be used once.
-    record = _refresh_tokens.pop(refresh_token, None)
+    tokens = _load_refresh_tokens(config)
+    record = tokens.pop(refresh_token, None)
     if record is None:
         await _send_json(send, 400, {
             "error": "invalid_grant",
             "error_description": "unknown, expired, or already-rotated refresh token",
         })
         return
+    _save_refresh_tokens(config, tokens)
     if record["expires_at"] < _now():
         await _send_json(send, 400, {
             "error": "invalid_grant",

--- a/tests/test_oauth_as.py
+++ b/tests/test_oauth_as.py
@@ -538,7 +538,7 @@ class TestServeAuthorizePost:
     async def test_correct_passphrase_redirects_with_code(
         self, as_config, registered_client
     ):
-        from mnemon.oauth_as import _auth_codes, serve_authorize
+        from mnemon.oauth_as import _load_auth_codes, serve_authorize
 
         cid = registered_client["client_id"]
         _, challenge = _pkce_pair()
@@ -557,8 +557,8 @@ class TestServeAuthorizePost:
         qs = parse_qs(parsed.query)
         assert "code" in qs
         assert qs["state"] == ["xyz"]
-        # Code stored server-side for later exchange
-        assert qs["code"][0] in _auth_codes
+        # Code persisted to auth_codes.json for later exchange
+        assert qs["code"][0] in _load_auth_codes(as_config)
 
 
 # ── /oauth/token ────────────────────────────────────────────────────────────
@@ -1189,3 +1189,152 @@ class TestVerifySelfHostedToken:
         token = jwt.encode(payload, private_pem, algorithm="RS256")
         with pytest.raises(ValueError):
             verify_self_hosted_token(as_config, token)
+
+
+# ── Volume-backed persistence of auth codes + refresh tokens ────────────────
+
+
+class TestStatePersistence:
+    """Auth codes and refresh tokens must survive process restarts so
+    Fly autostop wake doesn't force every claude.ai client to re-enter
+    the passphrase. File format: JSON at ``{key_dir}/auth_codes.json``
+    and ``{key_dir}/refresh_tokens.json``, mode 0600."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_token_survives_simulated_restart(
+        self, as_config, registered_client
+    ):
+        """Issue a refresh token, simulate a restart (drop in-memory
+        state by reimporting the module), then redeem via /token —
+        must succeed because the token was persisted to disk."""
+        import importlib
+        import mnemon.oauth_as as as_mod
+
+        issued = as_mod._issue_token_pair(
+            as_config,
+            subject="owner",
+            scope="mcp",
+            client_id=registered_client["client_id"],
+        )
+        refresh_token = issued["refresh_token"]
+
+        # Simulate restart: re-import the module so any module-level
+        # caches are dropped. The on-disk refresh_tokens.json must be
+        # the sole source of truth.
+        as_mod = importlib.reload(as_mod)
+
+        body = (
+            f"grant_type=refresh_token&refresh_token={refresh_token}"
+        ).encode()
+        status, _, resp_body = await _run_asgi(
+            as_mod.serve_token, as_config, method="POST", body=body
+        )
+        assert status == 200, resp_body
+        resp = json.loads(resp_body)
+        assert "access_token" in resp
+        assert "refresh_token" in resp
+        # Rotation: old token must no longer be redeemable.
+        assert resp["refresh_token"] != refresh_token
+
+    def test_refresh_tokens_file_is_mode_0600(
+        self, as_config, registered_client
+    ):
+        """Refresh tokens are bearer-equivalent secrets; file perms must
+        match the AS private key (0600)."""
+        from mnemon.oauth_as import _issue_token_pair, _refresh_tokens_path
+
+        _issue_token_pair(
+            as_config, subject="owner", scope="mcp",
+            client_id=registered_client["client_id"],
+        )
+        path = _refresh_tokens_path(as_config)
+        assert path.exists()
+        mode = path.stat().st_mode & 0o777
+        assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+
+    def test_expired_refresh_tokens_pruned_on_load(self, as_config):
+        """Entries past their expires_at must be dropped on load so the
+        file doesn't grow forever."""
+        from mnemon.oauth_as import (
+            _load_refresh_tokens,
+            _refresh_tokens_path,
+            _save_refresh_tokens,
+            _now,
+        )
+
+        _save_refresh_tokens(as_config, {
+            "fresh": {"subject": "owner", "scope": "mcp",
+                      "client_id": "c", "expires_at": _now() + 3600},
+            "stale": {"subject": "owner", "scope": "mcp",
+                      "client_id": "c", "expires_at": _now() - 1},
+        })
+        loaded = _load_refresh_tokens(as_config)
+        assert "fresh" in loaded
+        assert "stale" not in loaded
+
+    def test_corrupt_refresh_tokens_file_treated_as_empty(self, as_config):
+        """Unreadable JSON must not crash the server — affected clients
+        just re-auth, which is the same fallback as losing the dict."""
+        from mnemon.oauth_as import _load_refresh_tokens, _refresh_tokens_path
+
+        _refresh_tokens_path(as_config).write_text("{{not valid json")
+        assert _load_refresh_tokens(as_config) == {}
+
+    @pytest.mark.asyncio
+    async def test_auth_code_survives_simulated_restart(
+        self, as_config, registered_client
+    ):
+        """Issue an auth code via /authorize, simulate a restart, then
+        redeem at /token — must succeed. Covers the edge case where the
+        machine idles between authorize and token steps of an OAuth
+        flow."""
+        from mnemon.oauth_as import (
+            _load_auth_codes,
+            serve_authorize,
+            serve_token,
+        )
+
+        cid = registered_client["client_id"]
+        verifier, challenge = _pkce_pair()
+        form = (
+            f"client_id={cid}&redirect_uri=https://client/cb&"
+            f"response_type=code&code_challenge={challenge}&"
+            f"code_challenge_method=S256&passphrase=correct-horse-battery"
+        ).encode()
+        status, headers, _ = await _run_asgi(
+            serve_authorize, as_config, method="POST", body=form
+        )
+        assert status == 302
+        code = parse_qs(urlparse(headers["location"]).query)["code"][0]
+
+        # Confirm code persisted to disk, not just a dict.
+        assert code in _load_auth_codes(as_config)
+
+        # Simulate restart: in-memory state gone, but file survives.
+        token_body = (
+            f"grant_type=authorization_code&code={code}&"
+            f"redirect_uri=https://client/cb&client_id={cid}&"
+            f"code_verifier={verifier}"
+        ).encode()
+        status, _, resp_body = await _run_asgi(
+            serve_token, as_config, method="POST", body=token_body
+        )
+        assert status == 200, resp_body
+        resp = json.loads(resp_body)
+        assert "access_token" in resp
+
+    def test_auth_codes_file_is_mode_0600(self, as_config):
+        """Auth codes are short-lived but still authorization-grant
+        material; match private-key perms."""
+        from mnemon.oauth_as import _auth_codes_path, _save_auth_codes, _now
+
+        _save_auth_codes(as_config, {
+            "c": {"client_id": "x", "redirect_uri": "https://x/cb",
+                  "code_challenge": "x", "code_challenge_method": "S256",
+                  "scope": "mcp", "subject": "owner",
+                  "expires_at": _now() + 60},
+        })
+        mode = _auth_codes_path(as_config).stat().st_mode & 0o777
+        assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+
+


### PR DESCRIPTION
## Summary

- Fly autostop / deploy / secret-rotation all restart the machine, which wiped the in-memory `_auth_codes` and `_refresh_tokens` dicts. Claude.ai and other MCP clients responded by re-registering via DCR and prompting the user for the passphrase on every wake — visible as 6 stale `clients.json` entries accumulating in ~17 hours of post-cutover production.
- Persist both dicts to `{key_dir}/auth_codes.json` and `{key_dir}/refresh_tokens.json` using the same write-through / atomic-rename / mode 0600 pattern `clients.json` already uses. Expired entries are dropped on load so the files don't grow forever.
- Tests: restart survival via `importlib.reload(oauth_as)`, file perms == 0600, expired entries pruned on load, corrupt JSON falls back to empty. 5 new tests; existing 460-test suite still green.

## Why this unblocks PR #40

PR #40 removes the Auth0 fallback code path. Merging it was gated on 1–2 week soak confirming the self-hosted AS is stable in production. The 6-DCRs-in-17-hours symptom surfaced this morning as a real regression vs. the Auth0 path (Auth0 persists refresh tokens in its own DB). Fixing it before #40 closes the loop on soak cleanly instead of shipping a known UX cliff.

## Test plan

- [x] `pytest tests/test_oauth_as.py` — 77 passed
- [x] Full suite — 460 passed (4 integration tests only run outside sandbox, verified green)
- [ ] Deploy to Fly, run `mnemon doctor`, trigger a Fly restart (`fly machine restart`), re-run `mnemon doctor` — confirms hooks path still works after restart
- [ ] Re-connect claude.ai, search, trigger a Fly restart, search again — confirm NO passphrase prompt on the second search (refresh token survived)
- [ ] Then flip #40 draft → ready, merge, redeploy, verify one more time

🤖 Generated with [Claude Code](https://claude.com/claude-code)