### PR TITLE
feat: structured MCP tools for remote-aware dashboard (PR A)

### DIFF
--- a/src/mnemon/server.py
+++ b/src/mnemon/server.py
@@ -168,6 +168,24 @@ def memory_timeline(
     return "\n".join(lines)
 
 
+@mcp.tool()
+def memory_timeline_structured(
+    limit: int = 20,
+    content_type: str | None = None,
+) -> str:
+    """Recent memories as a JSON list of document objects.
+
+    Machine-readable counterpart to ``memory_timeline``. Used by the
+    mnemon dashboard's Timeline page. Each object carries the full
+    document shape (id, title, content, content_type, memory_type,
+    confidence, pinned, created_at, updated_at, access_count).
+    """
+    import dataclasses
+    store = _get_store()
+    docs = store.timeline(limit, content_type)
+    return json.dumps([dataclasses.asdict(d) for d in docs])
+
+
 # ── Mutation Tools ───────────────────────────────────────────────────────────
 
 
@@ -255,6 +273,21 @@ def memory_status() -> str:
 
 
 @mcp.tool()
+def memory_status_structured() -> str:
+    """Vault health stats as a JSON object.
+
+    Machine-readable counterpart to ``memory_status``. Used by the
+    mnemon dashboard's Home page to render counts without parsing prose.
+
+    Returns a JSON object: ``{total_documents, total_vectors, invalidated,
+    pinned, by_type, vault_path}`` where ``by_type`` is a list of
+    ``{content_type, count}``.
+    """
+    store = _get_store()
+    return json.dumps(store.status())
+
+
+@mcp.tool()
 def memory_sweep(dry_run: bool = True) -> str:
     """Archive stale memories that have exceeded their half-life.
 
@@ -276,6 +309,21 @@ def memory_sweep(dry_run: bool = True) -> str:
 
 
 @mcp.tool()
+def memory_sweep_structured(dry_run: bool = True) -> str:
+    """Sweep results as a JSON object.
+
+    Machine-readable counterpart to ``memory_sweep``. Used by the
+    mnemon dashboard to render stale-candidate tables. Returns
+    ``{archived: int, candidates: [{id, title, content_type, age_days}]}``.
+    """
+    import dataclasses
+    store = _get_store()
+    result = store.sweep(dry_run)
+    result["candidates"] = [dataclasses.asdict(c) for c in result["candidates"]]
+    return json.dumps(result)
+
+
+@mcp.tool()
 def memory_related(id: int, limit: int = 10) -> str:
     """Find memories related to a given memory via the relationship graph."""
     store = _get_store()
@@ -288,6 +336,104 @@ def memory_related(id: int, limit: int = 10) -> str:
         for r in related
     ]
     return "\n".join(lines)
+
+
+@mcp.tool()
+def memory_related_structured(id: int, limit: int = 10) -> str:
+    """Related memories as a JSON list.
+
+    Machine-readable counterpart to ``memory_related``. Each entry is
+    the full document shape extended with ``relation_type`` and
+    ``weight`` fields.
+    """
+    import dataclasses
+    store = _get_store()
+    return json.dumps([dataclasses.asdict(r) for r in store.get_related(id, limit)])
+
+
+# Vector-export cap: 5000 vectors × 384 floats ≈ 7-10 MB JSON at the
+# float representation we emit. Enough for any personal vault; explicit
+# cap so a runaway vault size doesn't OOM the server process silently.
+_VECTOR_EXPORT_MAX = 5000
+
+
+@mcp.tool()
+def memory_export_vectors() -> str:
+    """Export all stored embedding vectors joined to document metadata.
+
+    Used by the mnemon dashboard's Graph page to pull the full embedding
+    matrix over MCP and run UMAP projection client-side. Avoids exposing
+    a filesystem path or a bulk-SQL interface while keeping the dashboard
+    remote-aware.
+
+    Returns a JSON object ``{count, dim, truncated, items}``:
+
+    - ``count``: number of vectors returned (may be ≤ stored count if
+      capped).
+    - ``dim``: vector dimensionality (384 for bge-small-en-v1.5).
+    - ``truncated``: True if the vault exceeds the server's export cap
+      and results were truncated.
+    - ``items``: list of ``{doc_id, vec_id, title, content_type,
+      confidence, created_at, pinned, vector}``. ``vector`` is a list
+      of floats of length ``dim``. Invalidated docs are excluded.
+
+    Cap is ``_VECTOR_EXPORT_MAX`` (5000) vectors. Larger vaults need a
+    paginated API — file an issue if you hit this.
+    """
+    store = _get_store()
+    vec_ids, vectors = store.vec_store.export_all()
+
+    if not vec_ids:
+        return json.dumps({"count": 0, "dim": store.vec_store.dim,
+                           "truncated": False, "items": []})
+
+    truncated = len(vec_ids) > _VECTOR_EXPORT_MAX
+    if truncated:
+        vec_ids = vec_ids[:_VECTOR_EXPORT_MAX]
+        vectors = vectors[:_VECTOR_EXPORT_MAX]
+
+    # vec_id format is "{content_hash}_{seq}" — split once from the right
+    # since content_hash is a hex SHA-256 (no underscores).
+    hashes = [vid.rsplit("_", 1)[0] for vid in vec_ids]
+    unique_hashes = list(dict.fromkeys(hashes))
+
+    # One query for all hashes — cheaper than N queries. Take the first
+    # non-invalidated doc per hash (there may be multiple rows sharing a
+    # content hash after supersedes/updates).
+    placeholders = ",".join("?" * len(unique_hashes))
+    rows = store.db.execute(
+        f"""SELECT hash, id, title, content_type, confidence, created_at, pinned
+            FROM documents
+            WHERE hash IN ({placeholders})
+              AND invalidated_at IS NULL""",
+        unique_hashes,
+    ).fetchall()
+    hash_to_doc = {r["hash"]: dict(r) for r in rows}
+
+    items = []
+    for vec_id, content_hash, vector in zip(vec_ids, hashes, vectors):
+        doc = hash_to_doc.get(content_hash)
+        if doc is None:
+            # Vector exists but its source document is gone (invalidated
+            # or deleted). Skip — dashboard can't render it usefully.
+            continue
+        items.append({
+            "doc_id": doc["id"],
+            "vec_id": vec_id,
+            "title": doc["title"],
+            "content_type": doc["content_type"],
+            "confidence": doc["confidence"],
+            "created_at": doc["created_at"],
+            "pinned": bool(doc["pinned"]),
+            "vector": vector.tolist(),
+        })
+
+    return json.dumps({
+        "count": len(items),
+        "dim": store.vec_store.dim,
+        "truncated": truncated,
+        "items": items,
+    })
 
 
 @mcp.tool()

--- a/src/mnemon/vecstore.py
+++ b/src/mnemon/vecstore.py
@@ -68,6 +68,18 @@ class VecStore:
             for i in top_indices
         ]
 
+    def export_all(self) -> tuple[list[str], np.ndarray]:
+        """Return all stored (ids, vectors) as a snapshot.
+
+        Used by the remote dashboard's UMAP view to pull the full
+        embedding matrix over MCP and project it client-side. The
+        returned array is a copy — callers can mutate freely without
+        affecting the in-memory store.
+        """
+        if self._vectors is None or len(self._ids) == 0:
+            return [], np.zeros((0, self.dim), dtype=np.float32)
+        return list(self._ids), self._vectors.copy()
+
     def size(self) -> int:
         return len(self._ids)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,22 +2,29 @@
 
 from unittest.mock import MagicMock, patch
 
+import json
+
 import pytest
 
 import mnemon.server as server_mod
 from mnemon.server import (
     memory_check_contradictions,
+    memory_export_vectors,
     memory_forget,
     memory_get,
     memory_pin,
     memory_rebuild,
     memory_related,
+    memory_related_structured,
     memory_save,
     memory_search,
     memory_search_structured,
     memory_status,
+    memory_status_structured,
     memory_sweep,
+    memory_sweep_structured,
     memory_timeline,
+    memory_timeline_structured,
     profile_get,
     profile_update,
 )
@@ -739,3 +746,187 @@ class TestMemoryCheckContradictions:
             result = memory_check_contradictions(1)
 
         assert "0 memories had their confidence decayed." in result
+
+
+# ── Structured (JSON) tool variants ─────────────────────────────────────────
+
+
+class TestMemoryStatusStructured:
+    @patch("mnemon.server.Store")
+    def test_returns_raw_status_dict(self, MockStore):
+        status = {
+            "vault_path": "/x/y.sqlite",
+            "total_documents": 5,
+            "total_vectors": 3,
+            "pinned": 1,
+            "invalidated": 2,
+            "by_type": [{"content_type": "note", "count": 5}],
+        }
+        MockStore.return_value.status.return_value = status
+        assert json.loads(memory_status_structured()) == status
+
+
+def _real_document(**overrides):
+    """Build a real Document dataclass instance (asdict-compatible)."""
+    from mnemon.store import Document
+    defaults = {
+        "id": 1, "collection": "default", "path": None, "title": "T",
+        "hash": "abc", "content_type": "note", "memory_type": "semantic",
+        "confidence": 0.5, "quality_score": 0.0, "access_count": 0,
+        "pinned": 0, "source_client": None, "invalidated_at": None,
+        "invalidated_by": None, "created_at": "2026-01-01",
+        "updated_at": "2026-01-01", "content": "",
+    }
+    defaults.update(overrides)
+    return Document(**defaults)
+
+
+def _real_sweep_candidate(**overrides):
+    from mnemon.store import SweepCandidate
+    defaults = {"id": 1, "title": "T", "content_type": "note", "age_days": 90}
+    defaults.update(overrides)
+    return SweepCandidate(**defaults)
+
+
+def _real_related(**overrides):
+    from mnemon.store import RelatedDocument
+    doc_defaults = {
+        "id": 1, "collection": "default", "path": None, "title": "R",
+        "hash": "abc", "content_type": "note", "memory_type": "semantic",
+        "confidence": 0.5, "quality_score": 0.0, "access_count": 0,
+        "pinned": 0, "source_client": None, "invalidated_at": None,
+        "invalidated_by": None, "created_at": "2026-01-01",
+        "updated_at": "2026-01-01", "content": "",
+        "relation_type": "related", "weight": 1.0,
+    }
+    doc_defaults.update(overrides)
+    return RelatedDocument(**doc_defaults)
+
+
+class TestMemoryTimelineStructured:
+    @patch("mnemon.server.Store")
+    def test_empty(self, MockStore):
+        MockStore.return_value.timeline.return_value = []
+        assert json.loads(memory_timeline_structured()) == []
+
+    @patch("mnemon.server.Store")
+    def test_returns_docs_as_json(self, MockStore):
+        docs = [_real_document(id=7, title="T")]
+        MockStore.return_value.timeline.return_value = docs
+        parsed = json.loads(memory_timeline_structured(limit=5))
+        assert len(parsed) == 1
+        assert parsed[0]["id"] == 7
+        assert parsed[0]["title"] == "T"
+
+
+class TestMemorySweepStructured:
+    @patch("mnemon.server.Store")
+    def test_no_candidates(self, MockStore):
+        MockStore.return_value.sweep.return_value = {"archived": 0, "candidates": []}
+        parsed = json.loads(memory_sweep_structured())
+        assert parsed == {"archived": 0, "candidates": []}
+
+    @patch("mnemon.server.Store")
+    def test_with_candidates(self, MockStore):
+        c = _real_sweep_candidate(id=11, title="Stale", content_type="note", age_days=90)
+        MockStore.return_value.sweep.return_value = {"archived": 0, "candidates": [c]}
+        parsed = json.loads(memory_sweep_structured(dry_run=True))
+        assert parsed["archived"] == 0
+        assert len(parsed["candidates"]) == 1
+        assert parsed["candidates"][0]["id"] == 11
+
+
+class TestMemoryRelatedStructured:
+    @patch("mnemon.server.Store")
+    def test_empty(self, MockStore):
+        MockStore.return_value.get_related.return_value = []
+        assert json.loads(memory_related_structured(1)) == []
+
+    @patch("mnemon.server.Store")
+    def test_returns_related_docs(self, MockStore):
+        rel = _real_related(id=99, relation_type="supersedes", weight=0.8)
+        MockStore.return_value.get_related.return_value = [rel]
+        parsed = json.loads(memory_related_structured(5, limit=10))
+        assert len(parsed) == 1
+        assert parsed[0]["id"] == 99
+        assert parsed[0]["relation_type"] == "supersedes"
+        assert parsed[0]["weight"] == 0.8
+
+
+class TestMemoryExportVectors:
+    @patch("mnemon.server.Store")
+    def test_empty_vault(self, MockStore):
+        MockStore.return_value.vec_store.export_all.return_value = ([], __import__("numpy").zeros((0, 384)))
+        MockStore.return_value.vec_store.dim = 384
+        parsed = json.loads(memory_export_vectors())
+        assert parsed == {"count": 0, "dim": 384, "truncated": False, "items": []}
+
+    @patch("mnemon.server.Store")
+    def test_joins_vectors_to_docs(self, MockStore):
+        import numpy as np
+        vec_ids = ["abc_0", "def_0"]
+        vectors = np.array([[0.1] * 384, [0.2] * 384], dtype=np.float32)
+        MockStore.return_value.vec_store.export_all.return_value = (vec_ids, vectors)
+        MockStore.return_value.vec_store.dim = 384
+        # Simulate the sqlite join: return one row for each hash.
+        row1 = {"hash": "abc", "id": 1, "title": "First",
+                "content_type": "note", "confidence": 0.5,
+                "created_at": "2026-01-01", "pinned": 0}
+        row2 = {"hash": "def", "id": 2, "title": "Second",
+                "content_type": "decision", "confidence": 0.85,
+                "created_at": "2026-01-02", "pinned": 1}
+        MockStore.return_value.db.execute.return_value.fetchall.return_value = [row1, row2]
+
+        parsed = json.loads(memory_export_vectors())
+        assert parsed["count"] == 2
+        assert parsed["dim"] == 384
+        assert parsed["truncated"] is False
+        assert len(parsed["items"]) == 2
+        first = next(i for i in parsed["items"] if i["doc_id"] == 1)
+        assert first["title"] == "First"
+        assert first["pinned"] is False
+        assert len(first["vector"]) == 384
+        second = next(i for i in parsed["items"] if i["doc_id"] == 2)
+        assert second["pinned"] is True
+
+    @patch("mnemon.server.Store")
+    def test_skips_vectors_with_invalidated_docs(self, MockStore):
+        """If a vec_id's document has been invalidated/deleted, the hash
+        won't come back in the join — the item should be skipped, not
+        crash."""
+        import numpy as np
+        vec_ids = ["abc_0", "orphan_0"]
+        vectors = np.array([[0.1] * 384, [0.3] * 384], dtype=np.float32)
+        MockStore.return_value.vec_store.export_all.return_value = (vec_ids, vectors)
+        MockStore.return_value.vec_store.dim = 384
+        # Only "abc" exists in the docs table; "orphan" is gone.
+        MockStore.return_value.db.execute.return_value.fetchall.return_value = [
+            {"hash": "abc", "id": 1, "title": "Kept",
+             "content_type": "note", "confidence": 0.5,
+             "created_at": "2026-01-01", "pinned": 0},
+        ]
+        parsed = json.loads(memory_export_vectors())
+        assert parsed["count"] == 1
+        assert parsed["items"][0]["doc_id"] == 1
+
+    @patch("mnemon.server.Store")
+    def test_truncates_at_cap(self, MockStore):
+        """Over-cap vaults get the flag set and a bounded response."""
+        import numpy as np
+        from mnemon.server import _VECTOR_EXPORT_MAX
+        n = _VECTOR_EXPORT_MAX + 50
+        vec_ids = [f"hash{i}_0" for i in range(n)]
+        vectors = np.zeros((n, 384), dtype=np.float32)
+        MockStore.return_value.vec_store.export_all.return_value = (vec_ids, vectors)
+        MockStore.return_value.vec_store.dim = 384
+        # Pretend every hash resolves — the count we get back should be capped.
+        rows = [
+            {"hash": f"hash{i}", "id": i, "title": f"T{i}",
+             "content_type": "note", "confidence": 0.5,
+             "created_at": "2026-01-01", "pinned": 0}
+            for i in range(_VECTOR_EXPORT_MAX)
+        ]
+        MockStore.return_value.db.execute.return_value.fetchall.return_value = rows
+        parsed = json.loads(memory_export_vectors())
+        assert parsed["truncated"] is True
+        assert parsed["count"] == _VECTOR_EXPORT_MAX

--- a/tests/test_server_remote.py
+++ b/tests/test_server_remote.py
@@ -53,16 +53,19 @@ class TestMcpServer:
     def test_mcp_has_tools(self):
         from mnemon.server import mcp
         tools = mcp._tool_manager._tools
-        assert len(tools) == 14
+        assert len(tools) == 19
 
     def test_mcp_tool_names(self):
         from mnemon.server import mcp
         tool_names = set(mcp._tool_manager._tools.keys())
         expected = {
             "memory_search", "memory_search_structured",
-            "memory_get", "memory_timeline",
+            "memory_get", "memory_timeline", "memory_timeline_structured",
             "memory_save", "memory_pin", "memory_forget",
-            "memory_status", "memory_sweep", "memory_related",
+            "memory_status", "memory_status_structured",
+            "memory_sweep", "memory_sweep_structured",
+            "memory_related", "memory_related_structured",
+            "memory_export_vectors",
             "memory_rebuild", "memory_check_contradictions",
             "profile_get", "profile_update",
         }

--- a/tests/test_vecstore.py
+++ b/tests/test_vecstore.py
@@ -78,3 +78,20 @@ class TestVecStore:
     def test_dim_validation(self, vecstore):
         with pytest.raises(ValueError):
             vecstore.set("a_0", np.array([1, 0, 0], dtype=np.float32))
+
+    def test_export_all_empty(self, vecstore):
+        ids, vectors = vecstore.export_all()
+        assert ids == []
+        assert vectors.shape == (0, vecstore.dim)
+
+    def test_export_all_returns_snapshot(self, vecstore):
+        vecstore.set("a_0", np.array([1, 0, 0, 0], dtype=np.float32))
+        vecstore.set("b_0", np.array([0, 1, 0, 0], dtype=np.float32))
+
+        ids, vectors = vecstore.export_all()
+        assert ids == ["a_0", "b_0"]
+        assert vectors.shape == (2, 4)
+        # Mutations on the returned array must not affect the in-memory store.
+        vectors[0][0] = 99.0
+        _, vectors2 = vecstore.export_all()
+        assert vectors2[0][0] == 1.0


### PR DESCRIPTION
PR A of two. Server-side only. PR B will rewrite dashboard loaders to consume these.

## What

Five JSON-returning MCP tools mirroring the prose-returning ones the dashboard currently calls via direct Store():

- `memory_status_structured` — vault health as dict.
- `memory_timeline_structured` — recent docs as JSON list.
- `memory_sweep_structured` — stale candidates + archived count.
- `memory_related_structured` — related docs with relation_type + weight.
- `memory_export_vectors` — full embedding matrix joined to doc metadata. The interesting one: the dashboard's UMAP page currently reads the raw .npz file from disk, which doesn't exist for remote clients. This tool exposes (vec_id, doc_id, title, content_type, confidence, created_at, pinned, vector[384]) so the client can run UMAP against the server's vault.

Capped at 5000 vectors (with `truncated` flag in the response) to prevent runaway memory use if a vault grows past personal-scale. Pagination is a future follow-up.

## Design notes

- Prose tools unchanged — they stay for LLM consumption (compact, human-readable). Structured tools are the programmatic-client twin.
- Zero duplicated business logic — each structured tool is `json.dumps(existing_store_method())` with a dataclass-to-dict conversion.
- `VecStore.export_all()` returns a snapshot copy so dashboard mutation during UMAP can't corrupt the in-memory store.

## Test plan

- [x] 13 new tests (8 in test_server.py, 2 in test_vecstore.py, 3 test_server_remote.py updates for new tool count).
- [x] `pytest` — 467 pass (was 454).
- [x] `ruff check src/` clean.
- [ ] After merge: `fly deploy` to make new tools available in prod.
- [ ] PR B lands dashboard loaders + bumps to 0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)