### PR TITLE
feat: remote-aware dashboard loaders (PR B)

### DIFF
--- a/src/mnemon/dashboard/app.py
+++ b/src/mnemon/dashboard/app.py
@@ -33,8 +33,13 @@ def _render_sweep_candidates(sweep: dict) -> None:
 
 
 def main() -> None:
+    from mnemon.dashboard.loaders import _use_remote
+
     st.title("mnemon — Memory Vault")
-    st.caption("Long-term memory for AI agents")
+    st.caption(
+        "Long-term memory for AI agents"
+        + (" · remote" if _use_remote() else " · local")
+    )
 
     status = load_status()
     if not status or status["total_documents"] == 0:

--- a/src/mnemon/dashboard/loaders.py
+++ b/src/mnemon/dashboard/loaders.py
@@ -1,21 +1,68 @@
-"""Data access layer for the dashboard — wraps Store with Streamlit caching."""
+"""Data access layer for the dashboard.
+
+Post-0.5.0 the dashboard can point at either a **remote** vault (the
+default on Fly, via the ``memory_*`` MCP tools over Streamable HTTP) or
+a **local** vault (the SQLite file in ``~/.mnemon/``). Mode is detected
+from ``MNEMON_REMOTE_URL`` env var or the ``~/.mnemon/remote_url`` file;
+local mode is the fallback when neither is set.
+
+Streamlit ``@st.cache_data`` memoizes results per page-render cycle. A
+TTL of 5–15 min balances freshness (recent saves surface quickly) with
+cost (remote MCP calls are ~1s cold, ~100ms warm).
+"""
 
 from __future__ import annotations
 
 import dataclasses
+import json
+import os
 from pathlib import Path
 
 import numpy as np
 import streamlit as st
 
 
+# ── Mode detection ──────────────────────────────────────────────────────────
+
+
+def _use_remote() -> bool:
+    """True if the dashboard should route through the remote MCP server."""
+    if os.environ.get("MNEMON_REMOTE_URL", "").strip():
+        return True
+    remote_url_file = Path.home() / ".mnemon" / "remote_url"
+    if remote_url_file.exists() and remote_url_file.read_text().strip():
+        return True
+    return False
+
+
+def _call_remote(tool: str, args: dict) -> str:
+    """Call an MCP tool via the shared remote client. Raises on error —
+    callers decide whether to surface via ``st.error`` or silently fall
+    back."""
+    from mnemon.hooks._remote_client import call_tool_sync
+
+    raw, _elapsed = call_tool_sync(
+        tool,
+        args,
+        client_label="mnemon-dashboard",
+    )
+    return raw
+
+
+# ── Local-mode Store singleton ──────────────────────────────────────────────
+
+
 @st.cache_resource
 def get_store():
-    """Singleton read-only Store connection (cross-thread safe for Streamlit)."""
+    """Singleton read-only Store connection for local mode only.
+
+    Cross-thread safe via ``check_same_thread=False`` — Streamlit runs
+    pages in different threads than the cached Store. Not used when
+    ``_use_remote()`` is True.
+    """
     import sqlite3
     from mnemon.store import Store
     store = Store()
-    # Reopen with check_same_thread=False for Streamlit's multi-threaded pages
     store.db.close()
     store.db = sqlite3.connect(store.db_path, check_same_thread=False)
     store.db.row_factory = sqlite3.Row
@@ -24,30 +71,50 @@ def get_store():
     return store
 
 
+# ── Informational loaders (remote MCP + local fallback) ─────────────────────
+
+
 @st.cache_data(ttl=300)
 def load_status() -> dict:
     """Vault health stats."""
+    if _use_remote():
+        return json.loads(_call_remote("memory_status", {}))
     return get_store().status()
 
 
 @st.cache_data(ttl=300)
 def load_timeline(limit: int = 200, content_type: str | None = None) -> list[dict]:
-    """Recent memories as list of dicts."""
+    """Recent memories as a list of dicts."""
+    if _use_remote():
+        return json.loads(_call_remote(
+            "memory_timeline",
+            {"limit": limit, "content_type": content_type},
+        ))
     docs = get_store().timeline(limit, content_type)
     return [dataclasses.asdict(d) for d in docs]
 
 
 @st.cache_data(ttl=300)
 def load_search(query: str, limit: int = 20, content_type: str | None = None) -> list[dict]:
