### PR TITLE
fix: log instead of swallow at four silent except-pass sites

### DIFF
--- a/src/mnemon/search.py
+++ b/src/mnemon/search.py
@@ -8,12 +8,15 @@ alternative search terms. Falls back to BM25-only when vectors unavailable.
 
 from __future__ import annotations
 
+import logging
 import math
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from .config import COMPOSITE_WEIGHTS, MMR_THRESHOLD, RECENCY_HALF_LIFE_DAYS, RRF_K
 from .store import SearchResult, Store
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -205,8 +208,15 @@ def search(
             from .embedder import embed
             query_embedding = embed(f"query: {query}")
             vector_results = store.search_vector(query_embedding, limit * 2)
-        except Exception:
-            pass  # Fall back to BM25-only
+        except Exception as exc:
+            # BM25 still serves results — but we need the cause visible so
+            # "why is semantic search suddenly missing obvious matches?"
+            # isn't an invisible bug. Most common cause is an embedder
+            # model load failure after a fresh install or model upgrade.
+            logger.warning(
+                "search: vector path failed (%s: %s); falling back to BM25-only",
+                type(exc).__name__, exc,
+            )
 
     # Snapshot cosine similarities by doc_id before RRF fusion flattens
     # the scores into opaque RRF values. Needed so downstream clients can

--- a/src/mnemon/server.py
+++ b/src/mnemon/server.py
@@ -8,6 +8,7 @@ Tools: memory_search, memory_get, memory_save, memory_pin, memory_forget,
 from __future__ import annotations
 
 import json
+import logging
 import os
 
 from mcp.server.fastmcp import FastMCP
@@ -16,6 +17,8 @@ from mcp.server.transport_security import TransportSecuritySettings
 from .config import CONTENT_TYPE_VALUES
 from .search import search
 from .store import Store
+
+logger = logging.getLogger(__name__)
 
 
 def _build_transport_security() -> TransportSecuritySettings | None:
@@ -191,14 +194,20 @@ def memory_save(
         source_client=source_client,
     )
 
-    # Embed asynchronously (non-blocking, failures are non-fatal)
+    # Embed asynchronously (non-blocking, failures are non-fatal — the
+    # memory is in SQLite either way; only semantic search is affected).
     try:
         from .embedder import embed_document
         doc = store.get(doc_id)
         if doc:
             embed_document(store, doc.hash, title, content)
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning(
+            "memory_save: embedding failed for doc_id=%d (%s: %s); "
+            "memory is saved but won't surface in vector search until "
+            "`mnemon rebuild` runs",
+            doc_id, type(exc).__name__, exc,
+        )
 
     return f'Saved memory #{doc_id}: "{title}" [{content_type}]'
 
@@ -353,8 +362,13 @@ def profile_update(title: str, content: str) -> str:
         doc = store.get(doc_id)
         if doc:
             embed_document(store, doc.hash, title, content)
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning(
+            "profile_update: embedding failed for doc_id=%d (%s: %s); "
+            "preference is saved but won't surface in vector search until "
+            "`mnemon rebuild` runs",
+            doc_id, type(exc).__name__, exc,
+        )
 
     return f'Profile updated — saved preference #{doc_id}: "{title}"'
 

--- a/src/mnemon/vecstore.py
+++ b/src/mnemon/vecstore.py
@@ -6,9 +6,12 @@ Sub-millisecond search for <10k documents. No native extensions needed.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 
 class VecStore:
@@ -105,11 +108,24 @@ class VecStore:
             data = np.load(str(npz_path), allow_pickle=True)
             dim = int(data["dim"])
             if dim != self.dim:
+                logger.warning(
+                    "vecstore: %s has dim=%d, expected %d — ignoring file. "
+                    "Run `mnemon rebuild` after a model dimension change.",
+                    npz_path, dim, self.dim,
+                )
                 return
             ids = data["ids"].tolist()
             vectors = data["vectors"]
             if len(ids) > 0 and vectors.shape[0] == len(ids):
                 self._ids = ids
                 self._vectors = vectors.astype(np.float32)
-        except Exception:
-            pass
+        except Exception as exc:
+            # File exists but is corrupt or unreadable. Silently proceeding
+            # with an empty store would mean every memory loses semantic
+            # search until the user notices results are degraded — log
+            # loudly so a fresh server boot makes the cause obvious.
+            logger.warning(
+                "vecstore: failed to load %s (%s: %s); starting with empty "
+                "in-memory store. Run `mnemon rebuild` to re-embed.",
+                npz_path, type(exc).__name__, exc,
+            )


### PR DESCRIPTION
Per the no-silent-fails preference, every fallback path should log its trigger. Four sites were swallowing exceptions silently — including two where data partially didn't get persisted (memory saved to SQLite but vector indexing failed) without any signal to the operator.

Now log at WARNING level with enough context (exception type, message, doc_id where applicable, recovery instruction) to debug without re-running.

## Changed
- `search.py:208` — vector path failure → BM25-only. Logs cause.
- `vecstore.py:114` — corrupt .npz on startup → empty store. Logs cause + suggests `mnemon rebuild`.
- `vecstore.py:107` — dim mismatch (already early-return). Logs the mismatch.
- `server.py:200` (`memory_save`) — embedding failure. Logs doc_id + rebuild instruction. Tool response unchanged — semantic-only failure isn't worth surfacing to the MCP client.
- `server.py:356` (`profile_update`) — same pattern, same fix.

## Audited and left as-is
- `llm.py:71` — optional huggingface_hub dep missing → falls through to raised FileNotFoundError with install instructions.
- `_remote_client.py:82, :106` — file read fallthrough → raises RemoteClientConfigError with remediation.

Both have loud terminal error paths; logging intermediate attempts would just be noise.

## Test plan
- [x] `pytest` — 454 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)