### PR TITLE
fix(setup): stop installing broken hooks in local-only mode (P0)

### DIFF
--- a/src/mnemon/setup.py
+++ b/src/mnemon/setup.py
@@ -10,11 +10,21 @@ flag has **no default** — this is the highest-risk guardrail in the
 unification plan. If it defaulted to the author's Fly URL, a forked user
 running ``mnemon setup`` would accidentally send their memories into the
 wrong vault.
+
+P0 simplification (2026-04-21, mnemon memory #109): hooks are only ever
+written when ``--remote-url`` is supplied, because the hook code path
+(``hooks/_remote_client.py``) talks exclusively over HTTP. Installing
+hooks against a local stdio MCP produced silent config errors on every
+prompt. A remote endpoint is now validated end-to-end before any config
+is written, and a summary + ``mnemon doctor`` run fire at the end of
+every successful setup so config gaps surface loudly. See
+``private/mnemon-simplification-plan-260421.md``.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import secrets
 import subprocess
 import sys
@@ -24,6 +34,15 @@ from pathlib import Path
 MNEMON_DIR = Path.home() / ".mnemon"
 LOCAL_TOKEN_FILE = MNEMON_DIR / "local_token"
 REMOTE_URL_FILE = MNEMON_DIR / "remote_url"
+
+# Timeout for the setup-time remote preflight. Generous vs. the hook's
+# 8s budget because a brand-new Fly machine may be cold and the first
+# FastEmbed load adds ~15s to the first call.
+REMOTE_PREFLIGHT_TIMEOUT_SEC = 30.0
+
+
+class SetupError(Exception):
+    """Raised when setup cannot proceed — surfaces a user-facing message."""
 
 
 def _python_path() -> str:
@@ -158,6 +177,84 @@ def _ensure_local_token(token: str | None = None) -> str:
     return new_token
 
 
+def _strip_mnemon_hooks(hooks: dict) -> None:
+    """Remove any hook entries whose command references ``mnemon.hooks.*``.
+
+    Used when re-running setup in local mode to clean up stale remote-era
+    hook entries that would otherwise keep firing and surfacing config
+    errors. Mutates ``hooks`` in place and drops keys whose list is empty
+    after filtering.
+    """
+
+    def _keeps(entry: dict) -> dict | None:
+        inner = [
+            h
+            for h in entry.get("hooks", [])
+            if "mnemon.hooks." not in (h.get("command") or "")
+        ]
+        if not inner:
+            return None
+        return {**entry, "hooks": inner}
+
+    for event in ("UserPromptSubmit", "Stop", "SessionStart"):
+        entries = hooks.get(event)
+        if not isinstance(entries, list):
+            continue
+        filtered = [kept for kept in (_keeps(e) for e in entries) if kept]
+        if filtered:
+            hooks[event] = filtered
+        else:
+            del hooks[event]
+
+
+def _preflight_remote_endpoint(remote_url: str, local_token: str) -> None:
+    """Validate that ``remote_url`` + token round-trip a tool call.
+
+    Runs the real MCP ``memory_status`` call through the hook client path
+    so we exercise auth, transport, and server readiness — exactly what the
+    hooks will do at runtime. Env vars are set directly (not the config
+    files) so we do not leave partial state behind on failure.
+
+    Raises :class:`SetupError` with a concrete message on any failure.
+    """
+    # Import late: _remote_client pulls in the MCP SDK, which we do not
+    # want to load for users running local-only setup.
+    from .hooks._remote_client import (
+        RemoteClientConfigError,
+        call_tool_sync,
+    )
+
+    prior_url = os.environ.get("MNEMON_REMOTE_URL")
+    prior_token = os.environ.get("MNEMON_LOCAL_TOKEN")
+    os.environ["MNEMON_REMOTE_URL"] = remote_url
+    os.environ["MNEMON_LOCAL_TOKEN"] = local_token
+    try:
+        call_tool_sync(
+            "memory_status",
+            {},
+            timeout=REMOTE_PREFLIGHT_TIMEOUT_SEC,
+            client_label="mnemon-setup",
+        )
+    except RemoteClientConfigError as exc:
+        raise SetupError(f"Remote preflight failed: {exc}") from exc
+    except Exception as exc:  # noqa: BLE001 — any failure aborts setup
+        raise SetupError(
+            f"Remote endpoint {remote_url} did not respond to "
+            f"memory_status within {REMOTE_PREFLIGHT_TIMEOUT_SEC:.0f}s. "
+            f"Root cause: {type(exc).__name__}: {exc}. "
+            "No configuration was written."
+        ) from exc
+    finally:
+        if prior_url is None:
+            os.environ.pop("MNEMON_REMOTE_URL", None)
+        else:
+            os.environ["MNEMON_REMOTE_URL"] = prior_url
+        if prior_token is None:
+            os.environ.pop("MNEMON_LOCAL_TOKEN", None)
+        else:
+            os.environ["MNEMON_LOCAL_TOKEN"] = prior_token
+
+
 def _register_claude_code_mcp(remote_url: str, local_token: str) -> None:
     """Register the mnemon MCP server with Claude Code via the `claude` CLI.
 
@@ -198,16 +295,21 @@ def _register_claude_code_mcp(remote_url: str, local_token: str) -> None:
 
 
 def setup_claude_code(*, remote_url: str | None = None, token: str | None = None) -> str:
-    """Configure Claude Code hooks (and optionally MCP server).
+    """Configure Claude Code (MCP server, and hooks only when remote).
 
-    When ``remote_url`` is provided, writes the URL and token to
-    ``~/.mnemon/`` config files, registers the HTTP MCP server via
-    ``claude mcp add``, and adds a SessionStart pre-warm hook. The hooks
-    themselves read these files at runtime via ``_remote_client``.
+    When ``remote_url`` is provided:
+      - Preflight the endpoint (aborts setup if unreachable).
+      - Write URL + token to ``~/.mnemon/`` config files.
+      - Register the HTTP MCP server via ``claude mcp add``.
+      - Install UserPromptSubmit / Stop / SessionStart hooks.
 
-    When ``remote_url`` is not provided, configures a local stdio MCP server
-    for development/testing. Hooks will attempt to use remote if
-    ``~/.mnemon/remote_url`` exists, otherwise fall back to local.
+    When ``remote_url`` is not provided:
+      - Register a local stdio MCP server in ``settings.json``.
+      - **Hooks are NOT installed** — the hook code path is HTTP-only
+        (``hooks/_remote_client.py``) and has no local fallback. Writing
+        them against stdio would produce silent config errors on every
+        prompt. Users who want hooks should run ``mnemon upgrade web``
+        (forthcoming) or pass ``--remote-url``.
     """
     settings_path = Path.home() / ".claude" / "settings.json"
     settings = _read_json(settings_path)
@@ -216,9 +318,11 @@ def setup_claude_code(*, remote_url: str | None = None, token: str | None = None
 
     if remote_url:
         local_token = _ensure_local_token(token)
+        _preflight_remote_endpoint(remote_url, local_token)
         _ensure_remote_url(remote_url)
         lines.append(f"  Remote URL: {remote_url}")
         lines.append(f"  Token file: {LOCAL_TOKEN_FILE} (chmod 600)")
+        lines.append(f"  Preflight:  OK (memory_status round-trip < {REMOTE_PREFLIGHT_TIMEOUT_SEC:.0f}s)")
 
         _register_claude_code_mcp(remote_url, local_token)
         lines.append("  MCP server: mnemon (http, remote) — registered via `claude mcp add`")
@@ -229,24 +333,34 @@ def setup_claude_code(*, remote_url: str | None = None, token: str | None = None
             if not mcp_servers:
                 del settings["mcpServers"]
             lines.append("  Cleaned up stale settings.json mcpServers.mnemon entry")
+
+        hooks = _hooks_config(remote_url=remote_url)
+        if "hooks" not in settings:
+            settings["hooks"] = {}
+        settings["hooks"]["UserPromptSubmit"] = hooks["UserPromptSubmit"]
+        settings["hooks"]["Stop"] = hooks["Stop"]
+        settings["hooks"]["SessionStart"] = hooks["SessionStart"]
+        lines.append("  UserPromptSubmit: context-surfacing (8s)")
+        lines.append("  Stop: session-extractor (30s), handoff-generator (30s)")
+        lines.append("  SessionStart: pre-warm polling (90s background)")
     else:
         if "mcpServers" not in settings:
             settings["mcpServers"] = {}
         settings["mcpServers"]["mnemon"] = _mcp_config()
         lines.append("  MCP server: mnemon (stdio, local)")
-
-    # Hooks (always written — they detect remote/local from config files)
-    hooks = _hooks_config(remote_url=remote_url)
-    if "hooks" not in settings:
-        settings["hooks"] = {}
-    settings["hooks"]["UserPromptSubmit"] = hooks["UserPromptSubmit"]
-    settings["hooks"]["Stop"] = hooks["Stop"]
-    if "SessionStart" in hooks:
-        settings["hooks"]["SessionStart"] = hooks["SessionStart"]
-        lines.append("  SessionStart: pre-warm polling (90s background)")
-
-    lines.append("  UserPromptSubmit: context-surfacing (8s)")
-    lines.append("  Stop: session-extractor (30s), handoff-generator (30s)")
+        # Strip any previously-installed mnemon hooks so old configs on
+        # a machine being downgraded don't keep erroring.
+        existing_hooks = settings.get("hooks")
+        if isinstance(existing_hooks, dict):
+            _strip_mnemon_hooks(existing_hooks)
+            if not existing_hooks:
+                del settings["hooks"]
+        lines.append("  Hooks:      skipped (local-only setup)")
+        lines.append(
+            "              Hooks require a remote vault. Run "
+            "`mnemon setup claude-code --remote-url <URL>` or "
+            "`mnemon upgrade web` to enable them."
+        )
 
     _write_json(settings_path, settings)
 
@@ -270,15 +384,16 @@ def setup_cursor(*, remote_url: str | None = None, token: str | None = None) -> 
         config["mcpServers"] = {}
 
     if remote_url:
-        _ensure_remote_url(remote_url)
         local_token = _ensure_local_token(token)
+        _preflight_remote_endpoint(remote_url, local_token)
+        _ensure_remote_url(remote_url)
         config["mcpServers"]["mnemon"] = {
             "url": remote_url,
             "headers": {
                 "Authorization": f"Bearer {local_token}",
             },
         }
-        mode = "remote"
+        mode = "remote (preflight OK)"
     else:
         config["mcpServers"]["mnemon"] = _mcp_config()
         mode = "stdio (local)"
@@ -302,33 +417,48 @@ def setup_gemini() -> str:
 
 
 def setup_hooks(*, remote_url: str | None = None, token: str | None = None) -> str:
-    """Configure Claude Code hooks only (no MCP server)."""
+    """Configure Claude Code hooks only (no MCP server).
+
+    Hooks require a reachable remote vault — the hook code path speaks
+    HTTP exclusively. Calling this without ``--remote-url`` raises
+    :class:`SetupError` rather than writing broken config.
+    """
+    if not remote_url:
+        raise SetupError(
+            "`mnemon setup hooks` requires --remote-url. The hook code "
+            "path is HTTP-only; without a remote endpoint hooks would "
+            "emit a config error on every Claude Code prompt. Use "
+            "`mnemon setup claude-code` for a local-only (MCP-only) "
+            "install, or pass --remote-url to enable hooks."
+        )
+
     settings_path = Path.home() / ".claude" / "settings.json"
     settings = _read_json(settings_path)
 
-    if remote_url:
-        _ensure_remote_url(remote_url)
-        _ensure_local_token(token)
+    local_token = _ensure_local_token(token)
+    _preflight_remote_endpoint(remote_url, local_token)
+    _ensure_remote_url(remote_url)
 
     hooks = _hooks_config(remote_url=remote_url)
     if "hooks" not in settings:
         settings["hooks"] = {}
     settings["hooks"]["UserPromptSubmit"] = hooks["UserPromptSubmit"]
     settings["hooks"]["Stop"] = hooks["Stop"]
-    if "SessionStart" in hooks:
-        settings["hooks"]["SessionStart"] = hooks["SessionStart"]
+    settings["hooks"]["SessionStart"] = hooks["SessionStart"]
 
     _write_json(settings_path, settings)
 
-    lines = [
-        f"Hooks configured at {settings_path}",
-        "  UserPromptSubmit: context-surfacing (8s)",
-        "  Stop: session-extractor (30s), handoff-generator (30s)",
-    ]
-    if "SessionStart" in hooks:
-        lines.append("  SessionStart: pre-warm polling (90s background)")
-    lines.append("Restart Claude Code to activate.")
-    return "\n".join(lines)
+    return "\n".join(
+        [
+            f"Hooks configured at {settings_path}",
+            f"  Remote URL: {remote_url}",
+            f"  Preflight:  OK (memory_status round-trip < {REMOTE_PREFLIGHT_TIMEOUT_SEC:.0f}s)",
+            "  UserPromptSubmit: context-surfacing (8s)",
+            "  Stop: session-extractor (30s), handoff-generator (30s)",
+            "  SessionStart: pre-warm polling (90s background)",
+            "Restart Claude Code to activate.",
+        ]
+    )
 
 
 TARGETS = {
@@ -340,8 +470,12 @@ TARGETS = {
 
 
 def _parse_setup_args(args: list[str]) -> dict:
-    """Parse --remote-url and --token flags from CLI args."""
-    result: dict[str, str | None] = {"remote_url": None, "token": None}
+    """Parse --remote-url, --token, and --skip-doctor flags from CLI args."""
+    result: dict[str, str | bool | None] = {
+        "remote_url": None,
+        "token": None,
+        "skip_doctor": False,
+    }
     i = 0
     while i < len(args):
         if args[i] == "--remote-url" and i + 1 < len(args):
@@ -350,13 +484,47 @@ def _parse_setup_args(args: list[str]) -> dict:
         elif args[i] == "--token" and i + 1 < len(args):
             result["token"] = args[i + 1]
             i += 2
+        elif args[i] == "--skip-doctor":
+            result["skip_doctor"] = True
+            i += 1
         else:
             i += 1
     return result
 
 
+def _next_steps_block(target: str, remote_url: str | None) -> str:
+    """Human-readable next-steps footer for setup output."""
+    lines = ["", "Next steps:"]
+    if target == "claude-code":
+        lines.append("  • Restart Claude Code to activate the MCP tools.")
+    elif target == "cursor":
+        lines.append("  • Restart Cursor to activate the MCP tools.")
+    elif target == "hooks":
+        lines.append("  • Restart Claude Code to activate the hooks.")
+
+    if remote_url is None and target == "claude-code":
+        lines.append(
+            "  • Want mobile / claude.ai / cross-device memory? "
+            "Run `mnemon upgrade web` (coming soon) or pass "
+            "--remote-url <URL> to enable hooks now."
+        )
+    lines.append("  • Run `mnemon doctor` any time to re-verify the setup.")
+    return "\n".join(lines)
+
+
 def run_setup(target: str, args: list[str] | None = None) -> str:
-    """Run setup for the given target. Returns status message."""
+    """Run setup for the given target, auto-run doctor, return status.
+
+    After a successful setup, ``mnemon doctor`` runs against the
+    newly-configured vault (local or remote, auto-detected). A failing
+    doctor run is surfaced in the returned message but does not raise —
+    the setup itself already succeeded, and the doctor output is what
+    the user needs to read to act on the gap.
+
+    Pass ``--skip-doctor`` in ``args`` to suppress the automatic run
+    (useful for CI or scripted setups where the caller runs doctor
+    separately).
+    """
     if target not in TARGETS:
         valid = ", ".join(TARGETS.keys())
         return f"Unknown target: {target}\nValid targets: {valid}"
@@ -364,8 +532,43 @@ def run_setup(target: str, args: list[str] | None = None) -> str:
     parsed = _parse_setup_args(args or [])
     func = TARGETS[target]
 
-    # Gemini doesn't accept remote_url/token kwargs
-    if target == "gemini":
-        return func()
+    try:
+        if target == "gemini":
+            primary = func()
+        else:
+            primary = func(
+                remote_url=parsed["remote_url"], token=parsed["token"]
+            )
+    except SetupError as exc:
+        return f"setup failed: {exc}"
 
-    return func(remote_url=parsed["remote_url"], token=parsed["token"])
+    footer = _next_steps_block(target, parsed["remote_url"])
+
+    if parsed["skip_doctor"] or target == "gemini":
+        return primary + footer
+
+    # Capture doctor output so setup returns a single cohesive string
+    # (tests + CLI wrapper both consume this as one blob).
+    import io
+
+    from .doctor import run_doctor
+
+    buf = io.StringIO()
+    print("", file=buf)
+    print("Running mnemon doctor to verify...", file=buf)
+    try:
+        doctor_rc = run_doctor(out=buf)
+    except Exception as exc:  # noqa: BLE001
+        buf.write(
+            f"\n(doctor invocation crashed: {type(exc).__name__}: {exc})\n"
+        )
+        doctor_rc = 1
+
+    if doctor_rc != 0:
+        buf.write(
+            "\nNOTE: doctor reported issues. Setup files were written, "
+            "but the environment is not fully ready — fix the failing "
+            "check(s) above before using mnemon.\n"
+        )
+
+    return primary + footer + "\n" + buf.getvalue()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -9,16 +9,19 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from mnemon.setup import (
+    SetupError,
     run_setup,
     setup_claude_code,
     setup_cursor,
     setup_gemini,
     setup_hooks,
-    _mcp_config,
     _hooks_config,
+    _mcp_config,
     _ensure_local_token,
     _ensure_remote_url,
+    _next_steps_block,
     _parse_setup_args,
+    _strip_mnemon_hooks,
     TARGETS,
 )
 
@@ -106,7 +109,13 @@ class TestParseSetupArgs:
 
 
 class TestSetupClaudeCode:
-    def test_creates_settings_file_local_mode(self):
+    def test_creates_settings_file_local_mode_without_hooks(self):
+        """P0 (mnemon #109): local-only setup must NOT install hooks.
+
+        Hooks are HTTP-only (hooks/_remote_client.py has no local
+        fallback). Installing them with only a stdio MCP server produced
+        silent ``RemoteClientConfigError`` banners on every prompt.
+        """
         with tempfile.TemporaryDirectory() as tmpdir:
             settings_path = Path(tmpdir) / ".claude" / "settings.json"
             with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)):
@@ -115,9 +124,44 @@ class TestSetupClaudeCode:
             assert settings_path.exists()
             settings = json.loads(settings_path.read_text())
             assert "mnemon" in settings["mcpServers"]
-            assert "UserPromptSubmit" in settings["hooks"]
-            assert "Stop" in settings["hooks"]
+            assert "hooks" not in settings, (
+                "local-only setup must not write hook entries"
+            )
+            assert "Hooks" in result and "skipped" in result
             assert "Restart" in result
+
+    def test_local_mode_strips_stale_mnemon_hooks(self):
+        """Re-running setup locally after a prior remote install should
+        clean up old mnemon hook entries so they stop erroring."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_path = Path(tmpdir) / ".claude" / "settings.json"
+            settings_path.parent.mkdir(parents=True)
+            settings_path.write_text(json.dumps({
+                "hooks": {
+                    "UserPromptSubmit": [
+                        {"matcher": "", "hooks": [
+                            {"type": "command",
+                             "command": "python -m mnemon.hooks.context_surfacing"},
+                        ]},
+                    ],
+                    "Stop": [
+                        {"matcher": "", "hooks": [
+                            {"type": "command",
+                             "command": "python -m mnemon.hooks.session_extractor"},
+                            {"type": "command", "command": "other-thing"},
+                        ]},
+                    ],
+                },
+            }))
+            with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)):
+                setup_claude_code()
+            settings = json.loads(settings_path.read_text())
+            hooks = settings.get("hooks", {})
+            assert "UserPromptSubmit" not in hooks
+            # Non-mnemon entries survive
+            stop = hooks.get("Stop", [])
+            assert len(stop) == 1
+            assert stop[0]["hooks"][0]["command"] == "other-thing"
 
     def test_remote_mode_registers_via_claude_cli_and_cleans_stale_entry(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -134,12 +178,16 @@ class TestSetupClaudeCode:
                  patch("mnemon.setup.MNEMON_DIR", mnemon_dir), \
                  patch("mnemon.setup.LOCAL_TOKEN_FILE", mnemon_dir / "local_token"), \
                  patch("mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"), \
+                 patch("mnemon.setup._preflight_remote_endpoint") as mock_preflight, \
                  patch("mnemon.setup.subprocess.run") as mock_run:
                 mock_run.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
                 result = setup_claude_code(
                     remote_url="https://test.fly.dev/mcp",
                     token="test-tok",
                 )
+            mock_preflight.assert_called_once_with(
+                "https://test.fly.dev/mcp", "test-tok"
+            )
 
             add_calls = [c for c in mock_run.call_args_list if "add" in c.args[0]]
             assert len(add_calls) == 1
@@ -169,9 +217,32 @@ class TestSetupClaudeCode:
                  patch("mnemon.setup.MNEMON_DIR", mnemon_dir), \
                  patch("mnemon.setup.LOCAL_TOKEN_FILE", mnemon_dir / "local_token"), \
                  patch("mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"), \
+                 patch("mnemon.setup._preflight_remote_endpoint"), \
                  patch("mnemon.setup.subprocess.run", side_effect=FileNotFoundError):
                 with pytest.raises(RuntimeError, match="claude.*CLI was not found"):
                     setup_claude_code(remote_url="https://test.fly.dev/mcp", token="tok")
+
+    def test_remote_preflight_failure_aborts_setup_cleanly(self):
+        """Preflight must run BEFORE any destructive step. On failure, no
+        config files or settings.json edits are left behind."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_path = Path(tmpdir) / ".claude" / "settings.json"
+            mnemon_dir = Path(tmpdir) / ".mnemon"
+            with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)), \
+                 patch("mnemon.setup.MNEMON_DIR", mnemon_dir), \
+                 patch("mnemon.setup.LOCAL_TOKEN_FILE", mnemon_dir / "local_token"), \
+                 patch("mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"), \
+                 patch("mnemon.setup._preflight_remote_endpoint",
+                       side_effect=SetupError("endpoint unreachable")), \
+                 patch("mnemon.setup.subprocess.run") as mock_run:
+                with pytest.raises(SetupError, match="endpoint unreachable"):
+                    setup_claude_code(remote_url="https://test.fly.dev/mcp", token="tok")
+            # claude CLI never invoked (preflight aborted before it)
+            mock_run.assert_not_called()
+            # settings.json never written
+            assert not settings_path.exists()
+            # remote_url file never written (we bail before _ensure_remote_url)
+            assert not (mnemon_dir / "remote_url").exists()
 
     def test_remote_mode_adds_session_start_hook(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -181,6 +252,7 @@ class TestSetupClaudeCode:
                  patch("mnemon.setup.MNEMON_DIR", mnemon_dir), \
                  patch("mnemon.setup.LOCAL_TOKEN_FILE", mnemon_dir / "local_token"), \
                  patch("mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"), \
+                 patch("mnemon.setup._preflight_remote_endpoint"), \
                  patch("mnemon.setup.subprocess.run") as mock_run:
                 mock_run.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
                 setup_claude_code(remote_url="https://test.fly.dev/mcp")
@@ -229,7 +301,8 @@ class TestSetupCursor:
             with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)), \
                  patch("mnemon.setup.MNEMON_DIR", mnemon_dir), \
                  patch("mnemon.setup.LOCAL_TOKEN_FILE", mnemon_dir / "local_token"), \