-    """Hybrid search results as list of dicts."""
+    """Hybrid search results as a list of dicts."""
+    if _use_remote():
+        return json.loads(_call_remote(
+            "memory_search",
+            {"query": query, "limit": limit, "content_type": content_type},
+        ))
     from mnemon.search import search
-    results = search(get_store(), query, limit=limit, content_type=content_type, use_vector=True)
+    results = search(
+        get_store(), query,
+        limit=limit, content_type=content_type, use_vector=True,
+    )
     return [dataclasses.asdict(r) for r in results]
 
 
 @st.cache_data(ttl=300)
 def load_sweep() -> dict:
-    """Stale memory candidates (dry_run=True)."""
+    """Stale-memory sweep candidates (dry-run)."""
+    if _use_remote():
+        return json.loads(_call_remote("memory_sweep", {"dry_run": True}))
     result = get_store().sweep(dry_run=True)
     result["candidates"] = [dataclasses.asdict(c) for c in result["candidates"]]
     return result
@@ -55,7 +122,12 @@ def load_sweep() -> dict:
 
 @st.cache_data(ttl=300)
 def load_document(doc_id: int) -> dict | None:
-    """Single document by ID."""
+    """Single document by ID, or None if not found."""
+    if _use_remote():
+        parsed = json.loads(_call_remote("memory_get", {"id": doc_id}))
+        if parsed.get("error") == "not_found":
+            return None
+        return parsed
     doc = get_store().get(doc_id)
     return dataclasses.asdict(doc) if doc else None
 
@@ -63,13 +135,57 @@ def load_document(doc_id: int) -> dict | None:
 @st.cache_data(ttl=300)
 def load_related(doc_id: int, limit: int = 10) -> list[dict]:
     """Related documents for a given doc_id."""
+    if _use_remote():
+        return json.loads(_call_remote(
+            "memory_related",
+            {"id": doc_id, "limit": limit},
+        ))
     rels = get_store().get_related(doc_id, limit)
     return [dataclasses.asdict(r) for r in rels]
 
 
+# ── Graph page: vectors + doc metadata ──────────────────────────────────────
+
+
 @st.cache_data(ttl=900)
-def load_vectors() -> tuple[list, np.ndarray] | None:
-    """Raw vectors from .npz file. Returns (ids, vectors) or None."""
+def load_vectors() -> tuple[list[str], np.ndarray, dict[str, dict]] | None:
+    """Return (vec_ids, vectors, vec_id_to_doc_map) or None when empty.
+
+    In **remote** mode, all three come from ``memory_export_vectors`` in
+    a single call — the server does the vec_id → doc join.
+
+    In **local** mode, vectors come from the ``.npz`` file and the
+    doc-map is built via a SQLite query keyed on content hash.
+
+    Returns None when the vault has no vectors yet (fresh install or
+    before first embedding).
+    """
+    if _use_remote():
+        payload = json.loads(_call_remote("memory_export_vectors", {}))
+        items = payload.get("items", [])
+        if not items:
+            return None
+        vec_ids = [it["vec_id"] for it in items]
+        vectors = np.array([it["vector"] for it in items], dtype=np.float32)
+        doc_map = {
+            it["vec_id"]: {
+                "id": it["doc_id"],
+                "title": it["title"],
+                "content_type": it["content_type"],
+                "confidence": it["confidence"],
+                "created_at": it["created_at"],
+            }
+            for it in items
+        }
+        if payload.get("truncated"):
+            st.warning(
+                f"Vector export was truncated to {payload.get('count')} of "
+                "your vault's vectors — increase the server-side cap or "
+                "paginate if you need the full set."
+            )
+        return vec_ids, vectors, doc_map
+
+    # Local mode
     from mnemon.config import vault_path
     vec_path = str(vault_path()).replace(".sqlite", ".vec.npz")
     if not Path(vec_path).exists():
@@ -79,12 +195,13 @@ def load_vectors() -> tuple[list, np.ndarray] | None:
     vectors = data["vectors"].astype(np.float32)
     if len(ids) == 0:
         return None
