### PR TITLE
fix(dashboard): collapse chunks to one point per doc on graph

### DIFF
--- a/src/mnemon/dashboard/loaders.py
+++ b/src/mnemon/dashboard/loaders.py
@@ -200,6 +200,43 @@ def load_vectors() -> tuple[list[str], np.ndarray, dict[str, dict]] | None:
 
 
 @st.cache_data(ttl=900)
+def load_vectors_collapsed() -> tuple[list[str], np.ndarray, dict[str, dict]] | None:
+    """Same shape as ``load_vectors``, but one row per document.
+
+    Multi-chunk documents get mean-pooled (then L2-normalized so the
+    result stays on the unit sphere for cosine UMAP). The synthesized
+    vec_id is ``"doc_{doc_id}"`` so the Graph page's click-to-detail
+    keeps working through the ``customdata.doc_id`` field.
+    """
+    raw = load_vectors()
+    if raw is None:
+        return None
+    vec_ids, vectors, doc_map = raw
+
+    by_doc: dict[int, list[int]] = {}
+    for idx, vid in enumerate(vec_ids):
+        doc_id = doc_map[vid]["id"]
+        by_doc.setdefault(doc_id, []).append(idx)
+
+    new_ids: list[str] = []
+    pooled: list[np.ndarray] = []
+    new_map: dict[str, dict] = {}
+    for doc_id, idxs in by_doc.items():
+        chunk_vecs = vectors[idxs]
+        mean_vec = chunk_vecs.mean(axis=0)
+        norm = np.linalg.norm(mean_vec)
+        if norm > 0:
+            mean_vec = mean_vec / norm
+        synthetic_id = f"doc_{doc_id}"
+        new_ids.append(synthetic_id)
+        pooled.append(mean_vec)
+        # Use any chunk's doc info — they all point to the same doc.
+        new_map[synthetic_id] = doc_map[vec_ids[idxs[0]]]
+
+    return new_ids, np.array(pooled, dtype=np.float32), new_map
+
+
+@st.cache_data(ttl=900)
 def load_umap_coords(_vectors: np.ndarray, n_neighbors: int = 15) -> np.ndarray:
     """UMAP 384d → 2D. Cached aggressively since reprojecting is expensive."""
     import umap

--- a/src/mnemon/dashboard/pages/3_Graph.py
+++ b/src/mnemon/dashboard/pages/3_Graph.py
@@ -5,15 +5,15 @@ import streamlit as st
 st.set_page_config(page_title="Memory Graph — mnemon", layout="wide")
 st.title("Memory Graph")
 
-from mnemon.dashboard.loaders import load_vectors, load_umap_coords, load_related
+from mnemon.dashboard.loaders import load_vectors_collapsed, load_umap_coords, load_related
 from mnemon.dashboard.charts import make_graph_scatter, add_relation_edges
 
 CONTENT_TYPES = ["decision", "preference", "antipattern", "observation", "research", "project", "handoff", "note"]
 
-# Load vectors — post-0.5.0 loaders.load_vectors returns a 3-tuple with
-# the vec_id → doc map baked in (remote: from memory_export_vectors,
-# local: joined from SQLite).
-vec_data = load_vectors()
+# One point per document. Multi-chunk docs are mean-pooled in the
+# loader — otherwise a long memory showed up as several near-identical
+# points, which read as duplicates.
+vec_data = load_vectors_collapsed()
 if vec_data is None:
     st.warning("No vectors found. Save some memories with embeddings first.")
     st.stop()

--- a/tests/test_dashboard_loaders.py
+++ b/tests/test_dashboard_loaders.py
@@ -174,3 +174,51 @@ class TestLoadVectors:
         assert vectors.dtype == np.float32
         assert doc_map["abc_0"]["title"] == "T1"
         assert doc_map["def_0"]["content_type"] == "decision"
+
+
+class TestLoadVectorsCollapsed:
+    def test_collapses_multi_chunk_docs(self, remote, no_streamlit_cache):
+        """Doc 1 has 3 chunks, doc 2 has 1 chunk. After collapse we get
+        two rows total, each synthetic vec_id ``doc_{doc_id}`` mapped to
+        its document, and the pooled vectors are unit-norm."""
+        items = [
+            {"doc_id": 1, "vec_id": "aaa_0", "title": "T1",
+             "content_type": "note", "confidence": 0.5,
+             "created_at": "2026-01-01", "pinned": False,
+             "vector": [1.0, 0.0] + [0.0] * 382},
+            {"doc_id": 1, "vec_id": "aaa_1", "title": "T1",
+             "content_type": "note", "confidence": 0.5,
+             "created_at": "2026-01-01", "pinned": False,
+             "vector": [0.0, 1.0] + [0.0] * 382},
+            {"doc_id": 1, "vec_id": "aaa_2", "title": "T1",
+             "content_type": "note", "confidence": 0.5,
+             "created_at": "2026-01-01", "pinned": False,
+             "vector": [1.0, 1.0] + [0.0] * 382},
+            {"doc_id": 2, "vec_id": "bbb_0", "title": "T2",
+             "content_type": "decision", "confidence": 0.9,
+             "created_at": "2026-01-02", "pinned": True,
+             "vector": [0.0, 0.0, 1.0] + [0.0] * 381},
+        ]
+        with patch(
+            "mnemon.dashboard.loaders._call_remote",
+            return_value=json.dumps({"count": 4, "dim": 384,
+                                     "truncated": False, "items": items}),
+        ):
+            result = no_streamlit_cache.load_vectors_collapsed()
+        assert result is not None
+        vec_ids, vectors, doc_map = result
+        assert sorted(vec_ids) == ["doc_1", "doc_2"]
+        assert vectors.shape == (2, 384)
+        # Every row is unit-norm (ready for cosine UMAP).
+        norms = np.linalg.norm(vectors, axis=1)
+        np.testing.assert_allclose(norms, [1.0, 1.0], atol=1e-6)
+        assert doc_map["doc_1"]["title"] == "T1"
+        assert doc_map["doc_2"]["content_type"] == "decision"
+
+    def test_empty_vault_returns_none(self, remote, no_streamlit_cache):
+        with patch(
+            "mnemon.dashboard.loaders._call_remote",
+            return_value=json.dumps({"count": 0, "dim": 384,
+                                     "truncated": False, "items": []}),
+        ):
+            assert no_streamlit_cache.load_vectors_collapsed() is None


### PR DESCRIPTION
## Summary
- Long memories produce multiple embedding chunks, each becoming its own point in the UMAP scatter. In the prod vault that meant 38 docs → 87 points, reading as "duplicates" even though save-time content-hash dedup is working.
- Mean-pool chunk vectors per doc (L2-normalized so cosine UMAP still makes sense), one point per memory on the graph.
- New ``load_vectors_collapsed`` helper keeps the existing ``load_vectors`` API intact for any other callers.

## Test plan
- [x] ``pytest tests/test_dashboard_loaders.py`` — new ``TestLoadVectorsCollapsed`` class: multi-chunk collapse + empty-vault → None.
- [x] Full suite: 473 passed.
- [ ] User eyeballs the Graph page against prod and confirms the "cluster of 6 dots all labeled X" artifact is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)