### PR TITLE
feat: enforce 16-char minimum on MNEMON_AS_PASSPHRASE

### DIFF
--- a/src/mnemon/oauth_as.py
+++ b/src/mnemon/oauth_as.py
@@ -56,6 +56,13 @@ ENV_AS_PASSPHRASE = "MNEMON_AS_PASSPHRASE"
 ENV_PUBLIC_URL = "MNEMON_PUBLIC_URL"
 ENV_KEY_DIR = "MNEMON_AS_KEY_DIR"
 
+# Minimum passphrase length. 16 chars is well below what
+# `secrets.token_urlsafe(32)` produces (43 chars) but above most
+# casually-chosen passwords. The AS has no rate limiting and the
+# passphrase is the only credential gating the entire vault — a
+# brute-force-friendly passphrase defeats the whole self-hosted story.
+_MIN_PASSPHRASE_LEN = 16
+
 # RS256 is the default for OIDC/OAuth 2.1 JWT signing. Don't add alg
 # negotiation — pick one and stick with it.
 JWT_ALG = "RS256"
@@ -127,6 +134,13 @@ class AuthorizationServerConfig:
             problems.append(
                 f"{ENV_AS_PASSPHRASE} must be set when AS is enabled "
                 "(single-user login credential)"
+            )
+        elif len(self.passphrase) < _MIN_PASSPHRASE_LEN:
+            problems.append(
+                f"{ENV_AS_PASSPHRASE} is too short "
+                f"({len(self.passphrase)} chars, minimum {_MIN_PASSPHRASE_LEN}). "
+                "Generate a high-entropy value: "
+                "python -c \"import secrets; print(secrets.token_urlsafe(32))\""
             )
         return problems
 

--- a/tests/test_oauth_as.py
+++ b/tests/test_oauth_as.py
@@ -48,12 +48,12 @@ class TestAuthorizationServerConfig:
     def test_enabled_with_full_config_validates(self, monkeypatch, tmp_path):
         monkeypatch.setenv("MNEMON_AS_ENABLED", "true")
         monkeypatch.setenv("MNEMON_PUBLIC_URL", "https://example.fly.dev")
-        monkeypatch.setenv("MNEMON_AS_PASSPHRASE", "secret")
+        monkeypatch.setenv("MNEMON_AS_PASSPHRASE", "correct-horse-battery-staple")
         monkeypatch.setenv("MNEMON_AS_KEY_DIR", str(tmp_path))
         config = AuthorizationServerConfig.from_env()
         assert config.enabled is True
         assert config.issuer == "https://example.fly.dev"
-        assert config.passphrase == "secret"
+        assert config.passphrase == "correct-horse-battery-staple"
         assert config.key_dir == tmp_path
         assert config.validate() == []
 
@@ -61,6 +61,31 @@ class TestAuthorizationServerConfig:
         """When disabled, the AS has nothing to validate — don't block
         server startup because optional AS vars happen to be empty."""
         config = AuthorizationServerConfig(enabled=False)
+        assert config.validate() == []
+
+    def test_short_passphrase_rejected(self, tmp_path):
+        """The passphrase is the sole credential gating the vault and the
+        AS has no rate limiting. A 6-char passphrase is brute-forceable;
+        require 16+ chars and point users at secrets.token_urlsafe(32)
+        in the error message so they know what to do."""
+        config = AuthorizationServerConfig(
+            enabled=True,
+            public_url="https://example.fly.dev",
+            passphrase="short",  # 5 chars
+            key_dir=tmp_path,
+        )
+        problems = config.validate()
+        assert any("too short" in p for p in problems)
+        assert any("secrets.token_urlsafe" in p for p in problems)
+
+    def test_exactly_16_char_passphrase_accepted(self, tmp_path):
+        """Boundary: 16 chars is the minimum, not 17."""
+        config = AuthorizationServerConfig(
+            enabled=True,
+            public_url="https://example.fly.dev",
+            passphrase="x" * 16,
+            key_dir=tmp_path,
+        )
         assert config.validate() == []
 
     def test_issuer_strips_trailing_slash(self):


### PR DESCRIPTION
## Summary

The AS passphrase is the sole credential gating the entire vault, the AS has no rate limiting, and nothing currently stops a self-host user from setting `MNEMON_AS_PASSPHRASE=password`. That defeats the self-hosted OAuth 2.1 + PKCE + DCR story whose whole pitch is "you don't need a third-party auth vendor."

Validate() now rejects <16 chars with an error that points users directly at `secrets.token_urlsafe(32)` so they know what to do:

```
MNEMON_AS_PASSPHRASE is too short (6 chars, minimum 16).
Generate a high-entropy value: python -c "import secrets; print(secrets.token_urlsafe(32))"
```

16 was chosen because:
- `secrets.token_urlsafe(32)` (the README-recommended generator) yields 43 chars — well above the floor.
- 16 is above most casually-chosen passwords (`password123`, `Summer2026!`).
- Human passphrases ("correct-horse-battery-staple" = 28 chars) easily clear it.

Enforcement sits in `validate()`, which callers check before starting the AS — so a weak passphrase fails fast at boot rather than shipping a broken auth surface.

## ⚠️ Deploy risk — read before merging

**If the currently-live `MNEMON_AS_PASSPHRASE` is <16 chars, the next deploy will refuse to start the AS.** Verify the current Fly secret length before merging. If it's short, rotate to a fresh `secrets.token_urlsafe(32)` value, reconnect claude.ai, then merge this PR. (Our prior rotation used a fresh random value, so this is likely already fine — but worth checking explicitly.)

## Test plan

- [x] `pytest tests/test_oauth_as.py` — 79 pass (77 prior + 2 new: short-passphrase-rejected, exactly-16-accepted)
- [x] `pytest` — 443 pass (existing 441 + 2 new)
- [ ] Before merge: confirm live passphrase is ≥16 chars
- [ ] After merge: `fly deploy` and confirm AS still serves `/.well-known/oauth-authorization-server` (boot succeeded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)