### PR TITLE
docs: README opener rewrite + privacy statement + SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,15 @@
 [![MCP](https://img.shields.io/badge/MCP-compatible-blueviolet.svg)](https://modelcontextprotocol.io)
 [![PyPI](https://img.shields.io/badge/PyPI-v0.4.1-blue.svg)](https://pypi.org/project/mnemon-memory/)
 
-> Universal long-term memory layer for AI agents via [MCP](https://modelcontextprotocol.io).
+> One memory vault. Every MCP client. Self-hosted, no third-party auth.
 
-mnemon gives AI agents persistent, searchable memory that survives across sessions. It uses hybrid BM25 + vector search, automatic confidence decay, and contradiction detection via the Model Context Protocol. Deploy as a remote server on Fly.io for a unified vault across all your MCP clients (Claude Code, Claude Desktop, Cursor, claude.ai), or run locally for development.
+Claude Code remembers your architecture decisions. Cursor remembers your API conventions. claude.ai web/mobile/desktop remembers your project context. All from a single vault you own and run.
+
+mnemon is a [Model Context Protocol](https://modelcontextprotocol.io) server with hybrid BM25 + vector search, automatic confidence decay, and contradiction detection. Deploy as a remote server on Fly.io (~$1/mo for a personal vault) or run locally for development. Browser clients authenticate via self-hosted OAuth 2.1 + PKCE — no Auth0, Clerk, or other third-party auth vendor required.
+
+**Privacy:** mnemon sends no telemetry. Your vault never leaves your server. Embeddings run locally via FastEmbed. The optional LLM (1.7B params) runs on-device via llama.cpp. The only outbound calls are: (a) the FastEmbed model download on first run, (b) optional S3 vault sync if you configure it, and (c) `huggingface-hub` to fetch the optional LLM weights.
+
+**Platforms:** Tested on macOS 14+. Linux should work — Python + SQLite + FastEmbed are portable. Windows untested.
 
 ## Table of Contents
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you find a security vulnerability in mnemon, please report it privately:
+
+- **Preferred:** open a [GitHub Security Advisory](https://github.com/cipher813/mnemon/security/advisories/new). This keeps the discussion private until a fix ships.
+- **Alternative:** email `security@nousergon.ai` with a description and reproduction steps.
+
+Please **do not** open a public issue for security reports. I aim to acknowledge within 72 hours and ship a fix or mitigation within 14 days for high-severity issues.
+
+## Scope
+
+mnemon is a self-hosted single-user memory server. The following are in scope:
+
+- **Authentication bypass**: any path that lets an unauthenticated request reach an MCP tool or the SQLite vault.
+- **OAuth flow flaws**: PKCE downgrade, code/token leakage, JWT signature verification gaps, DCR abuse, replay attacks.
+- **Injection or escalation**: SQL injection, path traversal, command injection in any of the CLI tools or hooks.
+- **Cryptographic mistakes**: weak key generation, insecure storage of `private.pem`, refresh token predictability, timing attacks on passphrase comparison.
+- **Vault data exposure**: any path that lets one self-host user read another's vault, or that leaks vault contents through error messages, logs, or unauthenticated endpoints.
+
+The following are **out of scope**:
+
+- DoS via traffic volume (single-user infrastructure; rate-limit it yourself if you expose to the public internet).
+- Self-XSS in the passphrase login form (it's a single-user form; no other user to attack).
+- Issues that require local filesystem or process access (the SQLite vault and `private.pem` are protected by file-system permissions; if your machine is compromised, mnemon's threat model has already failed).
+- Vulnerabilities in upstream dependencies that have not been disclosed publicly — please report those to the upstream project first.
+
+## Threat model assumptions
+
+mnemon is designed for the **single-user self-host** case. Important assumptions:
+
+- The server owner is the sole authorized principal. There is no multi-user model and no plan to add one.
+- The `MNEMON_AS_PASSPHRASE` is the only credential gating browser-client access. A `secrets.token_urlsafe(32)`-class value is required (16-char minimum enforced at boot); shorter passphrases break the security model.
+- The `MNEMON_LOCAL_TOKEN` is a static bearer for headless clients (Claude Code hooks, Cursor) and bypasses OAuth entirely. Treat it as equivalent to a vault-master key.
+- The Fly volume holding `private.pem`, `clients.json`, `refresh_tokens.json`, and the SQLite vault is assumed to be encrypted at rest by Fly. Local deploys (or other hosts) inherit whatever the underlying disk encryption provides.
+- Network transport is HTTPS-only in production (`force_https = true` in `fly.toml`). HTTP is dev-only.
+
+## Hardening recommendations for self-hosters
+
+- Generate `MNEMON_LOCAL_TOKEN` and `MNEMON_AS_PASSPHRASE` with `secrets.token_urlsafe(32)` and store them in a password manager. Never reuse credentials across deployments.
+- Set `MNEMON_ALLOWED_HOSTS` to your exact deployment hostname (DNS-rebinding protection).
+- Run `mnemon doctor` after every deploy and verify all 7 checks pass.
+- Back up the Fly volume (`/data/oauth_keys/` + the SQLite vault) regularly, or enable S3 vault sync.
+- If `private.pem` is ever exposed, delete it from `/data/oauth_keys/`, restart the server (a new key auto-generates on boot), and reconnect every browser client. All previously-issued JWTs become unverifiable.


### PR DESCRIPTION
Pre-release polish bundle. Three README changes to the first impression + a new SECURITY.md for self-host auditors.

## README

- **Tagline rewrite** from abstract to concrete: "Claude Code remembers your architecture decisions. Cursor remembers your API conventions. claude.ai remembers your project context." Makes the value prop land in 10 seconds. The previous "persistent, searchable memory that survives across sessions" was technically correct but made you read 30s before understanding what mnemon does.
- **Privacy statement** near the top: no telemetry, vault never leaves your server, embeddings + optional LLM run locally. Enumerates the three legitimate outbound calls so nothing is hidden.
- **Platform note**: macOS-tested, Linux should work, Windows untested. Better than silent.

## SECURITY.md (new)

- Reporting channels (GitHub Security Advisory preferred, email fallback) with 72h ack and 14-day high-severity fix target.
- Scope enumeration — what we want to hear about, what we don't, so triage is fast.
- Threat model assumptions surfaced: single-user, passphrase is sole browser credential, MNEMON_LOCAL_TOKEN is vault-master-equivalent.
- Hardening checklist for self-hosters: random secrets, ALLOWED_HOSTS, run `mnemon doctor` post-deploy, backup the volume, recover from `private.pem` compromise.

GitHub auto-detects `SECURITY.md` and adds a "Security" tab to the repo, so no README link needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)