### PR TITLE
release: v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.4.1] - 2026-04-14
+
+### Added
+- **`mnemon doctor` exercises the OAuth AS metadata endpoint** (PR #49). Fetches `/.well-known/oauth-authorization-server`, validates required RFC 8414 fields, asserts `issuer` matches deployment base URL. Catches silent browser-client breakage from `MNEMON_PUBLIC_URL` typos that the local-token path doesn't surface. Warns (not fails) when the AS isn't enabled — legitimate for local-token-only deploys.
+- **Per-IP rate limit on failed `/oauth/authorize` attempts** (PR #50). 10 failures per 5-minute sliding window returns HTTP 429 with `Retry-After`. Correct passphrase clears the counter. Client IP resolved from `Fly-Client-IP` → `X-Forwarded-For` → `scope["client"][0]`.
+
+### Changed
+- `CHANGELOG.md` backfilled with 0.3.0 and 0.4.0 entries (PR #48).
+- `fly volume create` command in README's self-host runbook now includes `--yes` to skip the single-region-volume confirmation prompt (PR #48).
+
 ## [0.4.0] - 2026-04-14
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ src/mnemon/
 ```bash
 # Development
 pip install -e ".[dev]"         # Install with dev deps
-pytest                          # Run tests (102 tests)
+pytest                          # Run tests (460 tests)
 pytest -v                       # Verbose output
 pytest tests/test_store.py      # Single file
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Tests](https://img.shields.io/badge/tests-460_passing-brightgreen.svg)]()
 [![Coverage](https://img.shields.io/badge/coverage-90%25-brightgreen.svg)]()
 [![MCP](https://img.shields.io/badge/MCP-compatible-blueviolet.svg)](https://modelcontextprotocol.io)
-[![PyPI](https://img.shields.io/badge/PyPI-v0.4.0-blue.svg)](https://pypi.org/project/mnemon-memory/)
+[![PyPI](https://img.shields.io/badge/PyPI-v0.4.1-blue.svg)](https://pypi.org/project/mnemon-memory/)
 
 > Universal long-term memory layer for AI agents via [MCP](https://modelcontextprotocol.io).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.4.0"
+version = "0.4.1"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/src/mnemon/oauth_as.py
+++ b/src/mnemon/oauth_as.py
@@ -16,13 +16,9 @@ What's implemented
   server-side for later verification.
 - ``/oauth/token`` — authorization_code and refresh_token grants. RS256
   JWT access tokens, opaque refresh tokens with rotation.
+- ``/register`` — Dynamic Client Registration per RFC 7591. Browser
+  clients self-register; no manual client provisioning.
 - Feature flag ``MNEMON_AS_ENABLED``. Off by default.
-
-Out of scope (future PRs)
--------------------------
-- ``/register`` (DCR, RFC 7591) — PR #38
-- Switch resource-server middleware to verify self-hosted tokens — PR #39
-- Remove Auth0 env vars from production config — PR #40
 
 Design notes
 ------------
@@ -31,8 +27,7 @@ Design notes
   setup-time passphrase (``MNEMON_AS_PASSPHRASE``). No signup UI, no
   password reset, no account recovery — intentional scope reduction for
   personal self-host. Multi-user is explicitly out of scope indefinitely.
-- **RS256 signing.** Standard for OIDC/OAuth 2.1; matches what Auth0 was
-  doing, so Phase 2 cutover doesn't break existing client assumptions.
+- **RS256 signing.** Standard for OIDC/OAuth 2.1.
 - **Key storage on Fly volume.** ``/data/oauth_keys/private.pem`` persists
   across deploys because the volume does. If the volume is destroyed,
   all issued tokens become invalid — acceptable for personal use; in
@@ -49,8 +44,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# Environment variable names — keep these provider-agnostic so Phase 2
-# swap from Auth0 to self-hosted is env-var-only, no code changes.
+# Environment variable names.
 ENV_AS_ENABLED = "MNEMON_AS_ENABLED"
 ENV_AS_PASSPHRASE = "MNEMON_AS_PASSPHRASE"
 ENV_PUBLIC_URL = "MNEMON_PUBLIC_URL"
@@ -75,7 +69,9 @@ class AuthorizationServerConfig:
     Attributes:
         enabled: whether the AS is active. When False, all AS endpoints
             (well-known metadata, JWKS, /authorize, /token, /register)
-            return 404 and the resource server stays on Auth0.
+            return 404. Browser clients cannot authenticate; the
+            resource server still accepts ``MNEMON_LOCAL_TOKEN`` bearer
+            auth for headless clients.
         public_url: externally-reachable base URL (e.g.,
             ``https://mnemon-memory.fly.dev``). Used to build issuer
             claim and endpoint URLs in metadata documents.

--- a/src/mnemon/server_remote.py
+++ b/src/mnemon/server_remote.py
@@ -78,10 +78,11 @@ def run_remote() -> None:
 
     config = OAuthConfig.from_env()
 
-    # Self-hosted Authorization Server config (Phase 2 scaffolding). When
-    # MNEMON_AS_ENABLED=true, the well-known AS metadata + JWKS endpoints
-    # are served. The token-issuing endpoints themselves are not yet
-    # implemented — coming in PR #37.
+    # Self-hosted Authorization Server. When MNEMON_AS_ENABLED=true, the
+    # well-known AS metadata, JWKS, /authorize, /token, and /register
+    # endpoints are served. Browser MCP clients (claude.ai, Claude
+    # Desktop) authenticate via DCR + PKCE against these endpoints;
+    # headless clients (hooks, Cursor) use MNEMON_LOCAL_TOKEN instead.
     from .oauth_as import AuthorizationServerConfig
 
     as_config = AuthorizationServerConfig.from_env()


### PR DESCRIPTION
Version bump + CHANGELOG entry. Contents:
- #48 (CHANGELOG + fly volume --yes)
- #49 (doctor AS metadata check)
- #50 (authorize rate limit)

Merge → build → twine upload → tag → GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)