### PR TITLE
fix(dashboard): bump remote-call timeout above the 8s hook default

### DIFF
--- a/src/mnemon/dashboard/loaders.py
+++ b/src/mnemon/dashboard/loaders.py
@@ -35,16 +35,28 @@ def _use_remote() -> bool:
     return False
 
 
-def _call_remote(tool: str, args: dict) -> str:
+DASHBOARD_REMOTE_TIMEOUT_SEC = 30.0
+VECTOR_EXPORT_TIMEOUT_SEC = 60.0
+
+
+def _call_remote(tool: str, args: dict, *, timeout: float = DASHBOARD_REMOTE_TIMEOUT_SEC) -> str:
     """Call an MCP tool via the shared remote client. Raises on error —
     callers decide whether to surface via ``st.error`` or silently fall
-    back."""
+    back.
+
+    The default 30s timeout is dashboard-appropriate: the hook client
+    defaults to 8s (to stay inside Claude Code's hook budget), but a
+    browser page can reasonably wait longer, especially on Fly
+    cold-start. ``load_vectors`` overrides to 60s because the vector
+    export is the heaviest single tool call.
+    """
     from mnemon.hooks._remote_client import call_tool_sync
 
     raw, _elapsed = call_tool_sync(
         tool,
         args,
         client_label="mnemon-dashboard",
+        timeout=timeout,
     )
     return raw
 
@@ -161,7 +173,10 @@ def load_vectors() -> tuple[list[str], np.ndarray, dict[str, dict]] | None:
     before first embedding).
     """
     if _use_remote():
-        payload = json.loads(_call_remote("memory_export_vectors", {}))
+        payload = json.loads(_call_remote(
+            "memory_export_vectors", {},
+            timeout=VECTOR_EXPORT_TIMEOUT_SEC,
+        ))
         items = payload.get("items", [])
         if not items:
             return None

--- a/tests/test_dashboard_loaders.py
+++ b/tests/test_dashboard_loaders.py
@@ -222,3 +222,28 @@ class TestLoadVectorsCollapsed:
                                      "truncated": False, "items": []}),
         ):
             assert no_streamlit_cache.load_vectors_collapsed() is None
+
+
+class TestRemoteTimeout:
+    """The dashboard must override the hook client's 8s default — it's a
+    browser-facing surface, not a hook, so a cold Fly instance + a 87-vec
+    export would otherwise blow the timeout."""
+
+    def test_default_timeout_is_dashboard_not_hook(self, remote, no_streamlit_cache):
+        with patch(
+            "mnemon.hooks._remote_client.call_tool_sync",
+            return_value=("{}", 0.01),
+        ) as mock_call:
+            no_streamlit_cache._call_remote("memory_status", {})
+        assert mock_call.call_args.kwargs["timeout"] == 30.0
+
+    def test_vector_export_uses_longer_timeout(self, remote, no_streamlit_cache):
+        with patch(
+            "mnemon.hooks._remote_client.call_tool_sync",
+            return_value=(
+                json.dumps({"count": 0, "dim": 384, "truncated": False, "items": []}),
+                0.01,
+            ),
+        ) as mock_call:
+            no_streamlit_cache.load_vectors()
+        assert mock_call.call_args.kwargs["timeout"] == 60.0


### PR DESCRIPTION
## Summary
- Graph page hit ``asyncio.TimeoutError`` on ``memory_export_vectors`` against the prod Fly vault — an 87-vector export over a cold-ish instance, surfaced through an 8s ceiling that was never intended for the dashboard.
- Root cause: the dashboard was inheriting ``_remote_client.DEFAULT_TIMEOUT_SEC = 8s``, which exists to fit inside Claude Code's hook budget (``HOOK_REMOTE_TIMEOUT_SEC``). A browser page can afford to wait longer.
- Give the dashboard its own defaults (30s general, 60s for vector export) by threading ``timeout`` through the local ``_call_remote`` helper. Hook callers untouched.

## Test plan
- [x] ``pytest tests/test_dashboard_loaders.py`` — new ``TestRemoteTimeout`` class asserts 30s general / 60s export.
- [x] Full suite: 475 passed.
- [ ] User reopens the Graph page against prod and confirms it renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)