### PR TITLE
docs: CHANGELOG 0.3.0 + 0.4.0 + fly volume --yes tweak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [0.4.0] - 2026-04-14
+
+### Added
+- **Self-hosted OAuth 2.1 Authorization Server** (Phase 2). MCP-compliant `/oauth/authorize`, `/oauth/token`, `/oauth/register` endpoints with PKCE, RS256 JWTs, and RFC 7591 Dynamic Client Registration. No third-party auth vendor required — `fly deploy` gives you a working OAuth-protected MCP endpoint (PRs #36–#39).
+- **Volume-backed persistence for OAuth state.** Auth codes and refresh tokens now persist to `{key_dir}/auth_codes.json` and `{key_dir}/refresh_tokens.json` (mode 0600, atomic write-through) so Fly autostop wake doesn't force every client to re-enter the passphrase (PR #44).
+- **`fly.toml.example` template + self-host runbook in README.** Placeholder-driven config plus an end-to-end walkthrough (`fly launch` → `fly volume create` → secrets → deploy → `mnemon doctor` → client connection) so a new user can stand up a vault in ~10 minutes with zero Fly prior knowledge (PR #46).
+- **16-char minimum on `MNEMON_AS_PASSPHRASE`.** Validated at server boot via `validate()`; error message points at `secrets.token_urlsafe(32)` (PR #47).
+- Auth code + refresh token rotation: one-time-use auth codes, rotation on every refresh.
+
+### Changed
+- **Removed Auth0 / external-AS code path** (PR #40). `OAuthConfig` now only carries `local_token`; `MNEMON_OAUTH_ISSUER` / `JWKS_URL` / `AUDIENCE` / `USERINFO_URL` env vars are gone. The self-hosted AS is the only browser-auth path.
+- `fly.toml` is now gitignored; `fly.toml.example` is the canonical template (PR #46).
+- Test count: 253 → 460.
+
+### Removed
+- Auth0 JWKS validation, userinfo fallback, and all `MNEMON_OAUTH_*` env var parsing.
+- `MNEMON_OAUTH_AUDIENCE` from `fly.toml` (dead after PR #40; PR #45).
+
+## [0.3.0] - 2026-04-13 (not published to PyPI)
+
+### Added
+- **Remote-first architecture unification** (Phase 3). Claude Code hooks (context_surfacing, session_extractor, handoff_generator) rewritten to call the remote Fly vault via Streamable HTTP instead of the local SQLite vault (PRs #25–#30).
+- `MNEMON_LOCAL_TOKEN` static bearer path for headless clients (hooks, Cursor) that can't complete a browser OAuth flow (PR #24).
+- `mnemon setup` CLI: auto-configures Claude Code / Cursor / Gemini with a remote URL and bearer token (PR #28).
+- `mnemon doctor` CLI: six end-to-end diagnostics (remote URL, local token, file perms, health endpoint, auth + MCP tool call, save/search/forget round-trip) (PR #41).
+- Claude Code hook integration tests (PR #34).
+
+### Changed
+- Hooks read `MNEMON_REMOTE_URL` + `MNEMON_LOCAL_TOKEN` (or `~/.mnemon/remote_url` + `~/.mnemon/local_token`) instead of opening a local SQLite file.
+- Dedup in hooks switched from text-parsing to structured `memory_search_structured` MCP tool (PR #33).
+
 ## [0.2.0] - 2026-04-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The real `fly.toml` is gitignored — it holds your specific app identity. `fly.
 
 ```bash
 fly launch --copy-config --no-deploy      # creates the app from your edited fly.toml; no deploy yet
-fly volume create mnemon_data --size 1 --region sjc   # 1GB is enough for thousands of memories; use the same region as primary_region
+fly volume create mnemon_data --size 1 --region sjc --yes   # 1GB fits thousands of memories; match primary_region; --yes skips the single-region-volume confirmation prompt
 ```
 
 Without the volume step, every restart wipes your vault — the `[mounts]` block in `fly.toml` expects `mnemon_data` to exist.


### PR DESCRIPTION
Backfills CHANGELOG.md with 0.3.0 and 0.4.0 entries and fixes the one README friction point caught during the end-to-end dry-run (`fly volume create` was prompting without `--yes`).

Will cut the GitHub release tag (v0.4.0) after this + the upcoming doctor/rate-limit PRs all merge, so the release page points at a stable main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)