### PR TITLE
chore: pre-publish polish — local doctor + README onboarding rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ mnemon is a [Model Context Protocol](https://modelcontextprotocol.io) server wit
 pip install mnemon-memory
 ```
 
-With optional LLM support (local 1.7B model for query expansion, contradiction detection, and smarter session extraction):
+Optional extras:
 
 ```bash
-pip install "mnemon-memory[llm]"
+pip install "mnemon-memory[ui]"    # Streamlit dashboard (mnemon dashboard)
+pip install "mnemon-memory[llm]"   # local 1.7B model for query expansion + smarter extraction
+pip install "mnemon-memory[ui,llm]" # both
 ```
 
 From source:
@@ -57,28 +59,45 @@ pip install -e ".[dev]"
 
 ## Quick Start
 
-The recommended setup is a remote vault (one vault, all clients). You have two paths to `https://<your-app>.fly.dev/mcp`:
+Two paths, depending on how deep you want to go in the first sitting.
 
-- **Self-host** (~10 min, ~$1/mo): see [Self-host on Fly.io](#self-host-on-flyio) below for the end-to-end runbook.
-- **Local-only mode**: no remote server needed, useful for development.
+### Try it locally (60 seconds)
 
-### 1. Configure your client
+No Fly account, no secrets, no OAuth — a single-file SQLite vault at `~/.mnemon/default.sqlite`. Good for a first look and for offline development.
 
 ```bash
-# Claude Code with remote vault
-mnemon setup claude-code --remote-url https://your-app.fly.dev/mcp
-
-# Cursor with remote vault
-mnemon setup cursor --remote-url https://your-app.fly.dev/mcp
-
-# Local-only mode (development, no remote server needed)
-mnemon setup claude-code
-mnemon setup cursor
+pip install mnemon-memory
+mnemon setup claude-code        # or: cursor, gemini, hooks
+mnemon doctor                   # 3 green checks: vault, embedder, round-trip
 ```
 
-Verify with `mnemon doctor` — it runs 6 end-to-end checks against your configured remote (skip for local-only mode).
+Then use Claude Code / Cursor as usual — memories save and surface automatically.
 
-### 2. Use it
+**Heads-up:** the first `memory_search` after a fresh install takes ~10–20s while FastEmbed downloads the embedding model (one-time). Subsequent calls are fast.
+
+### Self-host a remote vault (10 min, ~$1/mo)
+
+One vault, all clients — Claude Code, Cursor, claude.ai web/mobile/desktop, Claude Desktop all read and write the same memories. See [Self-host on Fly.io](#self-host-on-flyio) for the end-to-end runbook.
+
+```bash
+# After you've deployed:
+mnemon setup claude-code --remote-url https://your-app.fly.dev/mcp
+mnemon setup cursor       --remote-url https://your-app.fly.dev/mcp
+mnemon doctor             # 6 green checks: URL, token, /health, OAuth AS, MCP round-trip
+```
+
+### Visualize your vault
+
+```bash
+pip install "mnemon-memory[ui]"
+mnemon dashboard
+```
+
+Opens a Streamlit UI at `http://localhost:8503` — Home stats, Search, Timeline, Graph (UMAP 2D projection of the vector space), Profile. Works against both local and remote vaults.
+
+![Memory Graph dashboard](docs/images/dashboard-graph.png)
+
+### Use it
 
 Once configured, mnemon works automatically:
 
@@ -198,11 +217,14 @@ Without the volume step, every restart wipes your vault — the `[mounts]` block
 **3. Generate and set secrets.**
 
 ```bash
-# Generate two independent high-entropy secrets. Do not reuse credentials.
+# Generate two independent high-entropy secrets. Copy both into your password
+# manager now — MNEMON_LOCAL_TOKEN is needed again on the client (step 5).
 python -c "import secrets; print('MNEMON_LOCAL_TOKEN   =', secrets.token_urlsafe(32))"
 python -c "import secrets; print('MNEMON_AS_PASSPHRASE =', secrets.token_urlsafe(32))"
 
-# Store both in your password manager, then:
+# Paste into Fly (values land in shell history — clear it after with
+# `history -d <n>` if that matters to you, or prefix the line with a
+# space if HISTCONTROL=ignorespace is set):
 fly secrets set MNEMON_LOCAL_TOKEN=<value-1> \
                 MNEMON_AS_ENABLED=true \
                 MNEMON_AS_PASSPHRASE=<value-2>
@@ -221,15 +243,21 @@ First deploy pulls the FastEmbed model (~15–25s on first `memory_search`). Sub
 **5. Verify.**
 
 ```bash
-# Write the remote URL + bearer token to your local client config.
-echo "https://<your-app>.fly.dev/mcp"          > ~/.mnemon/remote_url
-echo "<value-1 from step 3>"                   > ~/.mnemon/local_token
-chmod 600 ~/.mnemon/local_token
+# Write the remote URL (public — safe to echo).
+mkdir -p ~/.mnemon
+echo "https://<your-app>.fly.dev/mcp" > ~/.mnemon/remote_url
+
+# Write the token without leaking it to shell history. `read -rs` reads
+# silently; `printf %s` avoids a trailing newline in the file.
+read -rs -p "Paste MNEMON_LOCAL_TOKEN: " t && \
+  printf %s "$t" > ~/.mnemon/local_token && \
+  chmod 600 ~/.mnemon/local_token && \
+  unset t
 
 mnemon doctor
 ```
 
-`mnemon doctor` runs 6 checks: remote URL configured, local token configured + 0600 perms, `/health` reachable, authenticated MCP tool call round-trips, and save + search + forget cycle. All 6 should pass green. If any fail, the error message points at the specific misconfiguration.
+`mnemon doctor` runs 6 checks: remote URL configured, local token configured + 0600 perms, `/health` reachable, authenticated MCP tool call round-trips, and save + search + forget cycle. All 6 should pass green. If any fail, the error message points at the specific misconfiguration. (Without a configured remote, the same command switches to local mode and runs 3 equivalent checks against the on-disk SQLite vault.)
 
 **6. Connect clients.**
 

--- a/src/mnemon/doctor.py
+++ b/src/mnemon/doctor.py
@@ -1,10 +1,18 @@
-"""Self-diagnostic for mnemon remote deployments.
+"""Self-diagnostic for mnemon deployments.
 
-Runs an ordered series of checks against the configured remote vault and
-prints pass/fail per check. Designed as a validator for the Phase 2
-cutover (``MNEMON_AS_ENABLED=true`` on Fly) and for anyone self-hosting
-their own mnemon instance who wants a quick health signal after
-``fly deploy``.
+Runs an ordered series of checks against the configured vault and prints
+pass/fail per check. Works in both modes:
+
+- **Remote mode** (``MNEMON_REMOTE_URL`` env or ``~/.mnemon/remote_url``
+  set): validates the Fly-hosted MCP endpoint end-to-end, including
+  OAuth AS metadata when ``MNEMON_AS_ENABLED=true``.
+- **Local mode** (neither set): validates the on-disk SQLite vault —
+  schema, embedder load, and a save/search/forget round-trip via
+  ``Store`` directly.
+
+The caller does not pick a mode; ``run_doctor`` detects it from config
+and runs the appropriate check list. Output format is identical across
+modes so hook/CI integrations don't have to branch.
 
 Checks run top-down and short-circuit only on hard config failures — the
 rest run independently so a single broken piece does not hide others.
@@ -21,6 +29,7 @@ import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Callable
 
 from .hooks._remote_client import (
@@ -375,9 +384,134 @@ def _best_effort_forget(doc_id: int) -> None:
         pass
 
 
+# ── Local-mode checks ──────────────────────────────────────────────────────
+
+
+def check_local_vault() -> CheckResult:
+    """Open the local Store and confirm the SQLite schema is in place."""
+    try:
+        from .store import Store
+        store = Store()
+    except Exception as exc:  # noqa: BLE001 — schema/permission errors surface here
+        return CheckResult("Local vault reachable", False, f"{type(exc).__name__}: {exc}")
+
+    try:
+        stats = store.status()
+    except Exception as exc:  # noqa: BLE001
+        return CheckResult(
+            "Local vault reachable",
+            False,
+            f"status() failed: {type(exc).__name__}: {exc}",
+        )
+
+    vault_path = stats.get("vault_path", "?")
+    total = stats.get("total_documents", 0)
+    return CheckResult(
+        "Local vault reachable",
+        True,
+        f"{vault_path} — {total} documents",
+    )
+
+
+def check_local_embedder() -> CheckResult:
+    """Force a FastEmbed cold-load so the failure (missing model, no
+    network on first run, etc.) surfaces here rather than inside the
+    round-trip check — makes the diagnostic clearer."""
+    try:
+        from .embedder import embed
+        vec = embed("__mnemon_doctor_probe__")
+    except Exception as exc:  # noqa: BLE001
+        return CheckResult(
+            "Embedder loadable",
+            False,
+            f"{type(exc).__name__}: {exc}",
+        )
+
+    if vec is None or getattr(vec, "shape", ()) != (384,):
+        return CheckResult(
+            "Embedder loadable",
+            False,
+            f"unexpected vector shape: {getattr(vec, 'shape', None)}",
+        )
+    return CheckResult("Embedder loadable", True, "bge-small-en-v1.5 (384d)")
+
+
+def check_local_round_trip() -> CheckResult:
+    """Save a probe memory, search for it by title, then forget it — all
+    via ``Store`` directly so we're checking the local path that hooks
+    and the CLI actually use, not the MCP stdio layer."""
+    import uuid
+    from .search import search as hybrid_search
+    from .store import Store
+
+    probe_id = uuid.uuid4().hex[:8]
+    title = f"mnemon-doctor-probe-{probe_id}"
+    content = f"Probe memory created by `mnemon doctor` (run {probe_id}). Safe to delete."
+
+    try:
+        store = Store()
+    except Exception as exc:  # noqa: BLE001
+        return CheckResult(
+            "Round-trip (save + search + forget)",
+            False,
+            f"Store() failed: {type(exc).__name__}: {exc}",
+        )
+
+    try:
+        doc_id = store.save(title=title, content=content, content_type="note")
+    except Exception as exc:  # noqa: BLE001
+        return CheckResult(
+            "Round-trip (save + search + forget)",
+            False,
+            f"save failed: {type(exc).__name__}: {exc}",
+        )
+
+    try:
+        results = hybrid_search(store, title, limit=5, use_vector=True)
+    except Exception as exc:  # noqa: BLE001
+        _best_effort_local_forget(store, doc_id)
+        return CheckResult(
+            "Round-trip (save + search + forget)",
+            False,
+            f"search failed: {type(exc).__name__}: {exc}",
+        )
+
+    if not any(getattr(r, "title", None) == title for r in results):
+        _best_effort_local_forget(store, doc_id)
+        return CheckResult(
+            "Round-trip (save + search + forget)",
+            False,
+            f"saved memory not found by search for its own title (doc_id={doc_id})",
+        )
+
+    try:
+        store.forget(doc_id)
+    except Exception as exc:  # noqa: BLE001
+        return CheckResult(
+            "Round-trip (save + search + forget)",
+            True,
+            f"save+search ok but forget failed: {exc} (doc_id={doc_id} leaked)",
+            warn=True,
+        )
+
+    return CheckResult(
+        "Round-trip (save + search + forget)",
+        True,
+        f"doc_id={doc_id} saved, found, and forgotten",
+    )
+
+
+def _best_effort_local_forget(store, doc_id: int) -> None:
+    """Clean up a probe memory from the local Store; swallow errors."""
+    try:
+        store.forget(doc_id)
+    except Exception:  # noqa: BLE001
+        pass
+
+
 # ── Runner ─────────────────────────────────────────────────────────────────
 
-CHECKS: list[Callable[[], CheckResult]] = [
+REMOTE_CHECKS: list[Callable[[], CheckResult]] = [
     check_remote_url,
     check_local_token,
     check_token_file_perms,
@@ -387,13 +521,60 @@ CHECKS: list[Callable[[], CheckResult]] = [
     check_round_trip,
 ]
 
+LOCAL_CHECKS: list[Callable[[], CheckResult]] = [
+    check_local_vault,
+    check_local_embedder,
+    check_local_round_trip,
+]
+
+# Backwards-compat shim — one external caller (tests) may still import CHECKS.
+CHECKS = REMOTE_CHECKS
+
+
+def _has_remote_config() -> bool:
+    """True if the user has pointed mnemon at a remote vault.
+
+    Mirrors ``mnemon.dashboard.loaders._use_remote`` but kept local to
+    avoid pulling the dashboard's streamlit import chain into the CLI.
+    """
+    if os.environ.get("MNEMON_REMOTE_URL", "").strip():
+        return True
+    remote_url_file = Path.home() / ".mnemon" / "remote_url"
+    if remote_url_file.exists() and remote_url_file.read_text().strip():
+        return True
+    return False
+
 
 def run_doctor(out=sys.stdout) -> int:
-    """Run all checks, print results, return exit code (0 = all pass)."""
-    print("mnemon doctor — running diagnostics...\n", file=out)
+    """Run all checks, print results, return exit code (0 = all pass).
+
+    Auto-detects remote vs. local mode from config. Prints a one-line
+    banner so the user knows which flavor ran; everything else is
+    format-identical across modes.
+    """
+    if _has_remote_config():
+        mode_label = "remote"
+        try:
+            mode_detail = get_remote_url()
+        except RemoteClientConfigError:
+            mode_detail = "(unresolved)"
+        checks = REMOTE_CHECKS
+    else:
+        mode_label = "local"
+        try:
+            from .config import vault_path
+            mode_detail = str(vault_path())
+        except Exception:  # noqa: BLE001
+            mode_detail = "~/.mnemon/default.sqlite"
+        checks = LOCAL_CHECKS
+
+    print(
+        f"mnemon doctor — {mode_label} mode ({mode_detail})\n",
+        file=out,
+    )
 
     results: list[CheckResult] = []
-    for check in CHECKS:
+    for check in checks:
         result = check()
         results.append(result)
         prefix = PASS if result.ok and not result.warn else (WARN if result.warn else FAIL)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -381,19 +381,23 @@ class TestCheckRoundTrip:
 
 
 class TestRunDoctor:
+    """Remote-mode runner behavior — the list patched here is
+    ``REMOTE_CHECKS`` because ``run_doctor`` dispatches on
+    ``_has_remote_config``; each test pins that to True."""
+
     def test_all_pass_returns_zero(self):
         def ok(name: str) -> doctor.CheckResult:
             return doctor.CheckResult(name, True, "fine")
 
-        fake_checks = [
-            lambda: ok("A"),
-            lambda: ok("B"),
-        ]
+        fake_checks = [lambda: ok("A"), lambda: ok("B")]
         buf = io.StringIO()
-        with patch("mnemon.doctor.CHECKS", fake_checks):
+        with patch("mnemon.doctor._has_remote_config", return_value=True), \
+             patch("mnemon.doctor.get_remote_url", return_value="https://x/mcp"), \
+             patch("mnemon.doctor.REMOTE_CHECKS", fake_checks):
             code = doctor.run_doctor(out=buf)
         assert code == 0
         output = buf.getvalue()
+        assert "remote mode" in output
         assert "All 2 checks passed" in output
         assert doctor.PASS in output
 
@@ -403,7 +407,9 @@ class TestRunDoctor:
             lambda: doctor.CheckResult("B", False, "broken"),
         ]
         buf = io.StringIO()
-        with patch("mnemon.doctor.CHECKS", fake_checks):
+        with patch("mnemon.doctor._has_remote_config", return_value=True), \
+             patch("mnemon.doctor.get_remote_url", return_value="https://x/mcp"), \
+             patch("mnemon.doctor.REMOTE_CHECKS", fake_checks):
             code = doctor.run_doctor(out=buf)
         assert code == 1
         output = buf.getvalue()
@@ -416,11 +422,110 @@ class TestRunDoctor:
             lambda: doctor.CheckResult("B", True, "heads-up", warn=True),
         ]
         buf = io.StringIO()
-        with patch("mnemon.doctor.CHECKS", fake_checks):
+        with patch("mnemon.doctor._has_remote_config", return_value=True), \
+             patch("mnemon.doctor.get_remote_url", return_value="https://x/mcp"), \
+             patch("mnemon.doctor.REMOTE_CHECKS", fake_checks):
             code = doctor.run_doctor(out=buf)
         assert code == 0
         output = buf.getvalue()
         assert "1 warning" in output
+
+
+class TestRunDoctorLocalMode:
+    """Without any remote config, ``run_doctor`` should run LOCAL_CHECKS
+    and advertise local mode in the banner — no code from the remote
+    path should execute."""
+
+    def test_local_banner_and_checks_fire(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MNEMON_REMOTE_URL", raising=False)
+        monkeypatch.setenv("MNEMON_VAULT_DIR", str(tmp_path))
+
+        fake_local = [
+            lambda: doctor.CheckResult("LocalA", True, "ok"),
+            lambda: doctor.CheckResult("LocalB", True, "also ok"),
+        ]
+        buf = io.StringIO()
+        with patch("mnemon.doctor._has_remote_config", return_value=False), \
+             patch("mnemon.doctor.LOCAL_CHECKS", fake_local):
+            code = doctor.run_doctor(out=buf)
+        assert code == 0
+        output = buf.getvalue()
+        assert "local mode" in output
+        assert "LocalA" in output
+        assert "All 2 checks passed" in output
+
+    def test_local_failure_returns_one(self):
+        fake_local = [
+            lambda: doctor.CheckResult("LocalA", False, "broken"),
+        ]
+        buf = io.StringIO()
+        with patch("mnemon.doctor._has_remote_config", return_value=False), \
+             patch("mnemon.doctor.LOCAL_CHECKS", fake_local):
+            code = doctor.run_doctor(out=buf)
+        assert code == 1
+
+
+class TestHasRemoteConfig:
+    def test_env_var_wins(self, monkeypatch):
+        monkeypatch.setenv("MNEMON_REMOTE_URL", "https://x/mcp")
+        assert doctor._has_remote_config() is True
+
+    def test_empty_env_var_ignored(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MNEMON_REMOTE_URL", "   ")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert doctor._has_remote_config() is False
+
+    def test_file_fallback(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MNEMON_REMOTE_URL", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / ".mnemon").mkdir()
+        (tmp_path / ".mnemon" / "remote_url").write_text("https://x/mcp")
+        assert doctor._has_remote_config() is True
+
+    def test_neither_source_set(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MNEMON_REMOTE_URL", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert doctor._has_remote_config() is False
+
+
+class TestLocalChecks:
+    """The three local-mode check functions. Embedder is mocked to avoid
+    pulling the FastEmbed model during the test run."""
+
+    def test_check_local_vault_passes(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MNEMON_VAULT_DIR", str(tmp_path))
+        result = doctor.check_local_vault()
+        assert result.ok
+        assert "0 documents" in result.detail
+
+    def test_check_local_embedder_passes(self):
+        import numpy as np
+        fake_vec = np.zeros(384, dtype=np.float32)
+        with patch("mnemon.embedder.embed", return_value=fake_vec):
+            result = doctor.check_local_embedder()
+        assert result.ok
+        assert "384d" in result.detail
+
+    def test_check_local_embedder_fails_on_wrong_shape(self):
+        import numpy as np
+        wrong = np.zeros(128, dtype=np.float32)
+        with patch("mnemon.embedder.embed", return_value=wrong):
+            result = doctor.check_local_embedder()
+        assert not result.ok
+        assert "(128,)" in result.detail
+
+    def test_check_local_round_trip_passes(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MNEMON_VAULT_DIR", str(tmp_path))
+        import numpy as np
+        fake_vec = np.zeros(384, dtype=np.float32)
+        # Stub the embedder so save() + search() don't pull FastEmbed;
+        # the doc round-trip exercises the SQLite/FTS5 path which is
+        # what we care about in local mode.
+        with patch("mnemon.embedder.embed", return_value=fake_vec), \
+             patch("mnemon.embedder.embed_batch", return_value=[fake_vec]):
+            result = doctor.check_local_round_trip()
+        assert result.ok
+        assert "saved, found, and forgotten" in result.detail
 
     def test_cli_dispatches_to_doctor(self, monkeypatch):
         """`mnemon doctor` on the CLI should call run_doctor and exit with its code."""


### PR DESCRIPTION
## Summary

Pre-publish usability pass for 0.5.0 before it hits PyPI.

**1. ``mnemon doctor`` now works in local mode.** Auto-detects mode from config (same signal the dashboard uses). Remote users still get the 6 existing checks; local users get 3 parallel ones — vault reachable, embedder loadable, save/search/forget round-trip via ``Store`` directly. Same output format, same exit codes, no new flag. Previously local users were told to skip this command entirely.

**2. README Quick Start leads with the 60-second local path.** The prior README put 10-minute Fly self-host first and ``mnemon setup claude-code`` (no flag) second as a side bullet — inverting the on-ramp. Now: local-first, self-host as an explicit upgrade path.

**3. Dashboard is now visible in Install and Quick Start.** ``[ui]`` extra is documented, ``mnemon dashboard`` is mentioned by name, and there's an embedded screenshot at ``docs/images/dashboard-graph.png`` (see test-plan item).

**4. Self-host Step 5 no longer leaks secrets into shell history.** Swapped ``echo "$SECRET" > file`` for ``read -rs`` + ``printf %s`` + ``unset``. Step 3 secret-generation keeps the ``python -c`` output pattern but now explicitly notes the shell-history exposure and how to mitigate it.

**5. Cold-start note added to Quick Start.** First ``memory_search`` after install pulls the FastEmbed model (10–20s). Previously documented only in Known Limitations, five sections down.

## Test plan

- [x] ``pytest`` — 485 passed. New tests: ``TestRunDoctorLocalMode``, ``TestHasRemoteConfig``, ``TestLocalChecks``. Existing ``TestRunDoctor`` updated to patch ``REMOTE_CHECKS`` with ``_has_remote_config`` pinned True (prior tests were silently depending on the legacy ``CHECKS`` symbol).
- [x] ``ruff check src/`` — clean.
- [x] Smoke test: ``mnemon doctor`` in a forced-local env (fresh tmp vault, no remote config) — 3 green checks, correct banner.
- [x] Smoke test: same command in remote mode — 6 green checks still, unchanged behavior.
- [ ] **Action required before merge**: drop a dashboard screenshot at ``docs/images/dashboard-graph.png``. Any of the Graph page captures from today's UMAP testing will do; the README already references that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)