### PR TITLE
feat: mnemon doctor exercises OAuth AS metadata

### DIFF
--- a/src/mnemon/doctor.py
+++ b/src/mnemon/doctor.py
@@ -157,6 +157,90 @@ def check_health_endpoint() -> CheckResult:
         )
 
 
+def check_oauth_as_metadata() -> CheckResult:
+    """GET /.well-known/oauth-authorization-server to verify the
+    self-hosted Authorization Server is serving valid RFC 8414 metadata.
+
+    This exercises the browser-client auth path that ``check_auth_and_
+    tool_call`` can't reach — claude.ai, Claude Desktop etc. rely on
+    this endpoint to discover token/authorize URLs. A 404 means
+    ``MNEMON_AS_ENABLED`` is not set (local-token-only deployment —
+    legitimate, but browser clients won't work): warn rather than fail.
+    """
+    try:
+        url = get_remote_url()
+    except RemoteClientConfigError as exc:
+        return CheckResult("OAuth AS metadata", False, str(exc))
+
+    base = url.rstrip("/")
+    if base.endswith("/mcp"):
+        base = base[: -len("/mcp")]
+    metadata_url = f"{base}/.well-known/oauth-authorization-server"
+
+    try:
+        with urllib.request.urlopen(metadata_url, timeout=HEALTH_TIMEOUT_SEC) as resp:
+            status = resp.status
+            body = resp.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return CheckResult(
+                "OAuth AS metadata",
+                True,
+                "AS not enabled (MNEMON_AS_ENABLED unset) — browser clients won't work",
+                warn=True,
+            )
+        return CheckResult(
+            "OAuth AS metadata", False, f"{metadata_url}: HTTP {exc.code}"
+        )
+    except (urllib.error.URLError, socket.timeout, TimeoutError) as exc:
+        return CheckResult("OAuth AS metadata", False, f"{metadata_url}: {exc}")
+
+    if status != 200:
+        return CheckResult(
+            "OAuth AS metadata", False, f"HTTP {status} from {metadata_url}"
+        )
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        return CheckResult(
+            "OAuth AS metadata",
+            False,
+            f"non-JSON body from {metadata_url}: {body[:80]}",
+        )
+
+    required = [
+        "issuer",
+        "authorization_endpoint",
+        "token_endpoint",
+        "registration_endpoint",
+    ]
+    missing = [f for f in required if f not in payload]
+    if missing:
+        return CheckResult(
+            "OAuth AS metadata",
+            False,
+            f"missing required RFC 8414 fields: {', '.join(missing)}",
+        )
+
+    # Issuer must equal the deployment base — mismatches silently break
+    # browser clients by pointing them at the wrong AS. Commonly caused
+    # by a typo in MNEMON_PUBLIC_URL.
+    if payload["issuer"].rstrip("/") != base:
+        return CheckResult(
+            "OAuth AS metadata",
+            False,
+            f"issuer {payload['issuer']!r} ≠ deployment base {base!r} "
+            "(check MNEMON_PUBLIC_URL)",
+        )
+
+    return CheckResult(
+        "OAuth AS metadata",
+        True,
+        f"issuer={payload['issuer']}, "
+        "authorize/token/register endpoints present",
+    )
+
+
 def check_auth_and_tool_call() -> CheckResult:
     """Full MCP handshake + memory_search call. Exercises auth end-to-end."""
     try:
@@ -298,6 +382,7 @@ CHECKS: list[Callable[[], CheckResult]] = [
     check_local_token,
     check_token_file_perms,
     check_health_endpoint,
+    check_oauth_as_metadata,
     check_auth_and_tool_call,
     check_round_trip,
 ]

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -160,6 +160,95 @@ class TestCheckHealthEndpoint:
         assert "degraded" in result.detail
 
 