-                 patch("mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"):
+                 patch("mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"), \
+                 patch("mnemon.setup._preflight_remote_endpoint"):
                 setup_cursor(remote_url="https://test.fly.dev/mcp", token="test-tok")
 
             config = json.loads(cursor_path.read_text())
@@ -246,16 +319,15 @@ class TestSetupGemini:
 
 
 class TestSetupHooks:
-    def test_writes_hooks_only_local(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            settings_path = Path(tmpdir) / ".claude" / "settings.json"
-            with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)):
-                setup_hooks()
+    def test_refuses_without_remote_url(self):
+        """P0 (mnemon #109): setup_hooks without --remote-url must raise.
 
-            settings = json.loads(settings_path.read_text())
-            assert "hooks" in settings
-            assert "mcpServers" not in settings
-            assert "SessionStart" not in settings["hooks"]
+        The hook code path is HTTP-only; writing hook entries without a
+        configured remote endpoint guarantees a config error on every
+        prompt. Better to refuse loudly than to ship the broken config.
+        """
+        with pytest.raises(SetupError, match="requires --remote-url"):
+            setup_hooks()
 
     def test_writes_hooks_with_session_start_when_remote(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -264,11 +336,27 @@ class TestSetupHooks:
             with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)), \
                  patch("mnemon.setup.MNEMON_DIR", mnemon_dir), \
                  patch("mnemon.setup.LOCAL_TOKEN_FILE", mnemon_dir / "local_token"), \
