### PR TITLE
chore: remove dead Auth0 env var from fly.toml

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -7,10 +7,7 @@ primary_region = "sjc"
   PORT = "8080"
   MNEMON_VAULT_DIR = "/data"
   MNEMON_PUBLIC_URL = "https://mnemon-memory.fly.dev"
-  MNEMON_OAUTH_AUDIENCE = "https://mnemon-memory.fly.dev/mcp"
   MNEMON_ALLOWED_HOSTS = "mnemon-memory.fly.dev"
-  # MNEMON_OAUTH_ISSUER, MNEMON_OAUTH_JWKS_URL, and MNEMON_OAUTH_USERINFO_URL
-  # are set via `fly secrets set`
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
## Summary

PR #40 removed the Auth0 code path from `src/mnemon/auth.py`, but `fly.toml` still declared `MNEMON_OAUTH_AUDIENCE` plus a comment referencing `MNEMON_OAUTH_ISSUER`/`MNEMON_OAUTH_JWKS_URL`/`MNEMON_OAUTH_USERINFO_URL` as secrets. Nothing reads any of these now — just drift.

No runtime effect. Next deploy will drop the env var from the machine; nothing in the code path notices.

## Test plan
- [x] `grep -r MNEMON_OAUTH_ src/` → empty
- [ ] Deploy, confirm `fly ssh console -C 'env | grep MNEMON_OAUTH'` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)