+# ── check_oauth_as_metadata ─────────────────────────────────────────────────
+
+
+class TestCheckOAuthASMetadata:
+    def _fake_resp(self, status, body):
+        resp = MagicMock()
+        resp.status = status
+        resp.read.return_value = body.encode() if isinstance(body, str) else body
+        resp.__enter__.return_value = resp
+        resp.__exit__.return_value = False
+        return resp
+
+    def test_passes_when_metadata_valid(self, monkeypatch):
+        monkeypatch.setenv("MNEMON_REMOTE_URL", "https://example.fly.dev/mcp")
+        metadata = json.dumps({
+            "issuer": "https://example.fly.dev",
+            "authorization_endpoint": "https://example.fly.dev/oauth/authorize",
+            "token_endpoint": "https://example.fly.dev/oauth/token",
+            "registration_endpoint": "https://example.fly.dev/oauth/register",
+        })
+        with patch("urllib.request.urlopen", return_value=self._fake_resp(200, metadata)) as m:
+            result = doctor.check_oauth_as_metadata()
+        assert result.ok
+        assert not result.warn
+        assert "issuer=https://example.fly.dev" in result.detail
+        # Should have stripped the /mcp suffix before hitting /.well-known/.
+        assert m.call_args[0][0] == \
+            "https://example.fly.dev/.well-known/oauth-authorization-server"
+
+    def test_warns_when_as_not_enabled_404(self, monkeypatch):
+        """MNEMON_AS_ENABLED unset → /.well-known/ returns 404 via HTTPError.
+        Legitimate for a local-token-only deployment; warn, don't fail."""
+        monkeypatch.setenv("MNEMON_REMOTE_URL", "https://example.fly.dev/mcp")
+        import urllib.error
+        err = urllib.error.HTTPError(
+            "url", 404, "Not Found", {}, io.BytesIO(b"")
+        )
+        with patch("urllib.request.urlopen", side_effect=err):
+            result = doctor.check_oauth_as_metadata()
+        assert result.ok
+        assert result.warn
+        assert "AS not enabled" in result.detail
+
+    def test_fails_when_required_fields_missing(self, monkeypatch):
+        monkeypatch.setenv("MNEMON_REMOTE_URL", "https://example.fly.dev/mcp")
+        # Missing registration_endpoint — claude.ai's DCR flow would break.
+        partial = json.dumps({
+            "issuer": "https://example.fly.dev",
+            "authorization_endpoint": "https://example.fly.dev/oauth/authorize",
+            "token_endpoint": "https://example.fly.dev/oauth/token",
+        })
+        with patch("urllib.request.urlopen", return_value=self._fake_resp(200, partial)):
+            result = doctor.check_oauth_as_metadata()
+        assert not result.ok
+        assert "registration_endpoint" in result.detail
+
+    def test_fails_when_issuer_mismatches_base(self, monkeypatch):
+        """Common cause: MNEMON_PUBLIC_URL typo. Silent breakage for browser
+        clients — this is the single highest-value thing the check catches."""
+        monkeypatch.setenv("MNEMON_REMOTE_URL", "https://example.fly.dev/mcp")
+        bad = json.dumps({
+            "issuer": "https://WRONG.fly.dev",
+            "authorization_endpoint": "https://WRONG.fly.dev/oauth/authorize",
+            "token_endpoint": "https://WRONG.fly.dev/oauth/token",
+            "registration_endpoint": "https://WRONG.fly.dev/oauth/register",
+        })
+        with patch("urllib.request.urlopen", return_value=self._fake_resp(200, bad)):
+            result = doctor.check_oauth_as_metadata()
+        assert not result.ok
+        assert "MNEMON_PUBLIC_URL" in result.detail
+
+    def test_fails_on_connection_error(self, monkeypatch):
+        monkeypatch.setenv("MNEMON_REMOTE_URL", "https://example.fly.dev/mcp")
+        import urllib.error
+        with patch("urllib.request.urlopen",
+                   side_effect=urllib.error.URLError("connection refused")):
+            result = doctor.check_oauth_as_metadata()
+        assert not result.ok
+        assert "connection refused" in result.detail
+
+    def test_fails_on_non_json_body(self, monkeypatch):
+        monkeypatch.setenv("MNEMON_REMOTE_URL", "https://example.fly.dev/mcp")
+        with patch("urllib.request.urlopen",
+                   return_value=self._fake_resp(200, "<html>oops</html>")):
+            result = doctor.check_oauth_as_metadata()
+        assert not result.ok
+        assert "non-JSON" in result.detail
+
+
 # ── check_auth_and_tool_call ────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Previously, a self-host user with a misconfigured AS (wrong `MNEMON_PUBLIC_URL`, missing passphrase, key generation failure) saw `mnemon doctor` report 6/6 green because doctor only exercised the local-token path. Browser clients silently 401 despite the all-clear.

New `check_oauth_as_metadata`:
- GETs `/.well-known/oauth-authorization-server`.
- Warns (not fails) on 404 — legitimate for local-token-only deploys where the user never enabled `MNEMON_AS_ENABLED`. Emits a clear note that browser clients won't work.
- Validates required RFC 8414 fields (`issuer`, `authorization_endpoint`, `token_endpoint`, `registration_endpoint`).
- Asserts `issuer` matches the deployment base URL — the single highest-value signal because `MNEMON_PUBLIC_URL` typos cause silent breakage for browser clients with no other surface-level symptom.

## Test plan
- [x] 6 new unit tests covering each failure mode (32 doctor tests pass, was 26)
- [x] Verified against live prod: `mnemon doctor` now reports 7/7 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)