-                 patch("mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"):
+                 patch("mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"), \
+                 patch("mnemon.setup._preflight_remote_endpoint"):
                 setup_hooks(remote_url="https://test.fly.dev/mcp")
 
             settings = json.loads(settings_path.read_text())
             assert "SessionStart" in settings["hooks"]
+
+    def test_preflight_failure_leaves_no_state(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_path = Path(tmpdir) / ".claude" / "settings.json"
+            mnemon_dir = Path(tmpdir) / ".mnemon"
+            with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)), \
+                 patch("mnemon.setup.MNEMON_DIR", mnemon_dir), \
+                 patch("mnemon.setup.LOCAL_TOKEN_FILE", mnemon_dir / "local_token"), \
+                 patch("mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"), \
+                 patch("mnemon.setup._preflight_remote_endpoint",
+                       side_effect=SetupError("endpoint 502")):
+                with pytest.raises(SetupError, match="502"):
+                    setup_hooks(remote_url="https://test.fly.dev/mcp")
+            assert not settings_path.exists()
+            assert not (mnemon_dir / "remote_url").exists()
 
 
 class TestRunSetup:
@@ -286,15 +374,184 @@ class TestRunSetup:
                  patch("mnemon.setup.MNEMON_DIR", mnemon_dir), \
                  patch("mnemon.setup.LOCAL_TOKEN_FILE", mnemon_dir / "local_token"), \
                  patch("mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"), \
