### PR TITLE
feat: rate-limit /oauth/authorize failed attempts per client IP

### DIFF
--- a/src/mnemon/oauth_as.py
+++ b/src/mnemon/oauth_as.py
@@ -315,6 +315,17 @@ _REFRESH_TOKEN_TTL_SEC = 30 * 24 * 3600  # 30 days
 _AUTH_CODES_FILENAME = "auth_codes.json"
 _REFRESH_TOKENS_FILENAME = "refresh_tokens.json"
 
+# Per-IP rate limit on failed /oauth/authorize passphrase attempts.
+# Deliberately in-memory (resets on restart) — this is best-effort
+# brute-force hygiene, not a lockout mechanism that needs to persist.
+# A passphrase generated via `secrets.token_urlsafe(32)` has ~256 bits of
+# entropy so this is belt-and-suspenders, but at 10 tries per 5 minutes
+# per IP it raises the cost of even a 16-char low-entropy passphrase
+# from "seconds on one box" to "years across a distributed botnet."
+_FAILED_ATTEMPT_WINDOW_SEC = 300
+_MAX_FAILED_ATTEMPTS = 10
+_failed_attempts: dict[str, list[float]] = {}
+
 
 def _load_token_file(path: Path, label: str) -> dict[str, dict[str, Any]]:
     """Load a token JSON file, pruning expired entries. Returns {} on any
@@ -608,15 +619,23 @@ def _render_login_form(params: dict[str, str], error: str | None = None) -> byte
     return body
 
 
-async def _send_html(send, status: int, body: bytes) -> None:
+async def _send_html(
+    send,
+    status: int,
+    body: bytes,
+    extra_headers: list[tuple[bytes, bytes]] | None = None,
+) -> None:
+    headers = [
+        (b"content-type", b"text/html; charset=utf-8"),
+        (b"content-length", str(len(body)).encode("ascii")),
+        (b"cache-control", b"no-store"),
+    ]
+    if extra_headers:
+        headers.extend(extra_headers)
     await send({
         "type": "http.response.start",
         "status": status,
-        "headers": [
-            (b"content-type", b"text/html; charset=utf-8"),
-            (b"content-length", str(len(body)).encode("ascii")),
-            (b"cache-control", b"no-store"),
-        ],
+        "headers": headers,
     })
     await send({"type": "http.response.body", "body": body, "more_body": False})
 
@@ -733,8 +752,28 @@ async def serve_authorize(
         })
         return
 
+    # Rate-limit check before examining the passphrase — a brute-forcer
+    # must not be able to drive CPU into constant-time comparison while
+    # over the failure cap.
+    client_ip = _client_ip_from_scope(scope)
+    retry_after = _check_rate_limit(client_ip)
+    if retry_after is not None:
+        from math import ceil
+        headers = [(b"retry-after", str(ceil(retry_after)).encode("ascii"))]
+        await _send_html(
+            send, 429,
+            _render_login_form(
+                {k: v for k, v in params.items() if k != "passphrase"},
+                error=f"Too many failed attempts. Try again in "
+                      f"{ceil(retry_after)}s.",
+            ),
+            extra_headers=headers,
+        )
+        return
+
     passphrase = params.get("passphrase", "")
     if not _verify_passphrase(passphrase, config.passphrase or ""):
+        _record_failed_attempt(client_ip)
         # Re-render form with error — don't redirect back to client with
         # an error code, because that would leak "this URL is a valid
         # OAuth init" to anyone who can read network logs. A re-rendered
@@ -745,6 +784,8 @@ async def serve_authorize(
             _render_login_form(form_params, error="Invalid passphrase.")
         )
         return
+
+    _clear_failed_attempts(client_ip)
 
     # Issue auth code and redirect to client's redirect_uri.
     code = _new_random_token()
@@ -777,6 +818,63 @@ def _verify_passphrase(submitted: str, configured: str) -> bool:
     if not configured:
         return False
     return hmac.compare_digest(submitted, configured)
+
+
+def _client_ip_from_scope(scope: dict) -> str:
+    """Extract best-effort client IP for rate-limit keying.
+
+    On Fly, requests come through fly-proxy and the true client IP is
+    in the ``Fly-Client-IP`` header. Behind other reverse proxies,
+    ``X-Forwarded-For`` is the convention (first entry = original
+    client). Falls back to the ASGI scope's ``client`` tuple for local
+    dev where no proxy is in front.
+
+    Returns ``"unknown"`` if no IP can be determined — still a valid
+    rate-limit key, just lumps all such requests together.
+    """
+    headers = {k.lower(): v for k, v in scope.get("headers", [])}
+    fly_ip = headers.get(b"fly-client-ip")
+    if fly_ip:
+        return fly_ip.decode("latin-1", errors="replace")
+    xff = headers.get(b"x-forwarded-for")
+    if xff:
+        return xff.decode("latin-1", errors="replace").split(",")[0].strip()
+    client = scope.get("client")
+    if client and isinstance(client, (list, tuple)) and client:
+        return str(client[0])
+    return "unknown"
+
+
+def _check_rate_limit(ip: str) -> float | None:
+    """Return seconds-until-retry if ``ip`` is over the failure limit,
+    else None. Prunes stale timestamps inline."""
+    import time
+    now = time.monotonic()
+    cutoff = now - _FAILED_ATTEMPT_WINDOW_SEC
+    attempts = [t for t in _failed_attempts.get(ip, []) if t > cutoff]
+    if not attempts:
+        _failed_attempts.pop(ip, None)
+        return None
+    _failed_attempts[ip] = attempts
+    if len(attempts) >= _MAX_FAILED_ATTEMPTS:
+        # Oldest attempt in the window pins when the oldest will age out.
+        return (attempts[0] + _FAILED_ATTEMPT_WINDOW_SEC) - now
+    return None
+
+
+def _record_failed_attempt(ip: str) -> None:
+    import time
+    _failed_attempts.setdefault(ip, []).append(time.monotonic())
+
+
+def _clear_failed_attempts(ip: str) -> None:
+    """Called on successful passphrase — legitimate users shouldn't
+    carry penalty state from prior typos."""
+    _failed_attempts.pop(ip, None)
+
+
+def _reset_rate_limit_for_tests() -> None:
+    _failed_attempts.clear()
 
 
 # ── /oauth/token ────────────────────────────────────────────────────────────

--- a/tests/test_oauth_as.py
+++ b/tests/test_oauth_as.py
@@ -347,10 +347,10 @@ def _pkce_pair():
     return verifier, challenge
 
 
-async def _run_asgi(handler, config, method="GET", query=b"", body=b""):
+async def _run_asgi(handler, config, method="GET", query=b"", body=b"", headers=None):
     """Invoke an AS ASGI handler and return (status, headers_dict, body_bytes)."""
     scope = {"type": "http", "method": method, "path": "/oauth/test",
-             "query_string": query, "headers": []}
+             "query_string": query, "headers": headers or []}
     sent = []
 
     async def send(msg):
@@ -1361,5 +1361,178 @@ class TestStatePersistence:
         })
         mode = _auth_codes_path(as_config).stat().st_mode & 0o777
         assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+
+
+# ── Rate limiting on /oauth/authorize ───────────────────────────────────────
+
+
+class TestAuthorizeRateLimit:
+    """Per-IP rate limit on failed passphrase attempts.
+
+    The passphrase is single-user and has no second factor, so a bad
+    actor who discovers a deployment URL can brute-force offline-infeasibly-
+    slowly against a wide-open endpoint. 10 failures per 5 min per IP
+    is generous for a legit user fat-fingering while making automated
+    guessing infeasible without a distributed botnet."""
+
+    @pytest.fixture(autouse=True)
+    def reset_rate_limit(self):
+        from mnemon.oauth_as import _reset_rate_limit_for_tests
+        _reset_rate_limit_for_tests()
+        yield
+        _reset_rate_limit_for_tests()
+
+    def _bad_passphrase_form(self, cid, challenge):
+        return (
+            f"client_id={cid}&redirect_uri=https://client/cb&"
+            f"response_type=code&code_challenge={challenge}&"
+            f"code_challenge_method=S256&passphrase=wrong"
+        ).encode()
+
+    def _ip_headers(self, ip):
+        return [(b"fly-client-ip", ip.encode("ascii"))]
+
+    @pytest.mark.asyncio
+    async def test_blocks_after_10_failures_from_same_ip(
+        self, as_config, registered_client
+    ):
+        from mnemon.oauth_as import serve_authorize
+
+        cid = registered_client["client_id"]
+        _, challenge = _pkce_pair()
+        form = self._bad_passphrase_form(cid, challenge)
+        headers = self._ip_headers("198.51.100.1")
+
+        # First 10 return 401 (wrong passphrase, under the cap).
+        for _ in range(10):
+            status, _, _ = await _run_asgi(
+                serve_authorize, as_config,
+                method="POST", body=form, headers=headers,
+            )
+            assert status == 401
+
+        # 11th attempt from same IP hits the cap.
+        status, resp_headers, body = await _run_asgi(
+            serve_authorize, as_config,
+            method="POST", body=form, headers=headers,
+        )
+        assert status == 429
+        assert "retry-after" in resp_headers
+        # Retry-After is a non-negative integer count of seconds.
+        assert resp_headers["retry-after"].isdigit()
+        assert b"Too many failed attempts" in body
+
+    @pytest.mark.asyncio
+    async def test_different_ips_tracked_independently(
+        self, as_config, registered_client
+    ):
+        """One bad actor must not lock out a legit user on a different IP."""
+        from mnemon.oauth_as import serve_authorize
+
+        cid = registered_client["client_id"]
+        _, challenge = _pkce_pair()
+        form = self._bad_passphrase_form(cid, challenge)
+
+        # Exhaust IP A.
+        for _ in range(10):
+            await _run_asgi(
+                serve_authorize, as_config, method="POST",
+                body=form, headers=self._ip_headers("198.51.100.1"),
+            )
+        status, _, _ = await _run_asgi(
+            serve_authorize, as_config, method="POST",
+            body=form, headers=self._ip_headers("198.51.100.1"),
+        )
+        assert status == 429
+
+        # IP B still gets a normal 401 (wrong passphrase).
+        status, _, _ = await _run_asgi(
+            serve_authorize, as_config, method="POST",
+            body=form, headers=self._ip_headers("198.51.100.2"),
+        )
+        assert status == 401
+
+    @pytest.mark.asyncio
+    async def test_successful_login_clears_penalty(
+        self, as_config, registered_client
+    ):
+        """A legit user who fat-fingered a few times and then got it right
+        should not still be counting toward the cap — otherwise the next
+        day they're penalized for something they've already fixed."""
+        from mnemon.oauth_as import serve_authorize, _failed_attempts
+
+        cid = registered_client["client_id"]
+        _, challenge = _pkce_pair()
+        ip = "198.51.100.5"
+        headers = self._ip_headers(ip)
+
+        # Two wrong attempts.
+        for _ in range(2):
+            await _run_asgi(
+                serve_authorize, as_config, method="POST",
+                body=self._bad_passphrase_form(cid, challenge),
+                headers=headers,
+            )
+        assert len(_failed_attempts.get(ip, [])) == 2
+
+        # One correct attempt clears the counter.
+        good_form = (
+            f"client_id={cid}&redirect_uri=https://client/cb&"
+            f"response_type=code&code_challenge={challenge}&"
+            f"code_challenge_method=S256&passphrase=correct-horse-battery"
+        ).encode()
+        status, _, _ = await _run_asgi(
+            serve_authorize, as_config, method="POST",
+            body=good_form, headers=headers,
+        )
+        assert status == 302
+        assert ip not in _failed_attempts
+
+    @pytest.mark.asyncio
+    async def test_old_attempts_age_out(self, as_config, registered_client):
+        """After the window elapses, prior failures don't count any more."""
+        from mnemon.oauth_as import (
+            serve_authorize,
+            _failed_attempts,
+            _FAILED_ATTEMPT_WINDOW_SEC,
+        )
+
+        cid = registered_client["client_id"]
+        _, challenge = _pkce_pair()
+        ip = "198.51.100.9"
+        headers = self._ip_headers(ip)
+
+        # Manually seed 10 stale failures (older than the window).
+        import time
+        stale_ts = time.monotonic() - (_FAILED_ATTEMPT_WINDOW_SEC + 10)
+        _failed_attempts[ip] = [stale_ts] * 10
+
+        # Next attempt should succeed to 401 (wrong passphrase) not 429,
+        # because the prior failures aged out of the window.
+        status, _, _ = await _run_asgi(
+            serve_authorize, as_config, method="POST",
+            body=self._bad_passphrase_form(cid, challenge),
+            headers=headers,
+        )
+        assert status == 401
+
+    @pytest.mark.asyncio
+    async def test_x_forwarded_for_falls_back_when_fly_header_absent(
+        self, as_config, registered_client
+    ):
+        """Deploys not behind Fly should still get per-IP tracking via XFF."""
+        from mnemon.oauth_as import serve_authorize, _failed_attempts
+
+        cid = registered_client["client_id"]
+        _, challenge = _pkce_pair()
+        # XFF can hold multiple hops — first is the original client.
+        headers = [(b"x-forwarded-for", b"203.0.113.7, 10.0.0.1")]
+
+        await _run_asgi(
+            serve_authorize, as_config, method="POST",
+            body=self._bad_passphrase_form(cid, challenge),
+            headers=headers,
+        )
+        assert "203.0.113.7" in _failed_attempts
 
 


