### PR TITLE
fix(setup): register MCP server via claude mcp add

### DIFF
--- a/src/mnemon/setup.py
+++ b/src/mnemon/setup.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import secrets
+import subprocess
 import sys
 from pathlib import Path
 
@@ -157,12 +158,52 @@ def _ensure_local_token(token: str | None = None) -> str:
     return new_token
 
 
+def _register_claude_code_mcp(remote_url: str, local_token: str) -> None:
+    """Register the mnemon MCP server with Claude Code via the `claude` CLI.
+
+    Claude Code loads MCP server registrations from its own config
+    (managed by ``claude mcp add``), not from ``settings.json.mcpServers``.
+    Writing an HTTP transport entry to ``settings.json`` has no effect — the
+    CLI silently ignores it. Shelling out to ``claude mcp add`` is the only
+    supported registration path.
+    """
+    try:
+        subprocess.run(
+            ["claude", "mcp", "remove", "--scope", "user", "mnemon"],
+            check=False,
+            capture_output=True,
+        )
+        subprocess.run(
+            [
+                "claude", "mcp", "add",
+                "--scope", "user",
+                "--transport", "http",
+                "mnemon",
+                remote_url,
+                "--header", f"Authorization: Bearer {local_token}",
+            ],
+            check=True,
+            capture_output=True,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "The `claude` CLI was not found on PATH. Install Claude Code "
+            "before running `mnemon setup claude-code` with --remote-url."
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or b"").decode(errors="replace").strip()
+        raise RuntimeError(
+            f"`claude mcp add` failed (exit {exc.returncode}): {stderr}"
+        ) from exc
+
+
 def setup_claude_code(*, remote_url: str | None = None, token: str | None = None) -> str:
     """Configure Claude Code hooks (and optionally MCP server).
 
     When ``remote_url`` is provided, writes the URL and token to
-    ``~/.mnemon/`` config files and adds a SessionStart pre-warm hook.
-    The hooks themselves read these files at runtime via ``_remote_client``.
+    ``~/.mnemon/`` config files, registers the HTTP MCP server via
+    ``claude mcp add``, and adds a SessionStart pre-warm hook. The hooks
+    themselves read these files at runtime via ``_remote_client``.
 
     When ``remote_url`` is not provided, configures a local stdio MCP server
     for development/testing. Hooks will attempt to use remote if
@@ -174,21 +215,21 @@ def setup_claude_code(*, remote_url: str | None = None, token: str | None = None
     lines = []
 
     if remote_url:
+        local_token = _ensure_local_token(token)
         _ensure_remote_url(remote_url)
-        # Call for side-effect only (writes ~/.mnemon/local_token); the
-        # Claude-Code path doesn't need the token string back — hooks
-        # read the file directly at invocation time.
-        _ensure_local_token(token)
         lines.append(f"  Remote URL: {remote_url}")
         lines.append(f"  Token file: {LOCAL_TOKEN_FILE} (chmod 600)")
 
-        # Remove stdio MCP server — hooks use remote now
-        if "mcpServers" in settings and "mnemon" in settings["mcpServers"]:
-            del settings["mcpServers"]["mnemon"]
-            if not settings["mcpServers"]:
+        _register_claude_code_mcp(remote_url, local_token)
+        lines.append("  MCP server: mnemon (http, remote) — registered via `claude mcp add`")
+
+        mcp_servers = settings.get("mcpServers")
+        if isinstance(mcp_servers, dict) and "mnemon" in mcp_servers:
+            del mcp_servers["mnemon"]
+            if not mcp_servers:
                 del settings["mcpServers"]
+            lines.append("  Cleaned up stale settings.json mcpServers.mnemon entry")
     else:
-        # Local-only mode: add stdio MCP server
         if "mcpServers" not in settings:
             settings["mcpServers"] = {}
         settings["mcpServers"]["mnemon"] = _mcp_config()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -4,7 +4,7 @@ import json
 import os
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -119,29 +119,59 @@ class TestSetupClaudeCode:
             assert "Stop" in settings["hooks"]
             assert "Restart" in result
 
-    def test_remote_mode_removes_stdio_mcp(self):
+    def test_remote_mode_registers_via_claude_cli_and_cleans_stale_entry(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             settings_path = Path(tmpdir) / ".claude" / "settings.json"
             settings_path.parent.mkdir(parents=True)
             settings_path.write_text(json.dumps({
-                "mcpServers": {"mnemon": {"command": "python", "args": ["-m", "mnemon", "serve"]}},
+                "mcpServers": {
+                    "mnemon": {"type": "http", "url": "https://old.fly.dev/mcp"},
+                    "other": {"command": "keepme"},
+                },
             }))
             mnemon_dir = Path(tmpdir) / ".mnemon"
             with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)), \
                  patch("mnemon.setup.MNEMON_DIR", mnemon_dir), \
                  patch("mnemon.setup.LOCAL_TOKEN_FILE", mnemon_dir / "local_token"), \
-                 patch("mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"):
-                result = setup_claude_code(remote_url="https://test.fly.dev/mcp")
+                 patch("mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"), \
+                 patch("mnemon.setup.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
+                result = setup_claude_code(
+                    remote_url="https://test.fly.dev/mcp",
+                    token="test-tok",
+                )
+
+            add_calls = [c for c in mock_run.call_args_list if "add" in c.args[0]]
+            assert len(add_calls) == 1
+            cmd = add_calls[0].args[0]
+            assert cmd[:3] == ["claude", "mcp", "add"]
+            assert "--scope" in cmd and "user" in cmd
+            assert "--transport" in cmd and "http" in cmd
+            assert "https://test.fly.dev/mcp" in cmd
+            assert "Authorization: Bearer test-tok" in cmd
+
+            remove_calls = [c for c in mock_run.call_args_list if "remove" in c.args[0]]
+            assert len(remove_calls) == 1
 
             settings = json.loads(settings_path.read_text())
-            # stdio MCP server should be removed
-            assert "mcpServers" not in settings or "mnemon" not in settings.get("mcpServers", {})
-            # Hooks should exist
+            assert "mnemon" not in settings.get("mcpServers", {})
+            assert settings["mcpServers"]["other"]["command"] == "keepme"
             assert "UserPromptSubmit" in settings["hooks"]
             assert "SessionStart" in settings["hooks"]
-            # Remote URL file should be written
             assert (mnemon_dir / "remote_url").read_text() == "https://test.fly.dev/mcp"
             assert "Remote URL" in result
+            assert "claude mcp add" in result
+
+    def test_remote_mode_raises_when_claude_cli_missing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mnemon_dir = Path(tmpdir) / ".mnemon"
+            with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)), \
+                 patch("mnemon.setup.MNEMON_DIR", mnemon_dir), \
+                 patch("mnemon.setup.LOCAL_TOKEN_FILE", mnemon_dir / "local_token"), \
+                 patch("mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"), \
+                 patch("mnemon.setup.subprocess.run", side_effect=FileNotFoundError):
+                with pytest.raises(RuntimeError, match="claude.*CLI was not found"):
+                    setup_claude_code(remote_url="https://test.fly.dev/mcp", token="tok")
 
     def test_remote_mode_adds_session_start_hook(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -150,7 +180,9 @@ class TestSetupClaudeCode:
             with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)), \
                  patch("mnemon.setup.MNEMON_DIR", mnemon_dir), \
                  patch("mnemon.setup.LOCAL_TOKEN_FILE", mnemon_dir / "local_token"), \
-                 patch("mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"):
+                 patch("mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"), \
+                 patch("mnemon.setup.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
                 setup_claude_code(remote_url="https://test.fly.dev/mcp")
 
             settings = json.loads(settings_path.read_text())
@@ -253,7 +285,9 @@ class TestRunSetup:
             with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)), \
                  patch("mnemon.setup.MNEMON_DIR", mnemon_dir), \
                  patch("mnemon.setup.LOCAL_TOKEN_FILE", mnemon_dir / "local_token"), \
-                 patch("mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"):
+                 patch("mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"), \
+                 patch("mnemon.setup.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
                 result = run_setup("claude-code", ["--remote-url", "https://my.fly.dev/mcp"])
         assert "Remote URL" in result
         assert "https://my.fly.dev/mcp" in result


### PR DESCRIPTION
## Summary

- HTTP MCP servers written to `settings.json.mcpServers` are silently ignored by Claude Code — it only loads registrations from its CLI-managed `~/.claude.json`. Users ran `mnemon setup claude-code --remote-url ...`, saw a config block appear, restarted, and got no `mcp__mnemon__*` tools.
- `setup_claude_code` with `--remote-url` now shells out to `claude mcp remove` (idempotent) then `claude mcp add --scope user --transport http mnemon <url> --header "Authorization: Bearer <token>"`.
- Cleans up stale `settings.json.mcpServers.mnemon` entries from previous setup runs; preserves other MCP servers in that block.
- Clear `RuntimeError` if the `claude` CLI isn't on PATH.

Verified end-to-end today: `claude mcp add` via manual invocation → restart → `mcp__mnemon__*` tools load + UserPromptSubmit hook injects context.

## Test plan

- [x] `pytest tests/test_setup.py` — 27/27 pass
- [x] Full suite: 482 passed (4 pre-existing sandbox errors in `test_integration_remote.py` unrelated to this change)
- [x] New test `test_remote_mode_registers_via_claude_cli_and_cleans_stale_entry` asserts:
  - `claude mcp add` invoked with correct args (scope, transport, url, bearer header)
  - `claude mcp remove` invoked first for idempotency
  - stale `mcpServers.mnemon` deleted, other entries preserved
- [x] New test `test_remote_mode_raises_when_claude_cli_missing` asserts clean `RuntimeError`
- [ ] Post-merge: cut new mnemon version, re-run `mnemon setup claude-code --remote-url ...` from a fresh clone to confirm the happy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)