-    return ids, vectors
+    doc_map = _build_vector_doc_map_local(ids)
+    return ids, vectors, doc_map
 
 
 @st.cache_data(ttl=900)
 def load_umap_coords(_vectors: np.ndarray, n_neighbors: int = 15) -> np.ndarray:
-    """UMAP 384d -> 2D. Cached aggressively."""
+    """UMAP 384d → 2D. Cached aggressively since reprojecting is expensive."""
     import umap
     reducer = umap.UMAP(
         n_components=2,
@@ -96,12 +213,10 @@ def load_umap_coords(_vectors: np.ndarray, n_neighbors: int = 15) -> np.ndarray:
     return reducer.fit_transform(_vectors)
 
 
-def build_vector_doc_map(vec_ids: list[str]) -> dict[str, dict]:
-    """Map vector IDs to document metadata via content_hash.
-
-    Opens a separate SQLite connection to avoid cross-thread errors
-    (Streamlit runs pages in different threads than the cached Store).
-    """
+def _build_vector_doc_map_local(vec_ids: list[str]) -> dict[str, dict]:
+    """Local-mode doc-map: open a fresh SQLite connection and resolve
+    vec_ids → doc metadata via content_hash. Remote mode gets this
+    baked into ``memory_export_vectors``."""
     import sqlite3
     from mnemon.config import vault_path
 
@@ -110,7 +225,7 @@ def build_vector_doc_map(vec_ids: list[str]) -> dict[str, dict]:
         content_hash = vid.rsplit("_", 1)[0]
         hash_to_vec_ids.setdefault(content_hash, []).append(vid)
 
-    result = {}
+    result: dict[str, dict] = {}
     db = sqlite3.connect(str(vault_path()), check_same_thread=False)
     db.row_factory = sqlite3.Row
     try:

--- a/src/mnemon/dashboard/pages/3_Graph.py
+++ b/src/mnemon/dashboard/pages/3_Graph.py
@@ -5,18 +5,20 @@ import streamlit as st
 st.set_page_config(page_title="Memory Graph — mnemon", layout="wide")
 st.title("Memory Graph")
 
-from mnemon.dashboard.loaders import load_vectors, load_umap_coords, build_vector_doc_map, load_related
+from mnemon.dashboard.loaders import load_vectors, load_umap_coords, load_related
 from mnemon.dashboard.charts import make_graph_scatter, add_relation_edges
 
 CONTENT_TYPES = ["decision", "preference", "antipattern", "observation", "research", "project", "handoff", "note"]
 
-# Load vectors
+# Load vectors — post-0.5.0 loaders.load_vectors returns a 3-tuple with
+# the vec_id → doc map baked in (remote: from memory_export_vectors,
+# local: joined from SQLite).
 vec_data = load_vectors()
 if vec_data is None:
     st.warning("No vectors found. Save some memories with embeddings first.")
     st.stop()
 
-vec_ids, vectors = vec_data
+vec_ids, vectors, doc_map = vec_data
 
 if len(vec_ids) < 5:
     st.warning(f"Only {len(vec_ids)} vectors — need at least 5 for UMAP projection.")
@@ -36,8 +38,7 @@ show_edges = st.sidebar.checkbox("Show relation edges", value=True)
 with st.spinner("Computing UMAP projection..."):
     coords_2d = load_umap_coords(vectors, n_neighbors=n_neighbors)
 
-# Map vectors to documents
-doc_map = build_vector_doc_map(vec_ids)
+# doc_map is already populated by load_vectors() — no extra query needed.
 
 # Build scatter plot
 fig = make_graph_scatter(coords_2d, vec_ids, doc_map, visible_types=set(visible_types))

--- a/tests/test_dashboard_loaders.py
+++ b/tests/test_dashboard_loaders.py
@@ -1,0 +1,169 @@
+"""Tests for the remote-aware dashboard loaders.
+
+Verifies that each loader dispatches correctly based on the remote-URL
+detection, routes through ``memory_*`` MCP tools in remote mode, and
+preserves the fallback path for local-vault development.
+
+Streamlit caching is bypassed in tests — each call re-runs the loader
+body so patch targets fire every time.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def no_streamlit_cache(monkeypatch):
+    """Neutralize ``@st.cache_data`` / ``@st.cache_resource`` so each test
+    observes the underlying function body without Streamlit's memoization
+    short-circuiting the dispatch we're trying to test."""
+    import streamlit as st
+
+    def passthrough(*dargs, **dkwargs):
+        # Support both bare ``@cache_data`` (no parens) and
+        # ``@cache_data(ttl=N)`` (with parens) decoration styles.
+        if dargs and callable(dargs[0]):
+            return dargs[0]
+        def decorator(fn):
+            return fn
+        return decorator
+
+    monkeypatch.setattr(st, "cache_data", passthrough)
+    monkeypatch.setattr(st, "cache_resource", passthrough)
+    # Force a reimport so the decorators actually apply as no-ops.
+    import importlib
+    import mnemon.dashboard.loaders as loaders_mod
+    importlib.reload(loaders_mod)
+    yield loaders_mod
+    importlib.reload(loaders_mod)
+
+
+@pytest.fixture
+def remote(monkeypatch):
+    """Pin the dashboard into remote mode via env var."""
+    monkeypatch.setenv("MNEMON_REMOTE_URL", "https://example.fly.dev/mcp")
+
+
+@pytest.fixture
+def local(monkeypatch, tmp_path):
+    """Pin the dashboard into local mode — env unset, no remote_url file."""
+    monkeypatch.delenv("MNEMON_REMOTE_URL", raising=False)
+    # Redirect home to a tmp path that doesn't contain a remote_url file.
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+
+class TestUseRemoteDetection:
+    def test_detects_remote_via_env(self, remote, no_streamlit_cache):
+        assert no_streamlit_cache._use_remote() is True
+
+    def test_local_mode_when_unset(self, local, no_streamlit_cache):
+        assert no_streamlit_cache._use_remote() is False
+
+
+class TestLoadStatus:
+    def test_remote_calls_memory_status_and_parses_json(self, remote, no_streamlit_cache):
+        payload = {"total_documents": 3, "total_vectors": 2, "by_type": [],
+                   "pinned": 0, "invalidated": 0, "vault_path": "/data/x"}
+        with patch(
+            "mnemon.dashboard.loaders._call_remote",
+            return_value=json.dumps(payload),
+        ) as mock_call:
+            result = no_streamlit_cache.load_status()
+        mock_call.assert_called_once_with("memory_status", {})
+        assert result == payload
+
+    def test_local_falls_back_to_store(self, local, no_streamlit_cache):
+        with patch("mnemon.dashboard.loaders.get_store") as mock_store:
+            mock_store.return_value.status.return_value = {"total_documents": 5}
+            result = no_streamlit_cache.load_status()
+        assert result == {"total_documents": 5}
+
+
+class TestLoadTimeline:
+    def test_remote_passes_args(self, remote, no_streamlit_cache):
+        with patch(
+            "mnemon.dashboard.loaders._call_remote",
+            return_value="[]",
+        ) as mock_call:
+            result = no_streamlit_cache.load_timeline(limit=50, content_type="note")
+        mock_call.assert_called_once_with(
+            "memory_timeline", {"limit": 50, "content_type": "note"},
+        )
+        assert result == []
+
+
+class TestLoadSearch:
+    def test_remote_passes_args(self, remote, no_streamlit_cache):
+        with patch(
+            "mnemon.dashboard.loaders._call_remote",
+            return_value=json.dumps([{"doc_id": 1, "title": "hit"}]),
+        ) as mock_call:
+            result = no_streamlit_cache.load_search("q", limit=5, content_type="decision")
+        mock_call.assert_called_once_with(
+            "memory_search",
+            {"query": "q", "limit": 5, "content_type": "decision"},
+        )
+        assert len(result) == 1
+        assert result[0]["title"] == "hit"
+
+
+class TestLoadDocument:
+    def test_remote_hit_returns_doc(self, remote, no_streamlit_cache):
+        doc = {"id": 7, "title": "T", "content": "C"}
+        with patch(
+            "mnemon.dashboard.loaders._call_remote",
+            return_value=json.dumps(doc),
+        ):
+            assert no_streamlit_cache.load_document(7) == doc
+
+    def test_remote_miss_returns_none(self, remote, no_streamlit_cache):
+        """memory_get returns ``{"error": "not_found", "id": N}`` on miss —
+        the loader normalizes that to ``None`` for page-level truthiness."""
+        with patch(
+            "mnemon.dashboard.loaders._call_remote",
+            return_value=json.dumps({"error": "not_found", "id": 999}),
+        ):
+            assert no_streamlit_cache.load_document(999) is None
+
+
+class TestLoadVectors:
+    def test_remote_empty_returns_none(self, remote, no_streamlit_cache):
+        with patch(
+            "mnemon.dashboard.loaders._call_remote",
+            return_value=json.dumps({"count": 0, "dim": 384,
+                                     "truncated": False, "items": []}),
+        ):
+            assert no_streamlit_cache.load_vectors() is None
+
+    def test_remote_builds_3_tuple(self, remote, no_streamlit_cache):
+        """The server bakes the vec_id → doc join into ``memory_export_vectors``
+        so the loader doesn't need a second query — important for browser
+        clients that have no SQLite access."""
+        items = [
+            {"doc_id": 1, "vec_id": "abc_0", "title": "T1",
+             "content_type": "note", "confidence": 0.5,
+             "created_at": "2026-01-01", "pinned": False,
+             "vector": [0.1] * 384},
+            {"doc_id": 2, "vec_id": "def_0", "title": "T2",
+             "content_type": "decision", "confidence": 0.9,
+             "created_at": "2026-01-02", "pinned": True,
+             "vector": [0.2] * 384},
+        ]
+        with patch(
+            "mnemon.dashboard.loaders._call_remote",
+            return_value=json.dumps({"count": 2, "dim": 384,
+                                     "truncated": False, "items": items}),
+        ):
+            result = no_streamlit_cache.load_vectors()
+        assert result is not None
+        vec_ids, vectors, doc_map = result
+        assert vec_ids == ["abc_0", "def_0"]
+        assert vectors.shape == (2, 384)
+        assert vectors.dtype == np.float32
+        assert doc_map["abc_0"]["title"] == "T1"
+        assert doc_map["def_0"]["content_type"] == "decision"

--- a/tests/test_dashboard_loaders.py
+++ b/tests/test_dashboard_loaders.py
@@ -16,6 +16,13 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
+# Dashboard deps are in the ``[ui]`` extra. When running the core
+# ``[dev]`` test matrix these imports would crash the whole module at
+# collection time — skip cleanly instead so the rest of the suite stays
+# green.
+pytest.importorskip("streamlit")
+pytest.importorskip("umap", reason="umap-learn ships with [ui]")
+
 
 @pytest.fixture(autouse=True)
 def no_streamlit_cache(monkeypatch):


### PR DESCRIPTION
Completes the dashboard refactor. PR A (#58) added the JSON MCP tools; this PR teaches the dashboard to consume them.

## What now works

`MNEMON_REMOTE_URL=... mnemon dashboard` against a remote Fly vault renders correctly — Home (status + timeline + sweep), Search, Timeline, Profile, Graph (UMAP + doc metadata). No local SQLite file needed.

Local-mode dev is unchanged — if the env var and `~/.mnemon/remote_url` file are both absent, loaders fall through to `Store()` exactly like before.

## Design

- `_use_remote()` checks `MNEMON_REMOTE_URL` → falls back to `~/.mnemon/remote_url` file → returns False.
- Each loader branches on that check inside its body so Streamlit's `@st.cache_data` memoization still works and a mode flip during development invalidates the cache.
- `load_vectors` returns a 3-tuple `(vec_ids, vectors, doc_map)` in both modes. Remote mode gets the doc_map baked into `memory_export_vectors`; local mode builds it via the existing SQLite query helper. Graph page became mode-agnostic as a result.

## Small UX touch

Home page subtitle shows `· remote` or `· local` so users know which backend they're reading.

## Test plan

- [x] 10 new tests in `test_dashboard_loaders.py` — remote-vs-local dispatch + JSON parsing per loader.
- [x] Full suite: 477 pass.
- [x] Smoke-tested against prod v18: all 5 dashboard tools return expected shapes (status: 38 docs/109 vectors, timeline: 10 items, sweep: 0 candidates, search: 5 hits, export_vectors: 81×384).
- [ ] After merge: locally launch `MNEMON_REMOTE_URL=... mnemon dashboard` and click through each page against prod to confirm end-to-end rendering before screenshotting for the announcement post.
- [ ] After merge: publish 0.5.0 to PyPI, tag, release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)