### PR TITLE
fix: doctor memory_forget + config consolidation + small polish

### DIFF
--- a/src/mnemon/config.py
+++ b/src/mnemon/config.py
@@ -62,10 +62,18 @@ DEFAULT_CONFIDENCE: dict[ContentType, float] = {
 
 # Scoring constants
 RRF_K = 60
-MMR_THRESHOLD = 0.6
+MMR_THRESHOLD = 0.6                    # bigram Jaccard ≥ this → candidate is "too similar" to a selected result
+MMR_DEMOTION_FACTOR = 0.5              # composite-score multiplier applied to MMR-demoted results
 COMPOSITE_WEIGHTS = (0.5, 0.25, 0.25)  # (relevance, recency, confidence)
 RECENCY_HALF_LIFE_DAYS = 30
 PIN_BOOST = 0.3
+
+# Query expansion
+QUERY_EXPANSION_MAX_TOKENS = 200       # LLM token cap for alt-query generation
+
+# Contradiction detection
+CONTRADICTION_OVERLAP_THRESHOLD = 0.7  # minimum vector similarity to treat candidate as potentially conflicting
+CONTRADICTION_CONTEXT_MAX_CHARS = 500  # per-memory content truncation in the LLM classification prompt
 
 # Hook timeouts and budgets (seconds / chars)
 #

--- a/src/mnemon/contradiction.py
+++ b/src/mnemon/contradiction.py
@@ -17,10 +17,16 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING
 
+from .config import (
+    CONTRADICTION_CONTEXT_MAX_CHARS,
+    CONTRADICTION_OVERLAP_THRESHOLD,
+    DEFAULT_CONFIDENCE,
+    HALF_LIVES,
+)
+
 if TYPE_CHECKING:
     from .store import SearchResult, Store
 
-OVERLAP_THRESHOLD = 0.7  # minimum vector similarity to consider overlapping
 UPDATE_DECAY = 0.15      # confidence reduction for superseded memories
 CONTRADICTION_DECAY = 0.25
 CONFIDENCE_FLOOR = 0.2
@@ -62,7 +68,7 @@ def check_contradictions(
     # Filter to genuinely overlapping results (exclude self)
     candidates = [
         r for r in overlapping
-        if r.doc_id != new_doc_id and r.score >= OVERLAP_THRESHOLD
+        if r.doc_id != new_doc_id and r.score >= CONTRADICTION_OVERLAP_THRESHOLD
     ]
 
     if not candidates:
@@ -78,9 +84,9 @@ def check_contradictions(
         try:
             prompt = (
                 f"Existing memory:\nTitle: {candidate.title}\n"
-                f"Content: {candidate.content[:500]}\n\n"
+                f"Content: {candidate.content[:CONTRADICTION_CONTEXT_MAX_CHARS]}\n\n"
                 f"New memory:\nTitle: {new_title}\n"
-                f"Content: {new_content[:500]}"
+                f"Content: {new_content[:CONTRADICTION_CONTEXT_MAX_CHARS]}"
             )
 
             response = generate(CLASSIFY_SYSTEM_PROMPT, prompt, max_tokens=10)
@@ -131,8 +137,6 @@ def check_contradictions(
 
 # ── Confidence Decay ────────────────────────────────────────────────────────
 
-from .config import DEFAULT_CONFIDENCE, HALF_LIVES  # noqa: E402
-
 
 def apply_confidence_decay(store: "Store") -> int:
     """Apply time-based confidence decay to all documents.
@@ -166,7 +170,11 @@ def apply_confidence_decay(store: "Store") -> int:
 
             # Exponential decay: base_confidence * 2^(-age/halflife)
             decay_factor = math.pow(2, -row["age_days"] / effective_half_life)
-            base_confidence = DEFAULT_CONFIDENCE.get(content_type, 0.5)
+            # Strict lookup — every ContentType has an explicit mapping in
+            # config.DEFAULT_CONFIDENCE, so a KeyError here means someone
+            # added an enum value without updating the map. Fail loud
+            # instead of silently falling back to a made-up 0.5.
+            base_confidence = DEFAULT_CONFIDENCE[content_type]
             decayed_confidence = max(CONFIDENCE_FLOOR, base_confidence * decay_factor)
 
             # Only update if confidence changed meaningfully

--- a/src/mnemon/doctor.py
+++ b/src/mnemon/doctor.py
@@ -343,7 +343,7 @@ def check_round_trip() -> CheckResult:
     try:
         call_tool_sync(
             "memory_forget",
-            {"document_id": doc_id},
+            {"id": doc_id},
             timeout=MCP_TIMEOUT_SEC,
             client_label="mnemon-doctor",
         )
@@ -367,7 +367,7 @@ def _best_effort_forget(doc_id: int) -> None:
     try:
         call_tool_sync(
             "memory_forget",
-            {"document_id": doc_id},
+            {"id": doc_id},
             timeout=MCP_TIMEOUT_SEC,
             client_label="mnemon-doctor",
         )

--- a/src/mnemon/llm.py
+++ b/src/mnemon/llm.py
@@ -8,9 +8,12 @@ Phase 3: local LLM integration (replaces Phase 2 regex heuristics).
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 MODEL_REPO = "tobil/qmd-query-expansion-1.7B-gguf"
 MODEL_FILE = "qmd-query-expansion-1.7B-q4_k_m.gguf"
@@ -118,11 +121,11 @@ def try_generate(
 ) -> str | None:
     """Try to generate an LLM response, returning None if unavailable.
 
-    Unifies the try-import, check-available, generate-or-fail pattern
-    duplicated across ``session_extractor.extract_with_llm``,
-    ``handoff_generator.generate_with_llm``, and ``search.expand_query``.
-    Each caller still does its own parsing of the returned text; this
-    helper only covers the "is the LLM usable right now" plumbing.
+    Unifies the check-available / generate / fall-back plumbing shared
+    by the LLM-using callers (``search.expand_query``,
+    ``hooks.session_extractor``, ``hooks.handoff_generator``). Each
+    caller still does its own parsing of the returned text; this helper
+    only covers the "is the LLM usable right now" plumbing.
 
     Returns:
         The raw LLM output string, or None if the backend is unavailable
@@ -133,5 +136,10 @@ def try_generate(
         if not is_available():
             return None
         return generate(system_prompt, user_message, max_tokens=max_tokens)
-    except Exception:
+    except Exception as exc:
+        # LLM is optional infra — callers treat None as "fall back to
+        # regex/empty". But silent failure hides model crashes, OOMs,
+        # and llama-cpp version mismatches from the operator. Log once
+        # per failure so degradation is visible.
+        logger.warning("try_generate: LLM call failed (%s: %s)", type(exc).__name__, exc)
         return None

--- a/src/mnemon/search.py
+++ b/src/mnemon/search.py
@@ -13,7 +13,14 @@ import math
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
-from .config import COMPOSITE_WEIGHTS, MMR_THRESHOLD, RECENCY_HALF_LIFE_DAYS, RRF_K
+from .config import (
+    COMPOSITE_WEIGHTS,
+    MMR_DEMOTION_FACTOR,
+    MMR_THRESHOLD,
+    QUERY_EXPANSION_MAX_TOKENS,
+    RECENCY_HALF_LIFE_DAYS,
+    RRF_K,
+)
 from .store import SearchResult, Store
 
 logger = logging.getLogger(__name__)
@@ -110,9 +117,8 @@ def mmr_rerank(results: list[ScoredResult]) -> list[ScoredResult]:
         if too_similar:
             selected.append(ScoredResult(
                 **{k: getattr(candidate, k) for k in candidate.__dataclass_fields__},
-                # Demote by 50%
             ))
-            selected[-1].composite_score = candidate.composite_score * 0.5
+            selected[-1].composite_score = candidate.composite_score * MMR_DEMOTION_FACTOR
         else:
             selected.append(candidate)
 
@@ -166,7 +172,7 @@ def expand_query(query: str) -> list[str]:
         "Keep them short and diverse — include synonyms, related concepts, "
         "and different phrasings.",
         query,
-        max_tokens=200,
+        max_tokens=QUERY_EXPANSION_MAX_TOKENS,
     )
     if response is None:
         return []

--- a/src/mnemon/store.py
+++ b/src/mnemon/store.py
@@ -194,7 +194,7 @@ class Store:
         content_hash = _sha256(content)
         ct = ContentType(content_type)
         mt = MEMORY_TYPE_MAP.get(ct, MemoryType.SEMANTIC)
-        conf = confidence if confidence is not None else DEFAULT_CONFIDENCE.get(ct, 0.5)
+        conf = confidence if confidence is not None else DEFAULT_CONFIDENCE[ct]
 
         # Upsert content (idempotent)
         self.db.execute(

--- a/tests/test_contradiction.py
+++ b/tests/test_contradiction.py
@@ -8,12 +8,12 @@ from unittest.mock import patch, MagicMock
 import numpy as np
 import pytest
 
+from mnemon.config import CONTRADICTION_OVERLAP_THRESHOLD as OVERLAP_THRESHOLD
 from mnemon.store import Store, SearchResult
 from mnemon.contradiction import (
     CONFIDENCE_FLOOR,
     CONTRADICTION_DECAY,
     UPDATE_DECAY,
-    OVERLAP_THRESHOLD,
     check_contradictions,
     apply_confidence_decay,
 )

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -334,7 +334,7 @@ class TestCheckRoundTrip:
         assert not result.ok
         assert "search failed" in result.detail
         # Best-effort cleanup should still have fired
-        assert forget_calls == [{"document_id": 999}]
+        assert forget_calls == [{"id": 999}]
 
     def test_forget_failure_warns_but_passes(self):
         save_response = 'Saved memory #999: "mnemon-doctor-probe-xx"'
@@ -374,7 +374,7 @@ class TestCheckRoundTrip:
 
         assert not result.ok
         assert "not found by search" in result.detail
-        assert forget_calls == [{"document_id": 999}]
+        assert forget_calls == [{"id": 999}]
 
 
 # ── run_doctor end-to-end ───────────────────────────────────────────────────


### PR DESCRIPTION
## The bug that matters

`mnemon doctor`'s round-trip check called `memory_forget` with `{"document_id": doc_id}` but the tool signature is `id: int`. FastMCP returned the param-mismatch as a tool-error payload rather than a raised exception, so the `except Exception` fallback never fired. Doctor has been reporting "doc_id=N saved, found, and forgotten" while actually leaking every probe into the vault. Production accumulated 9 `mnemon-doctor-probe-*` memories today — will clean them up separately.

Fix is two character changes. Tests updated to match. Verified: doctor now reports success AND the vault doesn't grow.

## Config consolidation

Four magic numbers were inline when similar ones already lived in `config.py`. Moved to `config.py` where the tunable surface is discoverable:
- `MMR_DEMOTION_FACTOR = 0.5` (search.py:115)
- `QUERY_EXPANSION_MAX_TOKENS = 200` (search.py:169)
- `CONTRADICTION_OVERLAP_THRESHOLD = 0.7` (renamed from `OVERLAP_THRESHOLD` in contradiction.py:23 to match the scoping scheme)
- `CONTRADICTION_CONTEXT_MAX_CHARS = 500` (contradiction.py:81,83)

## Small polish

- `contradiction.py:169` and `store.py:197` — strict `DEFAULT_CONFIDENCE[ct]` (was `.get(ct, 0.5)`). The ContentType enum has an explicit mapping for every value; the fallback was dead code masking future enum additions.
- `llm.py:try_generate` — log WARNING on LLM failure. Previously silent; LLM is optional but hidden crashes (OOMs, version mismatches) have no operator signal. Also fixed a stale docstring that claimed callers still duplicate the pattern — they all migrated to this helper already.

## Test plan

- [x] `pytest` — 454 pass (same baseline)
- [x] Ran `mnemon doctor` against prod post-fix; forget now works, vault count stable across a second run.
- [ ] Post-merge: data-op cleanup of the 9 leaked probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)