### PR TITLE
refactor: consolidate MCP tool formats to JSON (v0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## [0.5.0] - 2026-04-14
+
+### Breaking
+
+- **MCP tools now return JSON instead of pre-formatted prose.** The
+  ``_structured`` paired variant (``memory_search_structured``) is gone
+  — ``memory_search`` itself returns the JSON array directly. Same
+  treatment for ``memory_get``, ``memory_timeline``, ``memory_status``,
+  ``memory_sweep``, ``memory_related``, ``profile_get``. The motivation:
+  a single clean-format contract beats paired tools with the same
+  concern but different shapes, and modern LLM clients (claude.ai,
+  Claude Code, Cursor, Claude Desktop) all parse JSON cleanly.
+  Mutation/side-effect tools (``memory_save``, ``memory_pin``,
+  ``memory_forget``, ``memory_rebuild``, ``memory_check_contradictions``,
+  ``profile_update``) still return short confirmation strings.
+- **Breaking for direct MCP consumers** that regex the old prose
+  output. The ``context_surfacing`` hook was the main such consumer
+  in-tree and has been migrated to JSON parsing + client-side
+  formatting. Migration for your own consumers: call the same tool
+  name, ``json.loads()`` the result, format or filter as you need.
+  Empty result is now ``"[]"`` (not a prose sentinel).
+
+### Added
+
+- ``memory_export_vectors`` — new tool exposing the full embedding
+  matrix joined to document metadata, for remote-aware clients that
+  want to run UMAP / visualization / similarity work client-side. JSON
+  only; capped at 5000 vectors per response with a ``truncated`` flag
+  for vaults past that size.
+- ``VecStore.export_all()`` — internal helper returning a snapshot
+  copy of (ids, vectors) so ``memory_export_vectors`` callers can
+  mutate the returned array safely.
+
+### Changed
+
+- Total tool count: 14 (was 14 in 0.4.3 — ``memory_search_structured``
+  was removed and ``memory_export_vectors`` added; net zero).
+- ``context_surfacing`` hook now parses JSON from ``memory_search`` and
+  formats the markdown context block client-side. Output in the
+  ``<mnemon-context>`` block is shape-identical to 0.4.x — Claude sees
+  the same injected context, just formatted by the hook rather than
+  the server.
+
 ## [0.4.3] - 2026-04-14
 
 Rolls up all 0.4.2 changes (which was built but never uploaded to PyPI) plus a final ruff-clean pass.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Tests](https://img.shields.io/badge/tests-450%2B_passing-brightgreen.svg)]()
 [![Coverage](https://img.shields.io/badge/coverage-90%25-brightgreen.svg)]()
 [![MCP](https://img.shields.io/badge/MCP-compatible-blueviolet.svg)](https://modelcontextprotocol.io)
-[![PyPI](https://img.shields.io/badge/PyPI-v0.4.3-blue.svg)](https://pypi.org/project/mnemon-memory/)
+[![PyPI](https://img.shields.io/badge/PyPI-v0.5.0-blue.svg)](https://pypi.org/project/mnemon-memory/)
 
 > One memory vault. Every MCP client. Self-hosted, no third-party auth.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.4.3"
+version = "0.5.0"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.4.3"
+__version__ = "0.5.0"

--- a/src/mnemon/hooks/context_surfacing.py
+++ b/src/mnemon/hooks/context_surfacing.py
@@ -22,6 +22,7 @@ All memory reads flow to the Fly vault via :mod:`mnemon.hooks._remote_client`.
 
 from __future__ import annotations
 
+import json
 import sys
 
 from ..config import (
@@ -40,40 +41,66 @@ SLOW_THRESHOLD_SEC = HOOK_SLOW_THRESHOLD_SEC
 CLIENT_LABEL = "claude-code-context-surfacing"
 SEARCH_LIMIT = 8
 
-# Sentinel string the server returns when memory_search finds nothing.
-# Kept in sync with src/mnemon/server.py memory_search().
-NO_RESULTS_SENTINEL = "No memories found matching your query."
+# Snippet size injected per result — matches the pre-0.5.0 server-side
+# truncation so context block size stays bounded independent of vault
+# content length.
+_SNIPPET_CHARS = 300
+
+
+def _format_results(results: list[dict]) -> str:
+    """Render a memory_search JSON response as a markdown list for prompt
+    injection. Mirrors the pre-0.5.0 server-side prose format so the
+    shape Claude sees in ``<mnemon-context>`` blocks is unchanged."""
+    lines: list[str] = []
+    for i, r in enumerate(results, 1):
+        content = r.get("content", "")
+        snippet = content[:_SNIPPET_CHARS]
+        ellipsis = "..." if len(content) > _SNIPPET_CHARS else ""
+        lines.append(
+            f"{i}. [{r.get('content_type', 'note')}] **{r.get('title', '')}** "
+            f"(score: {r.get('composite_score', 0):.3f}, "
+            f"confidence: {r.get('confidence', 0):.2f})\n"
+            f"   {snippet}{ellipsis}\n"
+            f"   _id: {r.get('doc_id', '?')} | "
+            f"created: {r.get('created_at', '')}_"
+        )
+    return "\n\n".join(lines)
 
 
 def build_context(raw_text: str, *, prefix: str = "") -> str:
-    """Wrap the ``memory_search`` response in a ``<mnemon-context>`` block.
+    """Wrap a ``memory_search`` JSON response in a ``<mnemon-context>`` block.
 
-    The server returns a pre-formatted markdown list of matches, each
-    already truncated to a 300-char snippet. We pass it through unchanged
-    and wrap it in a containing tag so Claude can recognise it as mnemon
-    context. A character budget is enforced as a safety net in case the
-    server ever returns an unexpectedly long payload.
+    Post-0.5.0 the server returns JSON instead of pre-formatted prose; we
+    parse it and format client-side so the block the LLM sees is stable
+    and token-efficient. A character budget caps the rendered output as
+    a safety net against unexpectedly large payloads.
 
     ``prefix`` is prepended inside the block before the memories header —
     used to surface latency warnings on slow-but-successful calls.
 
     Returns an empty string when there's nothing worth injecting — empty
-    input, the server's no-results sentinel, or whitespace-only content.
+    input, an empty result list, or unparseable JSON.
     """
     if not raw_text:
         return ""
     trimmed = raw_text.strip()
     if not trimmed:
         return ""
-    if NO_RESULTS_SENTINEL in trimmed:
+    try:
+        results = json.loads(trimmed)
+    except json.JSONDecodeError:
+        # Server contract violation — don't inject garbage into the prompt.
         return ""
-    if len(trimmed) > CHAR_BUDGET:
-        trimmed = trimmed[:CHAR_BUDGET].rstrip() + "\n...[truncated]"
+    if not isinstance(results, list) or not results:
+        return ""
+    rendered = _format_results(results)
+    if len(rendered) > CHAR_BUDGET:
+        rendered = rendered[:CHAR_BUDGET].rstrip() + "\n...[truncated]"
     lines = []
     if prefix:
         lines.append(prefix)
     lines.append("Relevant memories from previous sessions:")
-    lines.append(trimmed)
+    lines.append(rendered)
     inner = "\n".join(lines)
     return f"<mnemon-context>\n{inner}\n</mnemon-context>"
 

--- a/src/mnemon/hooks/session_extractor.py
+++ b/src/mnemon/hooks/session_extractor.py
@@ -132,7 +132,7 @@ def is_duplicate_remote(title: str, content: str) -> bool:
     """Check if an observation is too similar to existing memories via remote search.
 
     Searches the Fly vault for content matching the combined title+content
-    using ``memory_search_structured``, then compares the
+    using ``memory_search`` (which returns JSON), then compares the
     ``vector_similarity`` (true cosine similarity from the vector store)
     against ``HOOK_DEDUP_SIMILARITY_THRESHOLD``. Composite score is
     deliberately NOT used — it's a rank-fusion weighted score, not a
@@ -148,7 +148,7 @@ def is_duplicate_remote(title: str, content: str) -> bool:
 
         query = f"{title}: {content}"
         raw, _elapsed = call_tool_sync(
-            "memory_search_structured",
+            "memory_search",
             {"query": query, "limit": 3},
             timeout=HOOK_DEDUP_TIMEOUT_SEC,
             client_label=CLIENT_LABEL,

--- a/src/mnemon/server.py
+++ b/src/mnemon/server.py
@@ -73,52 +73,21 @@ def memory_search(
 ) -> str:
     """Search memories using hybrid BM25 + vector search with composite scoring.
 
-    This is the primary entry point for finding relevant memories.
-    Results are ranked by a composite of relevance, recency, and confidence.
+    Primary entry point for finding relevant memories. Results are ranked
+    by a composite of relevance, recency, and confidence.
+
+    Returns a JSON string — a list of result objects, empty when nothing
+    matches. Each object contains: ``doc_id``, ``title``, ``content``,
+    ``content_type``, ``confidence``, ``composite_score``,
+    ``vector_similarity``, ``created_at``. Score fields are floats.
+    ``vector_similarity`` is the raw cosine similarity (0.0–1.0) from the
+    vector store, preserved before RRF fusion; it is None for BM25-only
+    matches and is the right signal for dedup (``composite_score`` is a
+    weighted rank score, not a raw similarity).
     """
     store = _get_store()
     results = search(store, query, limit=limit, content_type=content_type)
-
-    if not results:
-        return "No memories found matching your query."
-
-    lines = []
-    for i, r in enumerate(results, 1):
-        snippet = r.content[:300]
-        ellipsis = "..." if len(r.content) > 300 else ""
-        lines.append(
-            f"{i}. [{r.content_type}] **{r.title}** "
-            f"(score: {r.composite_score:.3f}, confidence: {r.confidence:.2f})\n"
-            f"   {snippet}{ellipsis}\n"
-            f"   _id: {r.doc_id} | created: {r.created_at}_"
-        )
-    return "\n\n".join(lines)
-
-
-@mcp.tool()
-def memory_search_structured(
-    query: str,
-    limit: int = 10,
-    content_type: str | None = None,
-) -> str:
-    """Search memories and return results as a JSON array.
-
-    Machine-readable counterpart to ``memory_search``. Use this when a
-    client needs to act on score thresholds or individual fields rather
-    than present the results to a human. Returns a JSON string with one
-    object per result; empty array when nothing matches.
-
-    Each result object contains: doc_id, title, content, content_type,
-    confidence, composite_score, vector_similarity, created_at. Score
-    fields are floats — callers can compare against thresholds without
-    text parsing. ``vector_similarity`` is the raw cosine similarity
-    (0.0–1.0) from the vector store, preserved before RRF fusion; it
-    is None for BM25-only matches and is the right signal for dedup
-    (composite_score is a weighted rank score, not a similarity).
-    """
-    store = _get_store()
-    results = search(store, query, limit=limit, content_type=content_type)
-    payload = [
+    return json.dumps([
         {
             "doc_id": r.doc_id,
             "title": r.title,
@@ -130,24 +99,24 @@ def memory_search_structured(
             "created_at": r.created_at,
         }
         for r in results
-    ]
-    return json.dumps(payload)
+    ])
 
 
 @mcp.tool()
 def memory_get(id: int) -> str:
-    """Get a specific memory by its ID. Returns the full content."""
+    """Get a specific memory by its ID.
+
+    Returns a JSON string. On hit: the full document fields (``id``,
+    ``title``, ``content``, ``content_type``, ``confidence``,
+    ``created_at``, ``updated_at``, ``pinned``, ``access_count``, etc.).
+    On miss: ``{"error": "not_found", "id": <id>}``.
+    """
+    import dataclasses
     store = _get_store()
     doc = store.get(id)
     if not doc:
-        return f"Memory #{id} not found."
-
-    return (
-        f"# {doc.title}\n\n"
-        f"**Type:** {doc.content_type} | **Confidence:** {doc.confidence:.2f} | "
-        f"**Created:** {doc.created_at}\n\n"
-        f"{doc.content}"
-    )
+        return json.dumps({"error": "not_found", "id": id})
+    return json.dumps(dataclasses.asdict(doc))
 
 
 @mcp.tool()
@@ -155,17 +124,19 @@ def memory_timeline(
     limit: int = 20,
     content_type: str | None = None,
 ) -> str:
-    """Get recent memories in reverse chronological order."""
-    store = _get_store()
-    docs = store.timeline(limit, content_type)
-    if not docs:
-        return "No memories found."
+    """Recent memories in reverse chronological order as a JSON list.
 
-    lines = [
-        f"- **{d.title}** [{d.content_type}] (id: {d.id}, {d.created_at})"
-        for d in docs
-    ]
-    return "\n".join(lines)
+    Each item carries the full document shape (``id``, ``title``,
+    ``content``, ``content_type``, ``confidence``, ``pinned``,
+    ``created_at``, ``updated_at``, ``access_count``). Empty list when
+    no matches.
+    """
+    import dataclasses
+    store = _get_store()
+    return json.dumps([
+        dataclasses.asdict(d)
+        for d in store.timeline(limit, content_type)
+    ])
 
 
 # ── Mutation Tools ───────────────────────────────────────────────────────────
@@ -236,58 +207,125 @@ def memory_forget(id: int) -> str:
 
 @mcp.tool()
 def memory_status() -> str:
-    """Get vault health stats — document counts by type, pinned/invalidated counts."""
+    """Vault health stats as a JSON object.
+
+    Returns: ``{total_documents, total_vectors, invalidated, pinned,
+    by_type, vault_path}``. ``by_type`` is a list of
+    ``{content_type, count}`` ordered by count descending.
+    """
     store = _get_store()
-    stats = store.status()
-
-    by_type = "\n".join(
-        f"  {t['content_type']}: {t['count']}" for t in stats["by_type"]
-    )
-
-    return (
-        f"Vault: {stats['vault_path']}\n"
-        f"Total memories: {stats['total_documents']}\n"
-        f"Vectors: {stats['total_vectors']}\n"
-        f"Pinned: {stats['pinned']}\n"
-        f"Invalidated: {stats['invalidated']}\n\n"
-        f"By type:\n{by_type}"
-    )
+    return json.dumps(store.status())
 
 
 @mcp.tool()
 def memory_sweep(dry_run: bool = True) -> str:
     """Archive stale memories that have exceeded their half-life.
 
-    Runs in dry-run mode by default — pass dry_run=False to actually archive.
+    Runs in dry-run mode by default — pass ``dry_run=False`` to actually
+    archive. Returns JSON: ``{archived: int, candidates: [{id, title,
+    content_type, age_days}]}``. ``archived`` is 0 on dry-run.
     """
+    import dataclasses
     store = _get_store()
     result = store.sweep(dry_run)
-
-    if not result["candidates"]:
-        return "No stale memories to archive."
-
-    lines = [
-        f'- #{c.id} "{c.title}" [{c.content_type}] — {c.age_days} days old'
-        for c in result["candidates"]
-    ]
-
-    action = "Would archive" if dry_run else "Archived"
-    return f"{action} {len(result['candidates'])} memories:\n" + "\n".join(lines)
+    result["candidates"] = [dataclasses.asdict(c) for c in result["candidates"]]
+    return json.dumps(result)
 
 
 @mcp.tool()
 def memory_related(id: int, limit: int = 10) -> str:
-    """Find memories related to a given memory via the relationship graph."""
-    store = _get_store()
-    related = store.get_related(id, limit)
-    if not related:
-        return f"No related memories found for #{id}."
+    """Related memories via the relationship graph, as a JSON list.
 
-    lines = [
-        f"- [{r.relation_type}] **{r.title}** (id: {r.id}, weight: {r.weight:.2f})"
-        for r in related
-    ]
-    return "\n".join(lines)
+    Each entry is the full document shape plus ``relation_type`` and
+    ``weight``. Empty list when nothing is related.
+    """
+    import dataclasses
+    store = _get_store()
+    return json.dumps([
+        dataclasses.asdict(r) for r in store.get_related(id, limit)
+    ])
+
+
+# Vector-export cap: 5000 vectors × 384 floats ≈ 7-10 MB JSON at the
+# float representation we emit. Enough for any personal vault; explicit
+# cap so a runaway vault size doesn't OOM the server process silently.
+_VECTOR_EXPORT_MAX = 5000
+
+
+@mcp.tool()
+def memory_export_vectors() -> str:
+    """Export all stored embedding vectors joined to document metadata.
+
+    Used by the mnemon dashboard's Graph page to pull the full embedding
+    matrix over MCP and run UMAP projection client-side. Avoids exposing
+    a filesystem path or bulk-SQL interface while keeping the dashboard
+    remote-aware.
+
+    Returns a JSON object ``{count, dim, truncated, items}``:
+
+    - ``count``: number of vectors returned (may be ≤ stored count if
+      capped).
+    - ``dim``: vector dimensionality (384 for bge-small-en-v1.5).
+    - ``truncated``: True if the vault exceeds the server's export cap
+      and results were truncated.
+    - ``items``: list of ``{doc_id, vec_id, title, content_type,
+      confidence, created_at, pinned, vector}``. ``vector`` is a list
+      of floats of length ``dim``. Invalidated docs are excluded.
+
+    Cap is ``_VECTOR_EXPORT_MAX`` (5000) vectors.
+    """
+    store = _get_store()
+    vec_ids, vectors = store.vec_store.export_all()
+
+    if not vec_ids:
+        return json.dumps({"count": 0, "dim": store.vec_store.dim,
+                           "truncated": False, "items": []})
+
+    truncated = len(vec_ids) > _VECTOR_EXPORT_MAX
+    if truncated:
+        vec_ids = vec_ids[:_VECTOR_EXPORT_MAX]
+        vectors = vectors[:_VECTOR_EXPORT_MAX]
+
+    # vec_id format is "{content_hash}_{seq}" — split once from the right
+    # since content_hash is a hex SHA-256 (no underscores).
+    hashes = [vid.rsplit("_", 1)[0] for vid in vec_ids]
+    unique_hashes = list(dict.fromkeys(hashes))
+
+    # One query for all hashes; take the first non-invalidated doc per hash.
+    placeholders = ",".join("?" * len(unique_hashes))
+    rows = store.db.execute(
+        f"""SELECT hash, id, title, content_type, confidence, created_at, pinned
+            FROM documents
+            WHERE hash IN ({placeholders})
+              AND invalidated_at IS NULL""",
+        unique_hashes,
+    ).fetchall()
+    hash_to_doc = {r["hash"]: dict(r) for r in rows}
+
+    items = []
+    for vec_id, content_hash, vector in zip(vec_ids, hashes, vectors):
+        doc = hash_to_doc.get(content_hash)
+        if doc is None:
+            # Vector exists but its source document is gone (invalidated
+            # or deleted). Skip — dashboard can't render it usefully.
+            continue
+        items.append({
+            "doc_id": doc["id"],
+            "vec_id": vec_id,
+            "title": doc["title"],
+            "content_type": doc["content_type"],
+            "confidence": doc["confidence"],
+            "created_at": doc["created_at"],
+            "pinned": bool(doc["pinned"]),
+            "vector": vector.tolist(),
+        })
+
+    return json.dumps({
+        "count": len(items),
+        "dim": store.vec_store.dim,
+        "truncated": truncated,
+        "items": items,
+    })
 
 
 @mcp.tool()
@@ -318,31 +356,22 @@ def memory_rebuild() -> str:
 
 @mcp.tool()
 def profile_get() -> str:
-    """Get a synthesized user profile from stored preferences and decisions.
+    """Synthesized user profile from stored preferences and decisions.
 
-    Shows what mnemon knows about the user's habits, preferences, and key decisions.
+    Returns JSON: ``{preferences: [doc_dict, ...], decisions: [doc_dict, ...]}``.
+    Each list holds the most recent 50 items of its content type, with
+    the full document shape per entry. Both lists may be empty.
     """
+    import dataclasses
     store = _get_store()
-    preferences = store.timeline(50, "preference")
-    decisions = store.timeline(50, "decision")
-
-    if not preferences and not decisions:
-        return (
-            "No profile data yet. Preferences and decisions will be "
-            "collected automatically over time."
-        )
-
-    sections: list[str] = []
-
-    if preferences:
-        lines = [f"- **{d.title}**: {d.content[:200]}" for d in preferences]
-        sections.append("## Preferences\n" + "\n".join(lines))
-
-    if decisions:
-        lines = [f"- **{d.title}**: {d.content[:200]}" for d in decisions]
-        sections.append("## Key Decisions\n" + "\n".join(lines))
-
-    return "\n\n".join(sections)
+    return json.dumps({
+        "preferences": [
+            dataclasses.asdict(d) for d in store.timeline(50, "preference")
+        ],
+        "decisions": [
+            dataclasses.asdict(d) for d in store.timeline(50, "decision")
+        ],
+    })
 
 
 @mcp.tool()

--- a/src/mnemon/vecstore.py
+++ b/src/mnemon/vecstore.py
@@ -68,6 +68,18 @@ class VecStore:
             for i in top_indices
         ]
 
+    def export_all(self) -> tuple[list[str], np.ndarray]:
+        """Return all stored (ids, vectors) as a snapshot.
+
+        Used by ``memory_export_vectors`` so the remote dashboard can
+        pull the full embedding matrix over MCP and project it with
+        UMAP client-side. The returned array is a copy — callers can
+        mutate freely without affecting the in-memory store.
+        """
+        if self._vectors is None or len(self._ids) == 0:
+            return [], np.zeros((0, self.dim), dtype=np.float32)
+        return list(self._ids), self._vectors.copy()
+
     def size(self) -> int:
         return len(self._ids)
 

--- a/tests/test_hooks_extended.py
+++ b/tests/test_hooks_extended.py
@@ -214,14 +214,24 @@ class TestReadTranscript:
 
 # ── context_surfacing.py: build_context ───────────────────────────────────────
 #
-# After Phase 3 unification, build_context takes the raw string output of
-# the remote memory_search tool and wraps it in mnemon-context tags — the
-# old HOT/WARM/COLD tiered logic moved to the server (which always returns
-# 300-char snippets per match). build_context is now a thin wrapper with
-# budget-enforcement as a safety net.
+# Post-0.5.0 the remote memory_search tool returns JSON; build_context
+# parses it and formats the markdown list client-side. Still wraps the
+# rendered block in mnemon-context tags and enforces a char budget as a
+# safety net against oversized payloads.
 
 
 class TestBuildContext:
+    def _json_result(self, **overrides):
+        """Build a memory_search JSON object (single result) for tests."""
+        defaults = {
+            "doc_id": 1, "title": "Title", "content": "content here",
+            "content_type": "note", "confidence": 0.8,
+            "composite_score": 0.8, "vector_similarity": None,
+            "created_at": "2026-04-08",
+        }
+        defaults.update(overrides)
+        return defaults
+
     def test_empty_input_returns_empty(self):
         from mnemon.hooks.context_surfacing import build_context
 
@@ -233,62 +243,83 @@ class TestBuildContext:
 
         assert build_context("   \n  \t  ") == ""
 
-    def test_no_results_sentinel_returns_empty(self):
-        """The server returns a specific sentinel when nothing matches —
-        we must not wrap it in mnemon-context tags and inject noise."""
-        from mnemon.hooks.context_surfacing import (
-            NO_RESULTS_SENTINEL,
-            build_context,
-        )
+    def test_empty_json_array_returns_empty(self):
+        """Post-0.5.0 the server returns [] when nothing matches — we
+        must not wrap an empty list in mnemon-context tags."""
+        from mnemon.hooks.context_surfacing import build_context
 
-        assert build_context(NO_RESULTS_SENTINEL) == ""
+        assert build_context("[]") == ""
+
+    def test_invalid_json_returns_empty(self):
+        """Server contract violation — don't inject garbage into the prompt."""
+        from mnemon.hooks.context_surfacing import build_context
+
+        assert build_context("not json at all") == ""
 
     def test_wraps_in_mnemon_context_tags(self):
         from mnemon.hooks.context_surfacing import build_context
 
-        raw = "1. [note] **Title** (score: 0.80)\n   content here"
+        raw = json.dumps([self._json_result()])
         ctx = build_context(raw)
         assert ctx.startswith("<mnemon-context>")
         assert ctx.endswith("</mnemon-context>")
         assert "Relevant memories from previous sessions:" in ctx
-        assert raw in ctx
+        assert "**Title**" in ctx
+        assert "content here" in ctx
 
-    def test_preserves_server_formatting_unchanged(self):
-        """The server's pre-formatted snippets should pass through
-        untouched — no regex re-parsing, no re-ranking."""
+    def test_formats_multiple_results_with_metadata(self):
+        """JSON array should render to the same prose format the pre-0.5.0
+        server emitted — score, confidence, id, created date all visible."""
         from mnemon.hooks.context_surfacing import build_context
 
-        raw = (
-            "1. [decision] **Use PostgreSQL** (score: 0.950, confidence: 0.90)\n"
-            "   Chose PostgreSQL for JSON support.\n"
-            "   _id: 1 | created: 2026-04-08_\n"
-            "\n"
-            "2. [preference] **Tabs over spaces** (score: 0.320, confidence: 0.70)\n"
-            "   User prefers tabs.\n"
-            "   _id: 2 | created: 2026-04-07_"
-        )
+        raw = json.dumps([
+            self._json_result(
+                doc_id=1, title="Use PostgreSQL", content="Chose PostgreSQL for JSON support.",
+                content_type="decision", composite_score=0.950, confidence=0.90,
+                created_at="2026-04-08",
+            ),
+            self._json_result(
+                doc_id=2, title="Tabs over spaces", content="User prefers tabs.",
+                content_type="preference", composite_score=0.320, confidence=0.70,
+                created_at="2026-04-07",
+            ),
+        ])
         ctx = build_context(raw)
-        # All score/confidence/id metadata preserved.
         assert "score: 0.950" in ctx
         assert "confidence: 0.70" in ctx
         assert "_id: 1" in ctx
         assert "_id: 2" in ctx
+        assert "[decision]" in ctx
+        assert "[preference]" in ctx
+
+    def test_truncates_long_content_per_result(self):
+        """Each result's content is capped at 300 chars (the ellipsis
+        behavior the server used to apply server-side)."""
+        from mnemon.hooks.context_surfacing import build_context
+
+        raw = json.dumps([self._json_result(content="x" * 1000)])
+        ctx = build_context(raw)
+        assert "x" * 300 in ctx
+        # 301st char should not appear inline (the formatter truncates + ...).
+        assert "x" * 301 not in ctx
+        assert "..." in ctx
 
     def test_truncates_at_char_budget(self):
         from mnemon.hooks.context_surfacing import CHAR_BUDGET, build_context
 
-        raw = "X" * (CHAR_BUDGET * 2)
-        ctx = build_context(raw)
-        # Output includes the wrapper + truncation marker, but the inner
-        # payload is capped at CHAR_BUDGET chars.
+        # Create enough results to blow past CHAR_BUDGET.
+        results = [
+            self._json_result(doc_id=i, title=f"T{i}", content="x" * 200)
+            for i in range(200)
+        ]
+        ctx = build_context(json.dumps(results))
         assert "[truncated]" in ctx
-        # Sanity: total length bounded (wrapper adds <200 chars).
         assert len(ctx) < CHAR_BUDGET + 300
 
     def test_no_truncation_when_within_budget(self):
         from mnemon.hooks.context_surfacing import build_context
 
-        raw = "1. [note] **Small** (score: 0.5)\n   Small content"
+        raw = json.dumps([self._json_result(title="Small", content="Small content")])
         ctx = build_context(raw)
         assert "[truncated]" not in ctx
 
@@ -300,11 +331,13 @@ class TestContextSurfacingMain:
     def test_full_pipeline_calls_remote_and_emits_context(self):
         from mnemon.hooks.context_surfacing import main
 
-        raw_tool_output = (
-            "1. [note] **Pipeline** (score: 0.750, confidence: 0.80)\n"
-            "   It works via Step Functions\n"
-            "   _id: 42 | created: 2026-04-08_"
-        )
+        raw_tool_output = json.dumps([{
+            "doc_id": 42, "title": "Pipeline",
+            "content": "It works via Step Functions",
+            "content_type": "note", "confidence": 0.80,
+            "composite_score": 0.750, "vector_similarity": None,
+            "created_at": "2026-04-08",
+        }])
         with patch(
             "mnemon.hooks.framework.read_stdin",
             return_value={"prompt": "how does the pipeline work?"},
@@ -379,15 +412,12 @@ class TestContextSurfacingMain:
         mock_call.assert_not_called()
 
     def test_no_results_still_marks_seen(self):
-        """Even when memory_search returns the no-results sentinel, we
-        mark the prompt as seen so an immediate identical resubmit does
-        not re-hit the network. The remote call succeeded — the prompt
-        just has no matches — and dedup is about suppressing redundant
-        work, not about gating on output."""
-        from mnemon.hooks.context_surfacing import (
-            NO_RESULTS_SENTINEL,
-            main,
-        )
+        """Even when memory_search returns an empty array, we mark the
+        prompt as seen so an immediate identical resubmit does not re-hit
+        the network. The remote call succeeded — the prompt just has no
+        matches — and dedup is about suppressing redundant work, not
+        about gating on output."""
+        from mnemon.hooks.context_surfacing import main
 
         with patch(
             "mnemon.hooks.framework.read_stdin",
@@ -402,7 +432,7 @@ class TestContextSurfacingMain:
             "mnemon.hooks.framework.write_output"
         ) as mock_write, patch(
             "mnemon.hooks._remote_client.call_tool_sync",
-            return_value=(NO_RESULTS_SENTINEL, 0.3),
+            return_value=("[]", 0.3),
         ):
             main()
         mock_write.assert_not_called()
@@ -520,11 +550,12 @@ class TestContextSurfacingMain:
         latency degradation without watching logs."""
         from mnemon.hooks.context_surfacing import SLOW_THRESHOLD_SEC, main
 
-        raw_tool_output = (
-            "1. [note] **Thing** (score: 0.80)\n"
-            "   Some content\n"
-            "   _id: 1 | created: 2026-04-11_"
-        )
+        raw_tool_output = json.dumps([{
+            "doc_id": 1, "title": "Thing", "content": "Some content",
+            "content_type": "note", "confidence": 0.80,
+            "composite_score": 0.80, "vector_similarity": None,
+            "created_at": "2026-04-11",
+        }])
         slow_elapsed = SLOW_THRESHOLD_SEC + 1.0
 
         with patch(
@@ -557,11 +588,12 @@ class TestContextSurfacingMain:
         the context block contains only the memories header and results."""
         from mnemon.hooks.context_surfacing import SLOW_THRESHOLD_SEC, main
 
-        raw_tool_output = (
-            "1. [note] **Fast** (score: 0.90)\n"
-            "   Quick response\n"
-            "   _id: 2 | created: 2026-04-11_"
-        )
+        raw_tool_output = json.dumps([{
+            "doc_id": 2, "title": "Fast", "content": "Quick response",
+            "content_type": "note", "confidence": 0.90,
+            "composite_score": 0.90, "vector_similarity": None,
+            "created_at": "2026-04-11",
+        }])
         fast_elapsed = SLOW_THRESHOLD_SEC - 0.5
 
         with patch(
@@ -705,10 +737,10 @@ class TestSessionExtractorIsDuplicateRemote:
         with patch("mnemon.hooks._remote_client.call_tool_sync", return_value=(raw, 0.3)):
             assert is_duplicate_remote("title", "content") is True
 
-    def test_calls_structured_tool_not_text(self):
-        """Guard against regression to text-parsing dedup. The hook must
-        use memory_search_structured so scores aren't parsed from
-        human-readable formatted output."""
+    def test_calls_memory_search_not_text_parser(self):
+        """Guard against regression to text-parsing dedup. Post-0.5.0
+        memory_search returns JSON directly — the hook must consume
+        it as JSON and not regex it."""
         from mnemon.hooks.session_extractor import is_duplicate_remote
 
         raw = json.dumps([])
@@ -717,7 +749,7 @@ class TestSessionExtractorIsDuplicateRemote:
             return_value=(raw, 0.1),
         ) as mock_call:
             is_duplicate_remote("title", "content")
-        assert mock_call.call_args[0][0] == "memory_search_structured"
+        assert mock_call.call_args[0][0] == "memory_search"
 
 
 # ── session_extractor.py: main ────────────────────────────────────────────────

--- a/tests/test_integration_remote.py
+++ b/tests/test_integration_remote.py
@@ -6,7 +6,7 @@ to point at it via ``MNEMON_REMOTE_URL`` + ``MNEMON_LOCAL_TOKEN``, and
 exercises the actual MCP Streamable HTTP round-trip:
 
 1. ``memory_save`` lands in the server's vault
-2. ``memory_search_structured`` retrieves the saved memory
+2. ``memory_search`` retrieves the saved memory
 3. Bearer token auth works end-to-end (wrong token returns 401-ish error)
 
 Unit tests in ``test_hooks_extended.py`` mock ``call_tool_sync``. Those
@@ -147,7 +147,7 @@ def remote_env(monkeypatch, remote_server):
 
 def test_save_and_search_round_trip(remote_env):
     """Full path: call memory_save via _remote_client, then retrieve it
-    via memory_search_structured. Proves the hook → MCP SDK → Streamable
+    via memory_search. Proves the hook → MCP SDK → Streamable
     HTTP → FastMCP → Store pipeline is intact end-to-end."""
     from mnemon.hooks._remote_client import call_tool_sync
 
@@ -169,7 +169,7 @@ def test_save_and_search_round_trip(remote_env):
     # Round-trip via structured search — verifies the save actually
     # landed and indexing worked.
     search_result, _ = call_tool_sync(
-        "memory_search_structured",
+        "memory_search",
         {"query": "integration test memory", "limit": 5},
         timeout=30.0,
         client_label="pytest-integration",
@@ -194,7 +194,7 @@ def test_wrong_token_is_rejected(monkeypatch, remote_server):
 
     with pytest.raises(Exception):
         call_tool_sync(
-            "memory_search_structured",
+            "memory_search",
             {"query": "anything", "limit": 1},
             timeout=10.0,
             client_label="pytest-integration",
@@ -223,7 +223,7 @@ def test_structured_search_parses_real_server_json(remote_env):
     )
 
     raw, _ = call_tool_sync(
-        "memory_search_structured",
+        "memory_search",
         {"query": "schema guard memory", "limit": 5},
         timeout=30.0,
     )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,6 @@
 """Tests for the MCP server tool handlers."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -7,6 +8,7 @@ import pytest
 import mnemon.server as server_mod
 from mnemon.server import (
     memory_check_contradictions,
+    memory_export_vectors,
     memory_forget,
     memory_get,
     memory_pin,
@@ -14,7 +16,6 @@ from mnemon.server import (
     memory_related,
     memory_save,
     memory_search,
-    memory_search_structured,
     memory_status,
     memory_sweep,
     memory_timeline,
@@ -52,59 +53,48 @@ def _make_search_result(**overrides):
 
 
 def _make_document(**overrides):
-    """Build a mock Document."""
+    """Build a real Document dataclass instance. Post-0.5.0 the JSON-returning
+    tools serialize docs via ``dataclasses.asdict``, so test fixtures must be
+    real dataclasses rather than MagicMocks."""
+    from mnemon.store import Document
     defaults = {
-        "id": 1,
-        "collection": "default",
-        "path": None,
-        "title": "Test Doc",
-        "hash": "abc123",
-        "content_type": "note",
-        "memory_type": "explicit",
-        "confidence": 0.80,
-        "access_count": 1,
-        "is_pinned": False,
-        "is_invalidated": False,
-        "created_at": "2026-04-01T00:00:00Z",
+        "id": 1, "collection": "default", "path": None, "title": "Test Doc",
+        "hash": "abc123", "content_type": "note", "memory_type": "semantic",
+        "confidence": 0.80, "quality_score": 0.0, "access_count": 1,
+        "pinned": 0, "source_client": None, "invalidated_at": None,
+        "invalidated_by": None, "created_at": "2026-04-01T00:00:00Z",
         "updated_at": "2026-04-01T00:00:00Z",
         "content": "Full document content here.",
-        "source_client": None,
     }
     defaults.update(overrides)
-    m = MagicMock()
-    for k, v in defaults.items():
-        setattr(m, k, v)
-    return m
+    return Document(**defaults)
 
 
 def _make_sweep_candidate(**overrides):
-    """Build a mock SweepCandidate."""
+    """Build a real SweepCandidate dataclass instance."""
+    from mnemon.store import SweepCandidate
     defaults = {
-        "id": 5,
-        "title": "Old Memory",
-        "content_type": "note",
-        "age_days": 120,
+        "id": 5, "title": "Old Memory",
+        "content_type": "note", "age_days": 120,
     }
     defaults.update(overrides)
-    m = MagicMock()
-    for k, v in defaults.items():
-        setattr(m, k, v)
-    return m
+    return SweepCandidate(**defaults)
 
 
 def _make_related(**overrides):
-    """Build a mock RelatedDocument."""
+    """Build a real RelatedDocument dataclass instance."""
+    from mnemon.store import RelatedDocument
     defaults = {
-        "id": 2,
-        "title": "Related Doc",
-        "relation_type": "supports",
-        "weight": 0.85,
+        "id": 2, "collection": "default", "path": None, "title": "Related Doc",
+        "hash": "def456", "content_type": "note", "memory_type": "semantic",
+        "confidence": 0.80, "quality_score": 0.0, "access_count": 0,
+        "pinned": 0, "source_client": None, "invalidated_at": None,
+        "invalidated_by": None, "created_at": "2026-04-01T00:00:00Z",
+        "updated_at": "2026-04-01T00:00:00Z", "content": "",
+        "relation_type": "supports", "weight": 0.85,
     }
     defaults.update(overrides)
-    m = MagicMock()
-    for k, v in defaults.items():
-        setattr(m, k, v)
-    return m
+    return RelatedDocument(**defaults)
 
 
 # ── _get_store ───────────────────────────────────────────────────────────────
@@ -129,88 +119,29 @@ class TestGetStore:
 
 
 class TestMemorySearch:
+    """Post-0.5.0 memory_search returns a JSON array directly (the old
+    paired prose tool is gone). Clients needing human-facing output
+    format the JSON themselves — e.g., context_surfacing hook."""
+
     @patch("mnemon.server.search")
     @patch("mnemon.server.Store")
-    def test_no_results(self, MockStore, mock_search):
+    def test_no_results_returns_empty_array(self, MockStore, mock_search):
         mock_search.return_value = []
-        result = memory_search("test query")
-        assert result == "No memories found matching your query."
-
-    @patch("mnemon.server.search")
-    @patch("mnemon.server.Store")
-    def test_with_results(self, MockStore, mock_search):
-        r1 = _make_search_result(doc_id=1, title="Alpha", composite_score=0.9, confidence=0.85)
-        r2 = _make_search_result(doc_id=2, title="Beta", composite_score=0.7, confidence=0.60)
-        mock_search.return_value = [r1, r2]
-
-        result = memory_search("test query", limit=5)
-        assert "1. [note] **Alpha**" in result
-        assert "2. [note] **Beta**" in result
-        assert "score: 0.900" in result
-        assert "confidence: 0.85" in result
-        assert "id: 1" in result
-        assert "id: 2" in result
-
-    @patch("mnemon.server.search")
-    @patch("mnemon.server.Store")
-    def test_long_content_truncated(self, MockStore, mock_search):
-        long_content = "x" * 500
-        r = _make_search_result(content=long_content)
-        mock_search.return_value = [r]
-
-        result = memory_search("query")
-        assert "..." in result
-        # Only first 300 chars of content should appear
-        assert "x" * 300 in result
-        assert "x" * 301 not in result
-
-    @patch("mnemon.server.search")
-    @patch("mnemon.server.Store")
-    def test_short_content_no_ellipsis(self, MockStore, mock_search):
-        r = _make_search_result(content="short")
-        mock_search.return_value = [r]
-
-        result = memory_search("query")
-        assert "..." not in result
-
-    @patch("mnemon.server.search")
-    @patch("mnemon.server.Store")
-    def test_passes_content_type(self, MockStore, mock_search):
-        mock_search.return_value = []
-        memory_search("query", content_type="decision")
-        mock_search.assert_called_once_with(
-            MockStore.return_value, "query", limit=10, content_type="decision"
-        )
-
-
-# ── memory_search_structured ─────────────────────────────────────────────────
-
-
-class TestMemorySearchStructured:
-    @patch("mnemon.server.search")
-    @patch("mnemon.server.Store")
-    def test_empty_results_returns_empty_json_array(self, MockStore, mock_search):
-        import json
-        mock_search.return_value = []
-        result = memory_search_structured("q")
-        assert json.loads(result) == []
+        assert json.loads(memory_search("test query")) == []
 
     @patch("mnemon.server.search")
     @patch("mnemon.server.Store")
     def test_results_are_json_objects_with_numeric_scores(self, MockStore, mock_search):
-        import json
-        r1 = _make_search_result(doc_id=1, title="Alpha", composite_score=0.9, confidence=0.85)
-        r2 = _make_search_result(doc_id=2, title="Beta", composite_score=0.7, confidence=0.60)
+        r1 = _make_search_result(doc_id=1, title="Alpha",
+                                 composite_score=0.9, confidence=0.85)
+        r2 = _make_search_result(doc_id=2, title="Beta",
+                                 composite_score=0.7, confidence=0.60)
         mock_search.return_value = [r1, r2]
 
-        result = memory_search_structured("q", limit=5)
-        parsed = json.loads(result)
-
+        parsed = json.loads(memory_search("q", limit=5))
         assert len(parsed) == 2
         assert parsed[0]["doc_id"] == 1
         assert parsed[0]["title"] == "Alpha"
-        # Scores are native floats — callers can compare against thresholds
-        # without parsing any string format.
         assert isinstance(parsed[0]["composite_score"], float)
         assert parsed[0]["composite_score"] == 0.9
         assert parsed[1]["composite_score"] == 0.7
@@ -218,14 +149,12 @@ class TestMemorySearchStructured:
     @patch("mnemon.server.search")
     @patch("mnemon.server.Store")
     def test_includes_all_expected_fields(self, MockStore, mock_search):
-        import json
         mock_search.return_value = [_make_search_result(
             doc_id=42, title="T", content="C", content_type="decision",
             confidence=0.9, composite_score=0.5, vector_similarity=0.87,
             created_at="2026-04-12T00:00:00Z",
         )]
-        result = memory_search_structured("q")
-        parsed = json.loads(result)[0]
+        parsed = json.loads(memory_search("q"))[0]
         expected = {"doc_id", "title", "content", "content_type",
                     "confidence", "composite_score", "vector_similarity",
                     "created_at"}
@@ -236,9 +165,9 @@ class TestMemorySearchStructured:
     @patch("mnemon.server.Store")
     def test_passes_content_type(self, MockStore, mock_search):
         mock_search.return_value = []
-        memory_search_structured("q", content_type="preference")
+        memory_search("query", content_type="decision")
         mock_search.assert_called_once_with(
-            MockStore.return_value, "q", limit=10, content_type="preference"
+            MockStore.return_value, "query", limit=10, content_type="decision"
         )
 
 
@@ -257,17 +186,18 @@ class TestMemoryGet:
         )
         MockStore.return_value.get.return_value = doc
 
-        result = memory_get(1)
-        assert result.startswith("# My Decision")
-        assert "decision" in result
-        assert "0.90" in result
-        assert "We chose option A." in result
+        parsed = json.loads(memory_get(1))
+        assert parsed["id"] == 1
+        assert parsed["title"] == "My Decision"
+        assert parsed["content_type"] == "decision"
+        assert parsed["confidence"] == 0.90
+        assert parsed["content"] == "We chose option A."
 
     @patch("mnemon.server.Store")
     def test_not_found(self, MockStore):
         MockStore.return_value.get.return_value = None
-        result = memory_get(999)
-        assert result == "Memory #999 not found."
+        parsed = json.loads(memory_get(999))
+        assert parsed == {"error": "not_found", "id": 999}
 
 
 # ── memory_timeline ──────────────────────────────────────────────────────────
@@ -277,8 +207,7 @@ class TestMemoryTimeline:
     @patch("mnemon.server.Store")
     def test_empty(self, MockStore):
         MockStore.return_value.timeline.return_value = []
-        result = memory_timeline()
-        assert result == "No memories found."
+        assert json.loads(memory_timeline()) == []
 
     @patch("mnemon.server.Store")
     def test_populated(self, MockStore):
@@ -286,11 +215,12 @@ class TestMemoryTimeline:
         d2 = _make_document(id=11, title="Second", content_type="decision", created_at="2026-04-02")
         MockStore.return_value.timeline.return_value = [d1, d2]
 
-        result = memory_timeline(limit=5, content_type="note")
-        assert "**First** [note]" in result
-        assert "**Second** [decision]" in result
-        assert "id: 10" in result
-        assert "id: 11" in result
+        parsed = json.loads(memory_timeline(limit=5, content_type="note"))
+        assert len(parsed) == 2
+        assert parsed[0]["id"] == 10
+        assert parsed[0]["title"] == "First"
+        assert parsed[1]["id"] == 11
+        assert parsed[1]["content_type"] == "decision"
 
     @patch("mnemon.server.Store")
     def test_passes_args(self, MockStore):
@@ -391,8 +321,8 @@ class TestMemoryForget:
 
 class TestMemoryStatus:
     @patch("mnemon.server.Store")
-    def test_returns_formatted_status(self, MockStore):
-        MockStore.return_value.status.return_value = {
+    def test_returns_raw_status_dict(self, MockStore):
+        status = {
             "vault_path": "/home/user/.mnemon/default.sqlite",
             "total_documents": 42,
             "total_vectors": 38,
@@ -403,30 +333,18 @@ class TestMemoryStatus:
                 {"content_type": "decision", "count": 12},
             ],
         }
-
-        result = memory_status()
-        assert "Vault: /home/user/.mnemon/default.sqlite" in result
-        assert "Total memories: 42" in result
-        assert "Vectors: 38" in result
-        assert "Pinned: 3" in result
-        assert "Invalidated: 1" in result
-        assert "note: 30" in result
-        assert "decision: 12" in result
+        MockStore.return_value.status.return_value = status
+        assert json.loads(memory_status()) == status
 
     @patch("mnemon.server.Store")
     def test_empty_vault(self, MockStore):
-        MockStore.return_value.status.return_value = {
+        status = {
             "vault_path": "/tmp/test.sqlite",
-            "total_documents": 0,
-            "total_vectors": 0,
-            "pinned": 0,
-            "invalidated": 0,
-            "by_type": [],
+            "total_documents": 0, "total_vectors": 0,
+            "pinned": 0, "invalidated": 0, "by_type": [],
         }
-
-        result = memory_status()
-        assert "Total memories: 0" in result
-        assert "By type:" in result
+        MockStore.return_value.status.return_value = status
+        assert json.loads(memory_status()) == status
 
 
 # ── memory_sweep ─────────────────────────────────────────────────────────────
@@ -435,34 +353,38 @@ class TestMemoryStatus:
 class TestMemorySweep:
     @patch("mnemon.server.Store")
     def test_no_candidates(self, MockStore):
-        MockStore.return_value.sweep.return_value = {"candidates": []}
-        result = memory_sweep()
-        assert result == "No stale memories to archive."
+        MockStore.return_value.sweep.return_value = {"archived": 0, "candidates": []}
+        assert json.loads(memory_sweep()) == {"archived": 0, "candidates": []}
 
     @patch("mnemon.server.Store")
     def test_dry_run_with_candidates(self, MockStore):
-        c1 = _make_sweep_candidate(id=10, title="Old Note", content_type="note", age_days=90)
-        c2 = _make_sweep_candidate(id=11, title="Stale Obs", content_type="observation", age_days=200)
-        MockStore.return_value.sweep.return_value = {"candidates": [c1, c2]}
-
-        result = memory_sweep(dry_run=True)
-        assert "Would archive 2 memories:" in result
-        assert '#10 "Old Note" [note]' in result
-        assert '#11 "Stale Obs" [observation]' in result
-        assert "90 days old" in result
+        c1 = _make_sweep_candidate(id=10, title="Old Note",
+                                   content_type="note", age_days=90)
+        c2 = _make_sweep_candidate(id=11, title="Stale Obs",
+                                   content_type="observation", age_days=200)
+        MockStore.return_value.sweep.return_value = {
+            "archived": 0, "candidates": [c1, c2],
+        }
+        parsed = json.loads(memory_sweep(dry_run=True))
+        assert parsed["archived"] == 0
+        assert len(parsed["candidates"]) == 2
+        assert parsed["candidates"][0]["id"] == 10
+        assert parsed["candidates"][1]["age_days"] == 200
 
     @patch("mnemon.server.Store")
     def test_real_sweep(self, MockStore):
-        c = _make_sweep_candidate(id=5, title="Gone", content_type="note", age_days=365)
-        MockStore.return_value.sweep.return_value = {"candidates": [c]}
-
-        result = memory_sweep(dry_run=False)
-        assert "Archived 1 memories:" in result
-        assert "Would archive" not in result
+        c = _make_sweep_candidate(id=5, title="Gone",
+                                  content_type="note", age_days=365)
+        MockStore.return_value.sweep.return_value = {
+            "archived": 1, "candidates": [c],
+        }
+        parsed = json.loads(memory_sweep(dry_run=False))
+        assert parsed["archived"] == 1
+        assert len(parsed["candidates"]) == 1
 
     @patch("mnemon.server.Store")
     def test_passes_dry_run_arg(self, MockStore):
-        MockStore.return_value.sweep.return_value = {"candidates": []}
+        MockStore.return_value.sweep.return_value = {"archived": 0, "candidates": []}
         memory_sweep(dry_run=False)
         MockStore.return_value.sweep.assert_called_once_with(False)
 
@@ -474,21 +396,22 @@ class TestMemoryRelated:
     @patch("mnemon.server.Store")
     def test_empty(self, MockStore):
         MockStore.return_value.get_related.return_value = []
-        result = memory_related(1)
-        assert result == "No related memories found for #1."
+        assert json.loads(memory_related(1)) == []
 
     @patch("mnemon.server.Store")
     def test_populated(self, MockStore):
-        r1 = _make_related(id=2, title="Supporting Doc", relation_type="supports", weight=0.90)
-        r2 = _make_related(id=3, title="Contradicting Doc", relation_type="contradicts", weight=0.70)
+        r1 = _make_related(id=2, title="Supporting Doc",
+                           relation_type="supports", weight=0.90)
+        r2 = _make_related(id=3, title="Contradicting Doc",
+                           relation_type="contradicts", weight=0.70)
         MockStore.return_value.get_related.return_value = [r1, r2]
 
-        result = memory_related(1, limit=5)
-        assert "[supports] **Supporting Doc**" in result
-        assert "weight: 0.90" in result
-        assert "[contradicts] **Contradicting Doc**" in result
-        assert "id: 2" in result
-        assert "id: 3" in result
+        parsed = json.loads(memory_related(1, limit=5))
+        assert len(parsed) == 2
+        assert parsed[0]["id"] == 2
+        assert parsed[0]["relation_type"] == "supports"
+        assert parsed[0]["weight"] == 0.90
+        assert parsed[1]["relation_type"] == "contradicts"
 
     @patch("mnemon.server.Store")
     def test_passes_args(self, MockStore):
@@ -582,63 +505,58 @@ class TestProfileGet:
     @patch("mnemon.server.Store")
     def test_no_data(self, MockStore):
         MockStore.return_value.timeline.return_value = []
-
-        result = profile_get()
-        assert "No profile data yet" in result
+        assert json.loads(profile_get()) == {"preferences": [], "decisions": []}
 
     @patch("mnemon.server.Store")
     def test_only_preferences(self, MockStore):
-        pref = _make_document(title="Dark Mode", content="User prefers dark mode in all editors.")
-        mock_store = MockStore.return_value
-        mock_store.timeline.side_effect = lambda limit, ct: (
+        pref = _make_document(title="Dark Mode",
+                              content="User prefers dark mode in all editors.")
+        MockStore.return_value.timeline.side_effect = lambda limit, ct: (
             [pref] if ct == "preference" else []
         )
-
-        result = profile_get()
-        assert "## Preferences" in result
-        assert "**Dark Mode**" in result
-        assert "## Key Decisions" not in result
+        parsed = json.loads(profile_get())
+        assert len(parsed["preferences"]) == 1
+        assert parsed["preferences"][0]["title"] == "Dark Mode"
+        assert parsed["decisions"] == []
 
     @patch("mnemon.server.Store")
     def test_only_decisions(self, MockStore):
-        dec = _make_document(title="Use Python", content="Decided to use Python over TypeScript.")
-        mock_store = MockStore.return_value
-        mock_store.timeline.side_effect = lambda limit, ct: (
+        dec = _make_document(title="Use Python",
+                             content="Decided to use Python over TypeScript.")
+        MockStore.return_value.timeline.side_effect = lambda limit, ct: (
             [dec] if ct == "decision" else []
         )
-
-        result = profile_get()
-        assert "## Key Decisions" in result
-        assert "**Use Python**" in result
-        assert "## Preferences" not in result
+        parsed = json.loads(profile_get())
+        assert parsed["preferences"] == []
+        assert len(parsed["decisions"]) == 1
+        assert parsed["decisions"][0]["title"] == "Use Python"
 
     @patch("mnemon.server.Store")
     def test_both_preferences_and_decisions(self, MockStore):
         pref = _make_document(title="Vim Keys", content="Prefers vim keybindings.")
-        dec = _make_document(title="Chose SQLite", content="SQLite over Postgres for simplicity.")
-        mock_store = MockStore.return_value
-        mock_store.timeline.side_effect = lambda limit, ct: (
+        dec = _make_document(title="Chose SQLite",
+                             content="SQLite over Postgres for simplicity.")
+        MockStore.return_value.timeline.side_effect = lambda limit, ct: (
             [pref] if ct == "preference" else [dec] if ct == "decision" else []
         )
-
-        result = profile_get()
-        assert "## Preferences" in result
-        assert "## Key Decisions" in result
-        assert "**Vim Keys**" in result
-        assert "**Chose SQLite**" in result
+        parsed = json.loads(profile_get())
+        assert len(parsed["preferences"]) == 1
+        assert len(parsed["decisions"]) == 1
+        assert parsed["preferences"][0]["title"] == "Vim Keys"
+        assert parsed["decisions"][0]["title"] == "Chose SQLite"
 
     @patch("mnemon.server.Store")
-    def test_long_content_truncated(self, MockStore):
+    def test_content_not_truncated(self, MockStore):
+        """Post-0.5.0 the tool returns raw document content — any truncation
+        is the client's responsibility (e.g., the dashboard or the LLM
+        formatter). This test locks that in so we don't silently truncate
+        on the server again."""
         pref = _make_document(title="Long Pref", content="z" * 500)
-        mock_store = MockStore.return_value
-        mock_store.timeline.side_effect = lambda limit, ct: (
+        MockStore.return_value.timeline.side_effect = lambda limit, ct: (
             [pref] if ct == "preference" else []
         )
-
-        result = profile_get()
-        # Content should be truncated to 200 chars
-        assert "z" * 200 in result
-        assert "z" * 201 not in result
+        parsed = json.loads(profile_get())
+        assert parsed["preferences"][0]["content"] == "z" * 500
 
 
 # ── profile_update ───────────────────────────────────────────────────────────
@@ -739,3 +657,85 @@ class TestMemoryCheckContradictions:
             result = memory_check_contradictions(1)
 
         assert "0 memories had their confidence decayed." in result
+
+
+# ── memory_export_vectors ────────────────────────────────────────────────────
+
+
+class TestMemoryExportVectors:
+    @patch("mnemon.server.Store")
+    def test_empty_vault(self, MockStore):
+        import numpy as np
+        MockStore.return_value.vec_store.export_all.return_value = (
+            [], np.zeros((0, 384))
+        )
+        MockStore.return_value.vec_store.dim = 384
+        assert json.loads(memory_export_vectors()) == {
+            "count": 0, "dim": 384, "truncated": False, "items": [],
+        }
+
+    @patch("mnemon.server.Store")
+    def test_joins_vectors_to_docs(self, MockStore):
+        import numpy as np
+        vec_ids = ["abc_0", "def_0"]
+        vectors = np.array([[0.1] * 384, [0.2] * 384], dtype=np.float32)
+        MockStore.return_value.vec_store.export_all.return_value = (vec_ids, vectors)
+        MockStore.return_value.vec_store.dim = 384
+        rows = [
+            {"hash": "abc", "id": 1, "title": "First",
+             "content_type": "note", "confidence": 0.5,
+             "created_at": "2026-01-01", "pinned": 0},
+            {"hash": "def", "id": 2, "title": "Second",
+             "content_type": "decision", "confidence": 0.85,
+             "created_at": "2026-01-02", "pinned": 1},
+        ]
+        MockStore.return_value.db.execute.return_value.fetchall.return_value = rows
+
+        parsed = json.loads(memory_export_vectors())
+        assert parsed["count"] == 2
+        assert parsed["dim"] == 384
+        assert parsed["truncated"] is False
+        first = next(i for i in parsed["items"] if i["doc_id"] == 1)
+        assert first["title"] == "First"
+        assert first["pinned"] is False
+        assert len(first["vector"]) == 384
+        second = next(i for i in parsed["items"] if i["doc_id"] == 2)
+        assert second["pinned"] is True
+
+    @patch("mnemon.server.Store")
+    def test_skips_vectors_with_invalidated_docs(self, MockStore):
+        """Vectors whose source doc was invalidated/deleted are skipped."""
+        import numpy as np
+        MockStore.return_value.vec_store.export_all.return_value = (
+            ["abc_0", "orphan_0"],
+            np.array([[0.1] * 384, [0.3] * 384], dtype=np.float32),
+        )
+        MockStore.return_value.vec_store.dim = 384
+        MockStore.return_value.db.execute.return_value.fetchall.return_value = [
+            {"hash": "abc", "id": 1, "title": "Kept",
+             "content_type": "note", "confidence": 0.5,
+             "created_at": "2026-01-01", "pinned": 0},
+        ]
+        parsed = json.loads(memory_export_vectors())
+        assert parsed["count"] == 1
+        assert parsed["items"][0]["doc_id"] == 1
+
+    @patch("mnemon.server.Store")
+    def test_truncates_at_cap(self, MockStore):
+        import numpy as np
+        from mnemon.server import _VECTOR_EXPORT_MAX
+        n = _VECTOR_EXPORT_MAX + 50
+        vec_ids = [f"hash{i}_0" for i in range(n)]
+        vectors = np.zeros((n, 384), dtype=np.float32)
+        MockStore.return_value.vec_store.export_all.return_value = (vec_ids, vectors)
+        MockStore.return_value.vec_store.dim = 384
+        rows = [
+            {"hash": f"hash{i}", "id": i, "title": f"T{i}",
+             "content_type": "note", "confidence": 0.5,
+             "created_at": "2026-01-01", "pinned": 0}
+            for i in range(_VECTOR_EXPORT_MAX)
+        ]
+        MockStore.return_value.db.execute.return_value.fetchall.return_value = rows
+        parsed = json.loads(memory_export_vectors())
+        assert parsed["truncated"] is True
+        assert parsed["count"] == _VECTOR_EXPORT_MAX

--- a/tests/test_server_remote.py
+++ b/tests/test_server_remote.py
@@ -59,10 +59,11 @@ class TestMcpServer:
         from mnemon.server import mcp
         tool_names = set(mcp._tool_manager._tools.keys())
         expected = {
-            "memory_search", "memory_search_structured",
+            "memory_search",
             "memory_get", "memory_timeline",
             "memory_save", "memory_pin", "memory_forget",
             "memory_status", "memory_sweep", "memory_related",
+            "memory_export_vectors",
             "memory_rebuild", "memory_check_contradictions",
             "profile_get", "profile_update",
         }

--- a/tests/test_vecstore.py
+++ b/tests/test_vecstore.py
@@ -78,3 +78,20 @@ class TestVecStore:
     def test_dim_validation(self, vecstore):
         with pytest.raises(ValueError):
             vecstore.set("a_0", np.array([1, 0, 0], dtype=np.float32))
+
+    def test_export_all_empty(self, vecstore):
+        ids, vectors = vecstore.export_all()
+        assert ids == []
+        assert vectors.shape == (0, vecstore.dim)
+
+    def test_export_all_returns_snapshot(self, vecstore):
+        vecstore.set("a_0", np.array([1, 0, 0, 0], dtype=np.float32))
+        vecstore.set("b_0", np.array([0, 1, 0, 0], dtype=np.float32))
+
+        ids, vectors = vecstore.export_all()
+        assert ids == ["a_0", "b_0"]
+        assert vectors.shape == (2, 4)
+        # Mutations on the returned array must not affect the in-memory store.
+        vectors[0][0] = 99.0
+        _, vectors2 = vecstore.export_all()
+        assert vectors2[0][0] == 1.0


### PR DESCRIPTION
**Breaking change.** Single-format JSON for all informational tools — no more paired prose + structured variants.

## Why

Review feedback: 19 tools was unnecessary duplication, and modern LLM clients parse JSON cleanly. Single-format contract is simpler to reason about for both dashboard (which needs JSON anyway) and LLM consumers.

## Breaking surface

**JSON now**: `memory_search`, `memory_get`, `memory_timeline`, `memory_status`, `memory_sweep`, `memory_related`, `profile_get`.

**Gone**: `memory_search_structured` (its logic moved into `memory_search`).

**Still prose** (confirmation strings, no data): `memory_save`, `memory_pin`, `memory_forget`, `memory_rebuild`, `memory_check_contradictions`, `profile_update`.

**Migration for direct consumers**: call the same tool name, `json.loads()` the result. Empty is `"[]"` not a prose sentinel.

## Added

- `memory_export_vectors` (new, JSON-only) — full embedding matrix joined to doc metadata for remote-aware dashboards running UMAP client-side. Capped at 5000 vectors with a `truncated` flag.
- `VecStore.export_all()` snapshot helper.

## In-tree consumer migrations

- `context_surfacing` hook: parses JSON and formats the `<mnemon-context>` markdown block client-side. **LLM-visible context is shape-identical to 0.4.x** — only the serialization-vs-client-formatting boundary moved.
- `session_extractor` dedup: calls `memory_search` (was `memory_search_structured`).

## Test plan

- [x] `pytest` — 457 pass
- [x] `ruff check src/` — clean
- [x] `mnemon --version` → 0.5.0
- [ ] After merge: `fly deploy` → v18 (server changes must land before dashboard PR B consumes them)
- [ ] After merge: PR B rewrites dashboard `loaders.py` to call these JSON tools
- [ ] After PR B merges: publish to PyPI, tag v0.5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)