### PR DESCRIPTION
## Summary

The passphrase is the sole credential gating the vault and the AS had no throttling on the `/oauth/authorize` endpoint. A bad actor who found a deployment URL could brute-force even a 16-char passphrase faster than the cryptographic floor suggests (parallel connections, no delay between tries).

Adds a per-IP failure counter:
- **10 failures per 5-min sliding window** per source IP.
- In-memory only — best-effort hygiene, not durable lockout. Resets cleanly on restart.
- **Source IP extraction**: `Fly-Client-IP` (Fly-proxy, preferred) → `X-Forwarded-For` (generic reverse proxy, first hop) → `scope["client"][0]` (local/direct).
- Wrong passphrase increments; **correct passphrase clears the counter** — legit fat-fingering doesn't accumulate across sessions.
- Over-cap returns **HTTP 429** with a `Retry-After` header and a re-rendered login form showing the remaining wait time.

`_send_html` gains an `extra_headers` arg so the 429 can carry `Retry-After` without a second helper.

## Why in-memory / why not Redis

This is personal-scale self-hosted infra. A restart every few days resets the counter — acceptable given a committed attacker would outlast any in-memory window anyway. Redis adds an operational dependency for what is fundamentally a best-effort defense against opportunistic scanners, not determined adversaries.

## Test plan
- [x] 5 new unit tests: cap enforcement, per-IP isolation, window aging, success-clears-penalty, XFF fallback
- [x] `pytest tests/test_oauth_as.py` — 84 pass (was 79)
- [x] Full suite — 448 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)