+                 patch("mnemon.setup._preflight_remote_endpoint"), \
+                 patch("mnemon.doctor.run_doctor", return_value=0), \
                  patch("mnemon.setup.subprocess.run") as mock_run:
                 mock_run.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
-                result = run_setup("claude-code", ["--remote-url", "https://my.fly.dev/mcp"])
+                result = run_setup(
+                    "claude-code",
+                    ["--remote-url", "https://my.fly.dev/mcp", "--skip-doctor"],
+                )
         assert "Remote URL" in result
         assert "https://my.fly.dev/mcp" in result
 
     def test_gemini_ignores_remote_url(self):
-        result = run_setup("gemini", ["--remote-url", "https://ignored.fly.dev/mcp"])
+        result = run_setup(
+            "gemini",
+            ["--remote-url", "https://ignored.fly.dev/mcp", "--skip-doctor"],
+        )
         assert "mnemon" in result
+
+    def test_auto_runs_doctor_after_successful_setup(self):
+        """Without --skip-doctor, a successful setup invokes run_doctor
+        and appends its output to the returned message."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fake_doctor = MagicMock(return_value=0)
+
+            def _doctor_side_effect(out, **_kw):
+                out.write("mnemon doctor — local mode (FAKE)\n")
+                out.write("  OK fake_check: everything fine\n")
+                return 0
+
+            fake_doctor.side_effect = _doctor_side_effect
+            with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)), \
+                 patch("mnemon.doctor.run_doctor", fake_doctor):
+                result = run_setup("claude-code", [])
+
+            fake_doctor.assert_called_once()
+            assert "Running mnemon doctor" in result
+            assert "fake_check: everything fine" in result
+            assert "Next steps:" in result
+
+    def test_skip_doctor_bypasses_invocation(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)), \
+                 patch("mnemon.doctor.run_doctor") as mock_doctor:
+                result = run_setup("claude-code", ["--skip-doctor"])
+            mock_doctor.assert_not_called()
+            assert "Running mnemon doctor" not in result
+
+    def test_setup_error_returned_as_failure_message(self):
+        """A SetupError must be surfaced as a user-facing string, not a
+        crash. Keeps the CLI from dumping a traceback on the user."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mnemon_dir = Path(tmpdir) / ".mnemon"
+            with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)), \
+                 patch("mnemon.setup.MNEMON_DIR", mnemon_dir), \
+                 patch("mnemon.setup.LOCAL_TOKEN_FILE", mnemon_dir / "local_token"), \
+                 patch("mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"), \
+                 patch("mnemon.setup._preflight_remote_endpoint",
+                       side_effect=SetupError("cold fly machine")), \
+                 patch("mnemon.setup.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
+                result = run_setup(
+                    "claude-code",
+                    ["--remote-url", "https://x.fly.dev/mcp", "--skip-doctor"],
+                )
+        assert result.startswith("setup failed:")
+        assert "cold fly machine" in result
+
+    def test_doctor_failure_appends_note_but_does_not_raise(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            def _failing_doctor(out, **_kw):
+                out.write("mnemon doctor — local mode\n")
+                out.write("  FAIL vault: missing\n")
+                return 1
+
+            with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)), \
+                 patch("mnemon.doctor.run_doctor", side_effect=_failing_doctor):
+                result = run_setup("claude-code", [])
+
+        assert "doctor reported issues" in result
+
+
+class TestStripMnemonHooks:
+    def test_drops_mnemon_entries_keeps_others(self):
+        hooks = {
+            "UserPromptSubmit": [
+                {"matcher": "", "hooks": [
+                    {"type": "command",
+                     "command": "python -m mnemon.hooks.context_surfacing"},
+                    {"type": "command", "command": "other-tool"},
+                ]},
+            ],
+            "Stop": [
+                {"matcher": "", "hooks": [
+                    {"type": "command",
+                     "command": "python -m mnemon.hooks.session_extractor"},
+                ]},
+            ],
+        }
+        _strip_mnemon_hooks(hooks)
+        assert "Stop" not in hooks  # only had a mnemon entry
+        ups = hooks["UserPromptSubmit"][0]["hooks"]
+        assert len(ups) == 1
+        assert ups[0]["command"] == "other-tool"
+
+    def test_leaves_unrelated_events_untouched(self):
+        hooks = {
+            "CustomEvent": [
+                {"matcher": "", "hooks": [
+                    {"type": "command", "command": "python -m mnemon.hooks.foo"},
+                ]},
+            ],
+        }
+        _strip_mnemon_hooks(hooks)
+        # CustomEvent is not one of mnemon's three hook events, so the
+        # filter leaves it alone even if the command references mnemon.
+        assert "CustomEvent" in hooks
+
+
+class TestNextStepsBlock:
+    def test_local_claude_code_mentions_upgrade_web(self):
+        out = _next_steps_block("claude-code", None)
+        assert "upgrade web" in out
+        assert "Restart Claude Code" in out
+
+    def test_remote_claude_code_omits_upgrade_suggestion(self):
+        out = _next_steps_block("claude-code", "https://x.fly.dev/mcp")
+        assert "upgrade web" not in out
+        assert "Restart Claude Code" in out
+
+    def test_cursor_targets_cursor_restart(self):
+        out = _next_steps_block("cursor", None)
+        assert "Restart Cursor" in out
+
+
+class TestPreflightRemoteEndpoint:
+    def test_restores_env_vars_on_success(self):
+        os.environ.pop("MNEMON_REMOTE_URL", None)
+        os.environ.pop("MNEMON_LOCAL_TOKEN", None)
+
+        from mnemon.setup import _preflight_remote_endpoint
+
+        with patch("mnemon.hooks._remote_client.call_tool_sync",
+                   return_value=("ok", 0.01)):
+            _preflight_remote_endpoint("https://x.fly.dev/mcp", "tok")
+        # Env vars set during preflight must not leak into the process
+        assert "MNEMON_REMOTE_URL" not in os.environ
+        assert "MNEMON_LOCAL_TOKEN" not in os.environ
+
+    def test_restores_env_vars_on_failure(self):
+        os.environ["MNEMON_REMOTE_URL"] = "https://existing/mcp"
+        os.environ["MNEMON_LOCAL_TOKEN"] = "existing-token"
+        try:
+            from mnemon.setup import _preflight_remote_endpoint
+
+            with patch(
+                "mnemon.hooks._remote_client.call_tool_sync",
+                side_effect=TimeoutError("no response"),
+            ):
+                with pytest.raises(SetupError, match="did not respond"):
+                    _preflight_remote_endpoint(
+                        "https://new.fly.dev/mcp", "new-tok"
+                    )
+            # Prior values must be restored, not overwritten
+            assert os.environ["MNEMON_REMOTE_URL"] == "https://existing/mcp"
+            assert os.environ["MNEMON_LOCAL_TOKEN"] == "existing-token"
+        finally:
+            os.environ.pop("MNEMON_REMOTE_URL", None)
+            os.environ.pop("MNEMON_LOCAL_TOKEN", None)
+
+
+class TestParseSkipDoctor:
+    def test_skip_doctor_flag(self):
+        result = _parse_setup_args(["--skip-doctor"])
+        assert result["skip_doctor"] is True
+
+    def test_skip_doctor_default_false(self):
+        result = _parse_setup_args([])
+        assert result["skip_doctor"] is False
 
     def test_no_hardcoded_fly_url(self):
         """CRITICAL GUARDRAIL: setup must never contain a hardcoded default


### PR DESCRIPTION
## Summary

- **Stops the silent-broken-hooks bug** reported in mnemon memory #109: `mnemon setup claude-code` with no `--remote-url` was installing HTTP-only hooks that errored on every prompt.
- Adds setup-time preflight validation for any remote endpoint before any destructive step.
- Auto-runs `mnemon doctor` at end of every successful setup.
- Prints a "what just happened" next-steps block so local-only users see the path to mobile/web via `mnemon upgrade web` (P1).

## Context

This is P0 from the mnemon simplification plan (`private/mnemon-simplification-plan-260421.md`). P1 — the `mnemon upgrade web` / `mnemon downgrade local` symmetric commands and in-process hook client — lands in a follow-up PR. See the plan for full scope.

## Changes

### `setup_claude_code` behavior matrix
| Invocation | Before | After |
|---|---|---|
| No `--remote-url` | stdio MCP + **broken hooks** | stdio MCP only (hooks skipped, explicit message) |
| `--remote-url <URL>` | hooks written without validation | **Preflight required** via `memory_status` round-trip; aborts cleanly on failure |
| Re-run locally after prior remote install | stale mnemon hooks kept firing | `_strip_mnemon_hooks()` removes them |

### `setup_hooks` hard-fails without `--remote-url`
Hook code path is HTTP-only; there is no "local hooks" mode to fall back to. Raise `SetupError` instead of writing broken config.

### `run_setup` wires doctor + summary
- Runs `mnemon.doctor.run_doctor()` after success; appends output to the return value. Failing doctor run surfaces a loud NOTE but does not raise.
- `--skip-doctor` bypass for CI.
- `_next_steps_block()` footer mentions `mnemon upgrade web` for local-only users.
- `SetupError` becomes a user-facing `setup failed: <reason>` string, not a traceback.

### Preflight env-var hygiene
`_preflight_remote_endpoint()` saves and restores `MNEMON_REMOTE_URL` / `MNEMON_LOCAL_TOKEN` so a running session's prior config is not clobbered.

## Test plan

- [x] 43 setup tests (up from 27), covering: hook-skip path, stale-hook stripping, preflight-abort state hygiene, doctor invocation, `--skip-doctor`, `SetupError` surfacing, env-var restoration on success and failure
- [x] Full suite: **502 tests pass** (4 integration tests require local network bind, pass outside sandbox)
- [ ] Manual: fresh `mnemon setup claude-code` on this machine, verify no hooks written, verify doctor runs
- [ ] Manual: `mnemon setup claude-code --remote-url <bad-url>` verifies preflight aborts with no config left behind
- [ ] Manual: `mnemon setup claude-code --remote-url <good-url>` verifies full happy path + doctor green

## Out of scope (P1, follow-up PR)

- `mnemon upgrade web` / `mnemon downgrade local` symmetric commands
- In-process hook client (new `src/mnemon/api.py` + `hooks/_client.py`)
- Auto-detect-all-clients default for `mnemon setup`
- `mnemon config set/get/unset/list` CLI
- `memory_status` `deployment` field
- `mnemon doctor --fail-on-warn`
- Layer 1/2/3 test infrastructure for upgrade/downgrade

Full plan: `private/mnemon-simplification-plan-260421.md`.
E2E test runbook: `private/e2e-test-runbook-260421.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)