### PR TITLE
refactor: hook error logging + drop unused Store.save path kwarg (v0.4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.4.2] - 2026-04-14
+
+### Fixed
+- **`mnemon doctor` round-trip now actually forgets the probe memory.** Previously called `memory_forget` with wrong kwarg (`document_id` vs `id`); FastMCP returned a tool-error payload rather than raising, so the save/search/forget check always reported success while leaking probe memories into the vault on every run (PR #54).
+
+### Changed
+- `MMR_DEMOTION_FACTOR`, `QUERY_EXPANSION_MAX_TOKENS`, `CONTRADICTION_OVERLAP_THRESHOLD` (renamed from `OVERLAP_THRESHOLD`), and `CONTRADICTION_CONTEXT_MAX_CHARS` moved from inline literals to `config.py`. Tunable surface now discoverable in one file (PR #54).
+- Hook error logging consolidated via `framework.log_hook_error(hook_name, context, exc)`. All three hooks (`context_surfacing`, `session_extractor`, `handoff_generator`) now emit a single greppable format: `mnemon {hook} {context}: {Type}: {message}`. Nine call sites replaced (PR #55).
+- `Store.save()` dropped the unused `path` kwarg. Path was auto-generated in every call; the parameter had no callers. **Minor API break** — removed in 0.4.2 rather than deferring to a major version since 0.4.1 was published for only a few hours with no known external adoption (PR #55).
+- `DEFAULT_CONFIDENCE` lookups in `contradiction.py` and `store.py` switched from `.get(ct, 0.5)` to strict `[ct]`. The enum has an explicit mapping for every value; the fallback was dead code that would mask future enum additions (PR #54).
+- `llm.try_generate` now logs a WARNING on LLM failure instead of silently returning `None`. LLM is optional infra but hidden crashes (OOM, llama-cpp version mismatch) previously had no operator signal (PR #54).
+
 ## [0.4.1] - 2026-04-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Tests](https://img.shields.io/badge/tests-460_passing-brightgreen.svg)]()
 [![Coverage](https://img.shields.io/badge/coverage-90%25-brightgreen.svg)]()
 [![MCP](https://img.shields.io/badge/MCP-compatible-blueviolet.svg)](https://modelcontextprotocol.io)
-[![PyPI](https://img.shields.io/badge/PyPI-v0.4.1-blue.svg)](https://pypi.org/project/mnemon-memory/)
+[![PyPI](https://img.shields.io/badge/PyPI-v0.4.2-blue.svg)](https://pypi.org/project/mnemon-memory/)
 
 > One memory vault. Every MCP client. Self-hosted, no third-party auth.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.4.1"
+version = "0.4.2"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/src/mnemon/hooks/context_surfacing.py
+++ b/src/mnemon/hooks/context_surfacing.py
@@ -93,6 +93,7 @@ def main() -> None:
         from .framework import (
             is_duplicate,
             is_noise,
+            log_hook_error,
             mark_seen,
             read_stdin,
             write_output,
@@ -118,12 +119,13 @@ def main() -> None:
             # visible warning block so the user sees it in the prompt context,
             # not just buried in stderr. Do NOT mark_seen — the user can fix
             # the config and retry the same prompt immediately.
-            msg = f"⚠ mnemon config error: {e}"
-            print(f"mnemon context-surfacing config error: {e}", file=sys.stderr)
+            log_hook_error("context-surfacing", "config error", e)
             write_output({
                 "hookSpecificOutput": {
                     "hookEventName": "UserPromptSubmit",
-                    "additionalContext": build_warning_context(msg),
+                    "additionalContext": build_warning_context(
+                        f"⚠ mnemon config error: {e}"
+                    ),
                 },
             })
             return
@@ -132,15 +134,13 @@ def main() -> None:
             # Emit a visible warning block and log to stderr. Do NOT
             # mark_seen so the same prompt can retry after the transient
             # failure clears (e.g., wifi reconnect, Fly cold-start wakes).
-            msg = f"⚠ mnemon unavailable: {type(e).__name__}: {e}"
-            print(
-                f"mnemon context-surfacing remote error: {type(e).__name__}: {e}",
-                file=sys.stderr,
-            )
+            log_hook_error("context-surfacing", "remote error", e)
             write_output({
                 "hookSpecificOutput": {
                     "hookEventName": "UserPromptSubmit",
-                    "additionalContext": build_warning_context(msg),
+                    "additionalContext": build_warning_context(
+                        f"⚠ mnemon unavailable: {type(e).__name__}: {e}"
+                    ),
                 },
             })
             return
@@ -167,7 +167,13 @@ def main() -> None:
             },
         })
     except Exception as e:
-        print(f"mnemon context-surfacing error: {e}", file=sys.stderr)
+        # log_hook_error may not be importable if the hook crashed before
+        # the import block — write directly to sys.stderr in that tail path.
+        try:
+            from .framework import log_hook_error
+            log_hook_error("context-surfacing", "error", e)
+        except Exception:
+            sys.stderr.write(f"mnemon context-surfacing error: {e}\n")
 
 
 if __name__ == "__main__":

--- a/src/mnemon/hooks/framework.py
+++ b/src/mnemon/hooks/framework.py
@@ -99,6 +99,21 @@ def write_output(output: dict[str, Any]) -> None:
     sys.stdout.flush()
 
 
+def log_hook_error(hook_name: str, context: str, exc: BaseException) -> None:
+    """Write a consistent hook-error line to stderr.
+
+    Format: ``mnemon {hook_name} {context}: {ExceptionType}: {message}``.
+    Used by all three hooks for RemoteClientConfigError, generic remote
+    failures, and outer catch-alls so log lines from different hooks are
+    greppable by a single pattern. Callers handle control flow (return /
+    continue / fallthrough) themselves — this only formats and emits.
+    """
+    sys.stderr.write(
+        f"mnemon {hook_name} {context}: {type(exc).__name__}: {exc}\n"
+    )
+    sys.stderr.flush()
+
+
 def read_transcript(transcript_path: str, max_chars: int = 8000) -> str:
     """Read the last N characters from the transcript JSONL file."""
     if not transcript_path:

--- a/src/mnemon/hooks/handoff_generator.py
+++ b/src/mnemon/hooks/handoff_generator.py
@@ -104,7 +104,7 @@ def generate_with_regex(transcript: str) -> dict | None:
 
 def main() -> None:
     try:
-        from .framework import read_stdin, read_transcript
+        from .framework import log_hook_error, read_stdin, read_transcript
         from ._remote_client import RemoteClientConfigError, call_tool_sync
 
         hook_input = read_stdin()
@@ -133,14 +133,11 @@ def main() -> None:
             )
             print(f'mnemon: saved handoff "{handoff["title"]}"', file=sys.stderr)
         except RemoteClientConfigError as e:
-            print(f"mnemon handoff-generator config error: {e}", file=sys.stderr)
+            log_hook_error("handoff-generator", "config error", e)
         except Exception as e:
-            print(
-                f"mnemon handoff-generator save error: {type(e).__name__}: {e}",
-                file=sys.stderr,
-            )
+            log_hook_error("handoff-generator", "save error", e)
     except Exception as e:
-        print(f"mnemon handoff-generator error: {e}", file=sys.stderr)
+        log_hook_error("handoff-generator", "error", e)
 
 
 if __name__ == "__main__":

--- a/src/mnemon/hooks/session_extractor.py
+++ b/src/mnemon/hooks/session_extractor.py
@@ -167,7 +167,7 @@ def is_duplicate_remote(title: str, content: str) -> bool:
 
 def main() -> None:
     try:
-        from .framework import read_stdin, read_transcript
+        from .framework import log_hook_error, read_stdin, read_transcript
         from ._remote_client import RemoteClientConfigError, call_tool_sync
 
         hook_input = read_stdin()
@@ -206,19 +206,16 @@ def main() -> None:
                 saved += 1
                 print(f'mnemon: saved [{content_type}] "{obs["title"]}"', file=sys.stderr)
             except RemoteClientConfigError as e:
-                print(f"mnemon session-extractor config error: {e}", file=sys.stderr)
+                log_hook_error("session-extractor", "config error", e)
                 return
             except Exception as e:
-                print(
-                    f"mnemon session-extractor save error: {type(e).__name__}: {e}",
-                    file=sys.stderr,
-                )
+                log_hook_error("session-extractor", "save error", e)
                 continue
 
         if saved > 0:
             print(f"mnemon: extracted {saved} observations from session", file=sys.stderr)
     except Exception as e:
-        print(f"mnemon session-extractor error: {e}", file=sys.stderr)
+        log_hook_error("session-extractor", "error", e)
 
 
 if __name__ == "__main__":

--- a/src/mnemon/store.py
+++ b/src/mnemon/store.py
@@ -186,7 +186,6 @@ class Store:
         content: str,
         content_type: str = "note",
         collection: str = "default",
-        path: str | None = None,
         source_client: str | None = None,
         confidence: float | None = None,
     ) -> int:
@@ -215,9 +214,10 @@ class Store:
             self.db.commit()
             return row["id"]
 
-        # Generate path if not provided
-        if path is None:
-            path = f"{content_type}/{int(time.time() * 1000)}-{content_hash[:8]}"
+        # Auto-generate a stable path key — content-addressed, sortable by
+        # creation time. Callers have never needed to override this so the
+        # parameter was removed in 0.4.2.
+        path = f"{content_type}/{int(time.time() * 1000)}-{content_hash[:8]}"
 
         cur = self.db.execute(
             """INSERT INTO documents (collection, path, title, hash, content_type, memory_type, confidence, source_client)


### PR DESCRIPTION
## Changes

**Hook error logging** — the three hooks duplicated `print(f"mnemon <hook> <ctx> error: ...", file=sys.stderr)` across 9 sites with subtly inconsistent formats. Extracted `framework.log_hook_error(hook_name, context, exc)` writing a single greppable line: `mnemon {hook} {context}: {Type}: {message}`.

Callers retain their own control flow (return/continue/fallthrough) — the helper only formats+emits. Net: 9 sites collapsed, one place to evolve logging if/when we move from `sys.stderr` to the logging module.

**Dead code** — `Store.save()` carried a `path: str | None = None` kwarg that every call site left unset. Auto-generated internally in all cases. Removed. Minor API break — 0.4.1 was on PyPI for hours with no known external adoption, cleaner to drop now than defer to a major version.

## Release

- Version bump to `0.4.2`.
- CHANGELOG entry covers this PR plus the #54 fixes.
- README badge updated.

## Test plan

- [x] `pytest` — 454 pass
- [x] `mnemon --version` → `0.4.2`
- [ ] After merge: `fly deploy` → verify `mnemon doctor` still green (hooks aren't exercised by doctor but at least server imports clean)
- [ ] After merge: `python -m build && twine upload`
- [ ] After merge: `git tag v0.4.2 && gh release create v0.4.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)