### PR TITLE
chore: ruff-clean src + version 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## [0.4.2] - 2026-04-14
+## [0.4.3] - 2026-04-14
+
+Rolls up all 0.4.2 changes (which was built but never uploaded to PyPI) plus a final ruff-clean pass.
 
 ### Fixed
 - **`mnemon doctor` round-trip now actually forgets the probe memory.** Previously called `memory_forget` with wrong kwarg (`document_id` vs `id`); FastMCP returned a tool-error payload rather than raising, so the save/search/forget check always reported success while leaking probe memories into the vault on every run (PR #54).
@@ -8,9 +10,15 @@
 ### Changed
 - `MMR_DEMOTION_FACTOR`, `QUERY_EXPANSION_MAX_TOKENS`, `CONTRADICTION_OVERLAP_THRESHOLD` (renamed from `OVERLAP_THRESHOLD`), and `CONTRADICTION_CONTEXT_MAX_CHARS` moved from inline literals to `config.py`. Tunable surface now discoverable in one file (PR #54).
 - Hook error logging consolidated via `framework.log_hook_error(hook_name, context, exc)`. All three hooks (`context_surfacing`, `session_extractor`, `handoff_generator`) now emit a single greppable format: `mnemon {hook} {context}: {Type}: {message}`. Nine call sites replaced (PR #55).
-- `Store.save()` dropped the unused `path` kwarg. Path was auto-generated in every call; the parameter had no callers. **Minor API break** — removed in 0.4.2 rather than deferring to a major version since 0.4.1 was published for only a few hours with no known external adoption (PR #55).
+- `Store.save()` dropped the unused `path` kwarg. Path was auto-generated in every call; the parameter had no callers. **Minor API break** — removed rather than deferring to a major version since 0.4.1 was published for only a few hours with no known external adoption (PR #55).
 - `DEFAULT_CONFIDENCE` lookups in `contradiction.py` and `store.py` switched from `.get(ct, 0.5)` to strict `[ct]`. The enum has an explicit mapping for every value; the fallback was dead code that would mask future enum additions (PR #54).
 - `llm.try_generate` now logs a WARNING on LLM failure instead of silently returning `None`. LLM is optional infra but hidden crashes (OOM, llama-cpp version mismatch) previously had no operator signal (PR #54).
+
+### Removed (dead code / lint cleanup)
+- `contradiction.SearchResult` import, `server.CONTENT_TYPE_VALUES` import, `store.dataclasses.field` import, and a dead `local_token = _ensure_local_token(...)` assignment in `setup.py` — all caught by `ruff check --select F`.
+- Renamed ambiguous `l` loop variables to `label` / `line` in `charts.py` and `handoff_generator.py` (E741).
+- Added `[tool.ruff.lint.per-file-ignores]` suppressing E402 under `src/mnemon/dashboard/` — Streamlit pages require `st.set_page_config(...)` before other imports, legit convention.
+- Test-count claims switched from fixed "460 tests" to drift-tolerant "450+ tests" in `README.md` and `CLAUDE.md`.
 
 ## [0.4.1] - 2026-04-14
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ src/mnemon/
 ```bash
 # Development
 pip install -e ".[dev]"         # Install with dev deps
-pytest                          # Run tests (460 tests)
+pytest                          # Run tests (450+ tests)
 pytest -v                       # Verbose output
 pytest tests/test_store.py      # Single file
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)]()
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-460_passing-brightgreen.svg)]()
+[![Tests](https://img.shields.io/badge/tests-450%2B_passing-brightgreen.svg)]()
 [![Coverage](https://img.shields.io/badge/coverage-90%25-brightgreen.svg)]()
 [![MCP](https://img.shields.io/badge/MCP-compatible-blueviolet.svg)](https://modelcontextprotocol.io)
-[![PyPI](https://img.shields.io/badge/PyPI-v0.4.2-blue.svg)](https://pypi.org/project/mnemon-memory/)
+[![PyPI](https://img.shields.io/badge/PyPI-v0.4.3-blue.svg)](https://pypi.org/project/mnemon-memory/)
 
 > One memory vault. Every MCP client. Self-hosted, no third-party auth.
 
@@ -353,7 +353,7 @@ Client-side behaviors that affect mnemon users but are not bugs in mnemon itself
 # Install with dev dependencies
 pip install -e ".[dev]"
 
-# Run tests (460 tests)
+# Run tests (450+ tests)
 pytest
 
 # Run tests with coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.4.2"
+version = "0.4.3"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"
@@ -76,3 +76,9 @@ asyncio_mode = "auto"
 markers = [
     "integration: end-to-end tests that spawn a real mnemon serve-remote subprocess (skip with -m 'not integration')",
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# Streamlit convention: st.set_page_config(...) must precede any other
+# Streamlit command, so page modules import library code after the
+# call. Legit pattern, not refactoring.
+"src/mnemon/dashboard/**/*.py" = ["E402"]

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/src/mnemon/contradiction.py
+++ b/src/mnemon/contradiction.py
@@ -25,7 +25,7 @@ from .config import (
 )
 
 if TYPE_CHECKING:
-    from .store import SearchResult, Store
+    from .store import Store
 
 UPDATE_DECAY = 0.15      # confidence reduction for superseded memories
 CONTRADICTION_DECAY = 0.25

--- a/src/mnemon/dashboard/charts.py
+++ b/src/mnemon/dashboard/charts.py
@@ -36,7 +36,7 @@ def make_type_distribution_chart(by_type: list[dict]) -> go.Figure:
 
     labels = [t["content_type"] for t in by_type]
     values = [t["count"] for t in by_type]
-    colors = [CONTENT_TYPE_COLORS.get(l, "#999") for l in labels]
+    colors = [CONTENT_TYPE_COLORS.get(label, "#999") for label in labels]
 
     fig = go.Figure(data=[go.Pie(
         labels=labels,

--- a/src/mnemon/hooks/handoff_generator.py
+++ b/src/mnemon/hooks/handoff_generator.py
@@ -72,8 +72,8 @@ def generate_with_llm(transcript: str) -> dict | None:
 def generate_with_regex(transcript: str) -> dict | None:
     """Fallback: generate handoff using regex heuristics."""
     lines = transcript.split("\n")
-    user_lines = [l for l in lines if l.startswith("[user]:")]
-    assistant_lines = [l for l in lines if l.startswith("[assistant]:")]
+    user_lines = [line for line in lines if line.startswith("[user]:")]
+    assistant_lines = [line for line in lines if line.startswith("[assistant]:")]
 
     if len(user_lines) < 2:
         return None

--- a/src/mnemon/server.py
+++ b/src/mnemon/server.py
@@ -14,7 +14,6 @@ import os
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
-from .config import CONTENT_TYPE_VALUES
 from .search import search
 from .store import Store
 

--- a/src/mnemon/setup.py
+++ b/src/mnemon/setup.py
@@ -175,7 +175,10 @@ def setup_claude_code(*, remote_url: str | None = None, token: str | None = None
 
     if remote_url:
         _ensure_remote_url(remote_url)
-        local_token = _ensure_local_token(token)
+        # Call for side-effect only (writes ~/.mnemon/local_token); the
+        # Claude-Code path doesn't need the token string back — hooks
+        # read the file directly at invocation time.
+        _ensure_local_token(token)
         lines.append(f"  Remote URL: {remote_url}")
         lines.append(f"  Token file: {LOCAL_TOKEN_FILE} (chmod 600)")
 

--- a/src/mnemon/store.py
+++ b/src/mnemon/store.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import hashlib
 import sqlite3
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 


### PR DESCRIPTION
0.4.2 artifacts were built locally but never uploaded to PyPI. Rolling its changes into 0.4.3 along with a final lint pass so the first published release post-Phase-2 also passes `ruff check src/` cleanly.

## What's in 0.4.3

Everything from the uncut 0.4.2 (doctor forget fix, config consolidation, hook error logging, Store.save `path` kwarg removal, strict DEFAULT_CONFIDENCE lookups, llm failure logging) plus:

**Ruff F (4 real dead-code items)**
- `contradiction.py`: unused `SearchResult` in TYPE_CHECKING.
- `server.py`: unused `CONTENT_TYPE_VALUES` import.
- `store.py`: unused `dataclasses.field` import.
- `setup.py:178`: dead `local_token = ...` assignment (call retained for side-effect).

**Ruff E741 (ambiguous variable names)**
- `charts.py`, `handoff_generator.py`: `l` → `label` / `line`.

**Ruff E402 in dashboard/**
- Legit Streamlit convention (`st.set_page_config` before imports). Per-file-ignore in `pyproject.toml` rather than refactoring into non-idiomatic Streamlit.

**Drift cleanup**
- Badges / inline count changed from fixed "460 tests" to drift-tolerant "450+ tests".
- Version bumped in pyproject + `__init__` + README badge.

## Result

`ruff check src/` → "All checks passed!"
`pytest` → 454 pass.

## Test plan
- [x] `ruff check src/` clean
- [x] Full pytest suite green
- [ ] After merge: `fly deploy` → v18
- [ ] After merge: `python -m build && twine upload` for 0.4.3
- [ ] After merge: `git tag v0.4.3 && gh release create v0.4.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)