### PR TITLE
feat(setup): auto-detect clients + local-mode hooks + --fail-on-warn (P1b)

### DIFF
--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -143,16 +143,23 @@ def main() -> None:
             sys.exit(1)
 
     elif command == "setup":
-        target = args[1] if len(args) > 1 else ""
-        if not target:
-            print("Usage: mnemon setup <claude-code|cursor|gemini|hooks> [--remote-url URL] [--token TOKEN]", file=sys.stderr)
-            sys.exit(1)
+        # `mnemon setup` with no target auto-detects every installed
+        # client and configures each. Explicit target names
+        # (claude-code, claude-desktop, cursor, gemini, hooks) still
+        # work for narrow use cases.
         from .setup import run_setup
-        print(run_setup(target, args[2:]))
+        if len(args) > 1 and not args[1].startswith("--"):
+            target: str | None = args[1]
+            setup_args = args[2:]
+        else:
+            target = None
+            setup_args = args[1:]
+        print(run_setup(target, setup_args))
 
     elif command == "doctor":
         from .doctor import run_doctor
-        sys.exit(run_doctor())
+        fail_on_warn = "--fail-on-warn" in args[1:]
+        sys.exit(run_doctor(fail_on_warn=fail_on_warn))
 
     else:
         print(f"Unknown command: {command}", file=sys.stderr)
@@ -163,9 +170,13 @@ def main() -> None:
 def _print_usage() -> None:
     print(f"""mnemon v{__version__} — Universal long-term memory for AI agents
 
-Setup (configure clients to use remote vault):
-  mnemon setup <target>     Configure integration [--remote-url URL] [--token TOKEN]
-  mnemon doctor             Run diagnostics against the configured remote vault
+Setup (configure MCP clients; use --remote-url for web mode):
+  mnemon setup              Auto-detect installed clients and configure each
+  mnemon setup <target>     Configure one client explicitly
+                            (claude-code | claude-desktop | cursor | gemini | hooks)
+                            [--remote-url URL] [--token TOKEN] [--skip-doctor]
+  mnemon doctor             Run diagnostics (local or remote, auto-detected)
+                            [--fail-on-warn] treat warnings as failures
 
 Server:
   mnemon serve              Start MCP server (stdio, local development)

--- a/src/mnemon/doctor.py
+++ b/src/mnemon/doctor.py
@@ -545,12 +545,25 @@ def _has_remote_config() -> bool:
     return False
 
 
-def run_doctor(out=sys.stdout) -> int:
+def run_doctor(out=sys.stdout, *, fail_on_warn: bool = False) -> int:
     """Run all checks, print results, return exit code (0 = all pass).
 
     Auto-detects remote vs. local mode from config. Prints a one-line
     banner so the user knows which flavor ran; everything else is
     format-identical across modes.
+
+    Parameters
+    ----------
+    out:
+        File-like object for the human-readable report.
+    fail_on_warn:
+        When True (default False), warnings are treated as failures and
+        the exit code is 1 if any check emits a warning. Used by
+        ``run_setup`` / ``mnemon upgrade web`` / ``mnemon downgrade
+        local`` so scripted installs don't silently succeed in a
+        partially-broken state. Consistent with the "hard-fail until
+        stabilized" preference captured in the simplification plan
+        (``private/mnemon-simplification-plan-260421.md``).
     """
     if _has_remote_config():
         mode_label = "remote"
@@ -591,6 +604,13 @@ def run_doctor(out=sys.stdout) -> int:
         )
         return 1
     if warned:
+        if fail_on_warn:
+            print(
+                f"{FAIL} {len(warned)}/{len(results)} checks emitted "
+                f"warnings (--fail-on-warn treats these as failures).",
+                file=out,
+            )
+            return 1
         print(
             f"{WARN} All checks passed with {len(warned)} warning(s).",
             file=out,

--- a/src/mnemon/setup.py
+++ b/src/mnemon/setup.py
@@ -302,11 +302,13 @@ def setup_claude_code(*, remote_url: str | None = None, token: str | None = None
 
     When ``remote_url`` is not provided:
       - Register a local stdio MCP server in ``settings.json``.
-      - **Hooks are NOT installed** — the hook code path is HTTP-only
-        (``hooks/_remote_client.py``) and has no local fallback. Writing
-        them against stdio would produce silent config errors on every
-        prompt. Users who want hooks should run ``mnemon upgrade web``
-        (forthcoming) or pass ``--remote-url``.
+      - Install UserPromptSubmit / Stop hooks (no SessionStart — no
+        remote machine to pre-warm). Hooks dispatch in-process via
+        :class:`~mnemon.hooks._client.LocalMemoryClient` (added in P1a).
+
+    Note: P1a removed the constraint that hooks require HTTP. P0 skipped
+    hooks in local mode because the client path was HTTP-only; that's
+    been fixed.
     """
     settings_path = Path.home() / ".claude" / "settings.json"
     settings = _read_json(settings_path)
@@ -330,34 +332,44 @@ def setup_claude_code(*, remote_url: str | None = None, token: str | None = None
             if not mcp_servers:
                 del settings["mcpServers"]
             lines.append("  Cleaned up stale settings.json mcpServers.mnemon entry")
-
-        hooks = _hooks_config(remote_url=remote_url)
-        if "hooks" not in settings:
-            settings["hooks"] = {}
-        settings["hooks"]["UserPromptSubmit"] = hooks["UserPromptSubmit"]
-        settings["hooks"]["Stop"] = hooks["Stop"]
-        settings["hooks"]["SessionStart"] = hooks["SessionStart"]
-        lines.append("  UserPromptSubmit: context-surfacing (8s)")
-        lines.append("  Stop: session-extractor (30s), handoff-generator (30s)")
-        lines.append("  SessionStart: pre-warm polling (90s background)")
     else:
         if "mcpServers" not in settings:
             settings["mcpServers"] = {}
         settings["mcpServers"]["mnemon"] = _mcp_config()
         lines.append("  MCP server: mnemon (stdio, local)")
-        # Strip any previously-installed mnemon hooks so old configs on
-        # a machine being downgraded don't keep erroring.
-        existing_hooks = settings.get("hooks")
-        if isinstance(existing_hooks, dict):
-            _strip_mnemon_hooks(existing_hooks)
-            if not existing_hooks:
-                del settings["hooks"]
-        lines.append("  Hooks:      skipped (local-only setup)")
-        lines.append(
-            "              Hooks require a remote vault. Run "
-            "`mnemon setup claude-code --remote-url <URL>` or "
-            "`mnemon upgrade web` to enable them."
-        )
+
+    # Hooks: install in both modes. _hooks_config adds SessionStart only
+    # when remote_url is supplied (local mode has no cold-start to warm).
+    hooks = _hooks_config(remote_url=remote_url)
+    if "hooks" not in settings:
+        settings["hooks"] = {}
+    settings["hooks"]["UserPromptSubmit"] = hooks["UserPromptSubmit"]
+    settings["hooks"]["Stop"] = hooks["Stop"]
+    if "SessionStart" in hooks:
+        settings["hooks"]["SessionStart"] = hooks["SessionStart"]
+    else:
+        # Drop any stale SessionStart (set by a previous remote install);
+        # it would poll a remote URL that's no longer authoritative.
+        stale_session = settings["hooks"].get("SessionStart")
+        if isinstance(stale_session, list):
+            filtered = [
+                entry
+                for entry in stale_session
+                if not any(
+                    "mnemon" in (h.get("command") or "")
+                    for h in entry.get("hooks", [])
+                )
+            ]
+            if filtered:
+                settings["hooks"]["SessionStart"] = filtered
+            else:
+                del settings["hooks"]["SessionStart"]
+
+    hook_mode_tag = "remote" if remote_url else "local (in-process)"
+    lines.append(f"  UserPromptSubmit: context-surfacing (8s, {hook_mode_tag})")
+    lines.append(f"  Stop: session-extractor (30s), handoff-generator (30s) [{hook_mode_tag}]")
+    if remote_url:
+        lines.append("  SessionStart: pre-warm polling (90s background)")
 
     _write_json(settings_path, settings)
 
@@ -404,8 +416,85 @@ def setup_cursor(*, remote_url: str | None = None, token: str | None = None) -> 
     )
 
 
+def _claude_desktop_config_path() -> Path:
+    """Resolve the Claude Desktop MCP config path for this platform.
+
+    - macOS: ``~/Library/Application Support/Claude/claude_desktop_config.json``
+    - Windows: ``%APPDATA%\\Claude\\claude_desktop_config.json``
+    - Linux: ``~/.config/Claude/claude_desktop_config.json`` (Claude
+      Desktop is not officially supported on Linux but users who build
+      from source put the config here).
+    """
+    if sys.platform == "darwin":
+        return (
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / "Claude"
+            / "claude_desktop_config.json"
+        )
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            return Path(appdata) / "Claude" / "claude_desktop_config.json"
+        # Fallback if APPDATA is unset for any reason.
+        return (
+            Path.home()
+            / "AppData"
+            / "Roaming"
+            / "Claude"
+            / "claude_desktop_config.json"
+        )
+    return Path.home() / ".config" / "Claude" / "claude_desktop_config.json"
+
+
+def setup_claude_desktop(
+    *, remote_url: str | None = None, token: str | None = None
+) -> str:
+    """Configure Claude Desktop's MCP server.
+
+    Claude Desktop has no hook system — this only writes the MCP entry.
+    Config format mirrors Cursor's ``mcp.json``. When ``remote_url`` is
+    provided, writes an HTTP transport with bearer auth and preflights
+    the endpoint; otherwise writes a local stdio entry.
+    """
+    desktop_path = _claude_desktop_config_path()
+    config = _read_json(desktop_path)
+
+    if "mcpServers" not in config:
+        config["mcpServers"] = {}
+
+    if remote_url:
+        local_token = _ensure_local_token(token)
+        _preflight_remote_endpoint(remote_url, local_token)
+        _ensure_remote_url(remote_url)
+        config["mcpServers"]["mnemon"] = {
+            "url": remote_url,
+            "headers": {"Authorization": f"Bearer {local_token}"},
+        }
+        mode = "remote (preflight OK)"
+    else:
+        config["mcpServers"]["mnemon"] = _mcp_config()
+        mode = "stdio (local)"
+
+    _write_json(desktop_path, config)
+
+    return (
+        f"Claude Desktop MCP configured at {desktop_path}\n"
+        f"  Mode: {mode}\n"
+        "Restart Claude Desktop to activate."
+    )
+
+
 def setup_gemini() -> str:
-    """Show Gemini CLI MCP configuration."""
+    """Show Gemini CLI MCP configuration.
+
+    Gemini CLI config format is installation-specific and the CLI doesn't
+    commit to a single canonical path (varies across distributions and
+    user customizations), so we print the snippet for the user to paste
+    rather than auto-write. Keeps us out of the "accidentally wrote to
+    the wrong file" category.
+    """
     config = json.dumps({"mnemon": _mcp_config()}, indent=2)
     return (
         "Add this to your Gemini CLI MCP config:\n\n"
@@ -416,54 +505,84 @@ def setup_gemini() -> str:
 def setup_hooks(*, remote_url: str | None = None, token: str | None = None) -> str:
     """Configure Claude Code hooks only (no MCP server).
 
-    Hooks require a reachable remote vault — the hook code path speaks
-    HTTP exclusively. Calling this without ``--remote-url`` raises
-    :class:`SetupError` rather than writing broken config.
+    Works in both modes after P1a: local hooks dispatch in-process via
+    :class:`~mnemon.hooks._client.LocalMemoryClient`; remote hooks go
+    over HTTP. When ``remote_url`` is supplied, the endpoint is
+    preflighted and a SessionStart pre-warm hook is added.
     """
-    if not remote_url:
-        raise SetupError(
-            "`mnemon setup hooks` requires --remote-url. The hook code "
-            "path is HTTP-only; without a remote endpoint hooks would "
-            "emit a config error on every Claude Code prompt. Use "
-            "`mnemon setup claude-code` for a local-only (MCP-only) "
-            "install, or pass --remote-url to enable hooks."
-        )
-
     settings_path = Path.home() / ".claude" / "settings.json"
     settings = _read_json(settings_path)
 
-    local_token = _ensure_local_token(token)
-    _preflight_remote_endpoint(remote_url, local_token)
-    _ensure_remote_url(remote_url)
+    if remote_url:
+        local_token = _ensure_local_token(token)
+        _preflight_remote_endpoint(remote_url, local_token)
+        _ensure_remote_url(remote_url)
 
     hooks = _hooks_config(remote_url=remote_url)
     if "hooks" not in settings:
         settings["hooks"] = {}
     settings["hooks"]["UserPromptSubmit"] = hooks["UserPromptSubmit"]
     settings["hooks"]["Stop"] = hooks["Stop"]
-    settings["hooks"]["SessionStart"] = hooks["SessionStart"]
+    if "SessionStart" in hooks:
+        settings["hooks"]["SessionStart"] = hooks["SessionStart"]
 
     _write_json(settings_path, settings)
 
-    return "\n".join(
-        [
-            f"Hooks configured at {settings_path}",
+    mode_tag = "remote" if remote_url else "local (in-process)"
+    out_lines = [
+        f"Hooks configured at {settings_path}",
+        f"  Mode: {mode_tag}",
+    ]
+    if remote_url:
+        out_lines += [
             f"  Remote URL: {remote_url}",
             f"  Preflight:  OK (memory_status round-trip < {REMOTE_PREFLIGHT_TIMEOUT_SEC:.0f}s)",
-            "  UserPromptSubmit: context-surfacing (8s)",
-            "  Stop: session-extractor (30s), handoff-generator (30s)",
-            "  SessionStart: pre-warm polling (90s background)",
-            "Restart Claude Code to activate.",
         ]
-    )
+    out_lines += [
+        "  UserPromptSubmit: context-surfacing (8s)",
+        "  Stop: session-extractor (30s), handoff-generator (30s)",
+    ]
+    if remote_url:
+        out_lines.append("  SessionStart: pre-warm polling (90s background)")
+    out_lines.append("Restart Claude Code to activate.")
+    return "\n".join(out_lines)
 
 
 TARGETS = {
     "claude-code": setup_claude_code,
+    "claude-desktop": setup_claude_desktop,
     "cursor": setup_cursor,
     "gemini": setup_gemini,
     "hooks": setup_hooks,
 }
+
+
+# Auto-detect probes — a target is considered "installed" if its config
+# directory exists. Probes are lightweight filesystem checks; they do not
+# write anything. ``hooks`` is a pseudo-target (hooks-only install); it
+# is intentionally excluded from auto-detect since every auto-detected
+# ``claude-code`` install already handles hooks.
+_AUTODETECT_ORDER = ["claude-code", "claude-desktop", "cursor"]
+
+
+def _is_installed(target: str) -> bool:
+    """True if the machine appears to have the given MCP client installed."""
+    if target == "claude-code":
+        return (Path.home() / ".claude").is_dir()
+    if target == "claude-desktop":
+        return _claude_desktop_config_path().parent.is_dir()
+    if target == "cursor":
+        return (Path.home() / ".cursor").is_dir()
+    # Gemini and hooks have no reliable detection signal.
+    return False
+
+
+def detect_installed_clients() -> list[str]:
+    """Return the subset of auto-detect targets whose config dir exists.
+
+    Order is stable (``_AUTODETECT_ORDER``) so output is deterministic.
+    """
+    return [t for t in _AUTODETECT_ORDER if _is_installed(t)]
 
 
 def _parse_setup_args(args: list[str]) -> dict:
@@ -509,26 +628,18 @@ def _next_steps_block(target: str, remote_url: str | None) -> str:
     return "\n".join(lines)
 
 
-def run_setup(target: str, args: list[str] | None = None) -> str:
-    """Run setup for the given target, auto-run doctor, return status.
+def _run_single_target(
+    target: str, parsed: dict, *, include_footer: bool = True
+) -> str:
+    """Invoke one setup target and return its user-facing message.
 
-    After a successful setup, ``mnemon doctor`` runs against the
-    newly-configured vault (local or remote, auto-detected). A failing
-    doctor run is surfaced in the returned message but does not raise —
-    the setup itself already succeeded, and the doctor output is what
-    the user needs to read to act on the gap.
-
-    Pass ``--skip-doctor`` in ``args`` to suppress the automatic run
-    (useful for CI or scripted setups where the caller runs doctor
-    separately).
+    Shared by :func:`run_setup` (single-target) and
+    :func:`_run_autodetect` (one entry per detected client). When
+    ``include_footer`` is False, the "Next steps" block is omitted so
+    the caller can print a single aggregate footer instead of one per
+    target.
     """
-    if target not in TARGETS:
-        valid = ", ".join(TARGETS.keys())
-        return f"Unknown target: {target}\nValid targets: {valid}"
-
-    parsed = _parse_setup_args(args or [])
     func = TARGETS[target]
-
     try:
         if target == "gemini":
             primary = func()
@@ -537,15 +648,98 @@ def run_setup(target: str, args: list[str] | None = None) -> str:
                 remote_url=parsed["remote_url"], token=parsed["token"]
             )
     except SetupError as exc:
-        return f"setup failed: {exc}"
+        return f"setup failed ({target}): {exc}"
 
-    footer = _next_steps_block(target, parsed["remote_url"])
+    if include_footer:
+        primary += _next_steps_block(target, parsed["remote_url"])
+    return primary
 
+
+def _run_autodetect(parsed: dict) -> str:
+    """Configure every detected client, emit an aggregate summary.
+
+    Gemini is tacked onto the end as a manual-step reminder — we print
+    the snippet but don't pretend to have configured it. If no clients
+    are detected, returns a clear message pointing at `--help`.
+    """
+    detected = detect_installed_clients()
+    if not detected:
+        return (
+            "No MCP clients detected on this machine.\n"
+            "Checked: ~/.claude (Claude Code), ~/.cursor (Cursor), "
+            "Claude Desktop config dir.\n"
+            "Install one of those, or run `mnemon setup <target>` "
+            "explicitly (see `mnemon setup --help`)."
+        )
+
+    blocks: list[str] = [
+        f"Detected MCP clients: {', '.join(detected)}",
+        "",
+    ]
+    for target in detected:
+        blocks.append(f"── {target} ──")
+        blocks.append(_run_single_target(target, parsed, include_footer=False))
+        blocks.append("")
+
+    # Gemini tail: print snippet as a manual step reminder.
+    blocks.append("── gemini (manual) ──")
+    blocks.append(setup_gemini())
+
+    # Single footer for the aggregate.
+    remote_url = parsed["remote_url"]
+    blocks.append("")
+    blocks.append("Next steps:")
+    blocks.append("  • Restart each client above to activate the MCP tools.")
+    if remote_url is None:
+        blocks.append(
+            "  • Want mobile / claude.ai / cross-device memory? "
+            "Run `mnemon upgrade web` (coming soon) or rerun with "
+            "--remote-url <URL>."
+        )
+    blocks.append("  • Run `mnemon doctor` any time to re-verify the setup.")
+
+    return "\n".join(blocks)
+
+
+def run_setup(target: str | None, args: list[str] | None = None) -> str:
+    """Run setup for the given target (or auto-detect when ``target`` is None).
+
+    Behavior matrix:
+
+    - ``target=None`` → configure every detected client (auto-detect).
+      Matches the documented happy-path ``mnemon setup`` invocation.
+    - ``target="claude-code" | "cursor" | "claude-desktop" | "hooks"``
+      → configure just that client.
+    - ``target="gemini"`` → print the config snippet; never auto-writes.
+
+    After a successful setup, ``mnemon doctor`` runs against the
+    newly-configured vault with ``fail_on_warn=True`` (per the P1b plan —
+    any config gap should surface as a non-zero exit so scripted installs
+    propagate the failure). Pass ``--skip-doctor`` in ``args`` to
+    suppress the automatic run.
+    """
+    parsed = _parse_setup_args(args or [])
+
+    if target is None:
+        primary = _run_autodetect(parsed)
+        # Auto-detect block already has its own footer; doctor still runs.
+        footer = ""
+    elif target in TARGETS:
+        primary = _run_single_target(target, parsed)
+        if primary.startswith("setup failed"):
+            return primary
+        footer = ""  # _run_single_target already appended the next-steps block
+    else:
+        valid = ", ".join(TARGETS.keys())
+        return f"Unknown target: {target}\nValid targets: {valid}"
+
+    if primary.startswith("setup failed"):
+        return primary
+
+    # Doctor doesn't make sense for "gemini-only" or pure print targets.
     if parsed["skip_doctor"] or target == "gemini":
         return primary + footer
 
-    # Capture doctor output so setup returns a single cohesive string
-    # (tests + CLI wrapper both consume this as one blob).
     import io
 
     from .doctor import run_doctor
@@ -554,7 +748,7 @@ def run_setup(target: str, args: list[str] | None = None) -> str:
     print("", file=buf)
     print("Running mnemon doctor to verify...", file=buf)
     try:
-        doctor_rc = run_doctor(out=buf)
+        doctor_rc = run_doctor(out=buf, fail_on_warn=True)
     except Exception as exc:  # noqa: BLE001
         buf.write(
             f"\n(doctor invocation crashed: {type(exc).__name__}: {exc})\n"
@@ -563,9 +757,11 @@ def run_setup(target: str, args: list[str] | None = None) -> str:
 
     if doctor_rc != 0:
         buf.write(
-            "\nNOTE: doctor reported issues. Setup files were written, "
-            "but the environment is not fully ready — fix the failing "
-            "check(s) above before using mnemon.\n"
+            "\nNOTE: doctor reported issues (including warnings, which "
+            "are now treated as failures). Setup files were written, but "
+            "the environment is not fully ready — fix the failing "
+            "check(s) above before using mnemon, or rerun with "
+            "--skip-doctor to bypass.\n"
         )
 
     return primary + footer + "\n" + buf.getvalue()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -347,13 +347,52 @@ class TestSetup:
         out = capsys.readouterr().out
         assert "Configured claude-code successfully." in out
 
-    def test_setup_without_target_exits(self, capsys):
+    @patch("mnemon.setup.run_setup")
+    def test_setup_without_target_invokes_autodetect(
+        self, mock_run, capsys
+    ):
+        """P1b: `mnemon setup` with no target auto-detects clients
+        instead of printing usage and exiting. CLI passes ``None`` for
+        target when no positional arg is given (only flags, or nothing)."""
+        mock_run.return_value = "auto-detect output"
         with patch("sys.argv", ["mnemon", "setup"]):
+            main()
+        mock_run.assert_called_once_with(None, [])
+        assert "auto-detect output" in capsys.readouterr().out
+
+    @patch("mnemon.setup.run_setup")
+    def test_setup_with_only_flags_is_autodetect(self, mock_run, capsys):
+        """Flags like --remote-url without a target should still be
+        treated as auto-detect, not as a target name."""
+        mock_run.return_value = "ok"
+        with patch(
+            "sys.argv",
+            ["mnemon", "setup", "--remote-url", "https://x/mcp", "--skip-doctor"],
+        ):
+            main()
+        mock_run.assert_called_once_with(
+            None, ["--remote-url", "https://x/mcp", "--skip-doctor"]
+        )
+
+
+class TestDoctorCli:
+    @patch("mnemon.doctor.run_doctor")
+    def test_default_invocation_does_not_fail_on_warn(self, mock_doctor):
+        mock_doctor.return_value = 0
+        with patch("sys.argv", ["mnemon", "doctor"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 0
+        mock_doctor.assert_called_once_with(fail_on_warn=False)
+
+    @patch("mnemon.doctor.run_doctor")
+    def test_fail_on_warn_flag_propagates(self, mock_doctor):
+        mock_doctor.return_value = 1
+        with patch("sys.argv", ["mnemon", "doctor", "--fail-on-warn"]):
             with pytest.raises(SystemExit) as exc_info:
                 main()
         assert exc_info.value.code == 1
-        err = capsys.readouterr().err
-        assert "Usage: mnemon setup" in err
+        mock_doctor.assert_called_once_with(fail_on_warn=True)
 
 
 class TestUnknownCommand:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -430,6 +430,31 @@ class TestRunDoctor:
         output = buf.getvalue()
         assert "1 warning" in output
 
+    def test_fail_on_warn_promotes_warning_to_failure(self):
+        """P1b: setup/upgrade/downgrade invoke doctor with fail_on_warn=True
+        so warning-only runs propagate as non-zero exits. Matches the
+        "hard-fail until stabilized" preference."""
+        fake_checks = [
+            lambda: doctor.CheckResult("A", True, "ok"),
+            lambda: doctor.CheckResult("B", True, "heads-up", warn=True),
+        ]
+        buf = io.StringIO()
+        with patch("mnemon.doctor._has_remote_config", return_value=True), \
+             patch("mnemon.doctor.get_remote_url", return_value="https://x/mcp"), \
+             patch("mnemon.doctor.REMOTE_CHECKS", fake_checks):
+            code = doctor.run_doctor(out=buf, fail_on_warn=True)
+        assert code == 1
+        assert "--fail-on-warn" in buf.getvalue()
+
+    def test_fail_on_warn_all_clean_still_passes(self):
+        fake_checks = [lambda: doctor.CheckResult("A", True, "ok")]
+        buf = io.StringIO()
+        with patch("mnemon.doctor._has_remote_config", return_value=True), \
+             patch("mnemon.doctor.get_remote_url", return_value="https://x/mcp"), \
+             patch("mnemon.doctor.REMOTE_CHECKS", fake_checks):
+            code = doctor.run_doctor(out=buf, fail_on_warn=True)
+        assert code == 0
+
 
 class TestRunDoctorLocalMode:
     """Without any remote config, ``run_doctor`` should run LOCAL_CHECKS

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -109,13 +109,12 @@ class TestParseSetupArgs:
 
 
 class TestSetupClaudeCode:
-    def test_creates_settings_file_local_mode_without_hooks(self):
-        """P0 (mnemon #109): local-only setup must NOT install hooks.
-
-        Hooks are HTTP-only (hooks/_remote_client.py has no local
-        fallback). Installing them with only a stdio MCP server produced
-        silent ``RemoteClientConfigError`` banners on every prompt.
-        """
+    def test_creates_settings_file_local_mode_installs_local_hooks(self):
+        """P1b: local-mode setup installs UserPromptSubmit + Stop hooks
+        that dispatch via :class:`LocalMemoryClient`. P0 skipped them
+        because the hook client was HTTP-only; P1a fixed that.
+        SessionStart is intentionally omitted in local mode — no remote
+        machine to pre-warm."""
         with tempfile.TemporaryDirectory() as tmpdir:
             settings_path = Path(tmpdir) / ".claude" / "settings.json"
             with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)):
@@ -124,31 +123,27 @@ class TestSetupClaudeCode:
             assert settings_path.exists()
             settings = json.loads(settings_path.read_text())
             assert "mnemon" in settings["mcpServers"]
-            assert "hooks" not in settings, (
-                "local-only setup must not write hook entries"
-            )
-            assert "Hooks" in result and "skipped" in result
+            assert "UserPromptSubmit" in settings["hooks"]
+            assert "Stop" in settings["hooks"]
+            assert "SessionStart" not in settings["hooks"]
+            assert "local (in-process)" in result
             assert "Restart" in result
 
-    def test_local_mode_strips_stale_mnemon_hooks(self):
-        """Re-running setup locally after a prior remote install should
-        clean up old mnemon hook entries so they stop erroring."""
+    def test_local_mode_drops_stale_session_start(self):
+        """Re-running setup in local mode after a prior remote install
+        must strip the mnemon SessionStart pre-warm hook (it polls a
+        remote URL that's no longer authoritative). UserPromptSubmit /
+        Stop are overwritten with the local variants; SessionStart is
+        removed entirely."""
         with tempfile.TemporaryDirectory() as tmpdir:
             settings_path = Path(tmpdir) / ".claude" / "settings.json"
             settings_path.parent.mkdir(parents=True)
             settings_path.write_text(json.dumps({
                 "hooks": {
-                    "UserPromptSubmit": [
+                    "SessionStart": [
                         {"matcher": "", "hooks": [
                             {"type": "command",
-                             "command": "python -m mnemon.hooks.context_surfacing"},
-                        ]},
-                    ],
-                    "Stop": [
-                        {"matcher": "", "hooks": [
-                            {"type": "command",
-                             "command": "python -m mnemon.hooks.session_extractor"},
-                            {"type": "command", "command": "other-thing"},
+                             "command": "curl mnemon.fly.dev/health"},
                         ]},
                     ],
                 },
@@ -157,11 +152,10 @@ class TestSetupClaudeCode:
                 setup_claude_code()
             settings = json.loads(settings_path.read_text())
             hooks = settings.get("hooks", {})
-            assert "UserPromptSubmit" not in hooks
-            # Non-mnemon entries survive
-            stop = hooks.get("Stop", [])
-            assert len(stop) == 1
-            assert stop[0]["hooks"][0]["command"] == "other-thing"
+            assert "SessionStart" not in hooks
+            # Local UserPromptSubmit + Stop were installed
+            assert "UserPromptSubmit" in hooks
+            assert "Stop" in hooks
 
     def test_remote_mode_registers_via_claude_cli_and_cleans_stale_entry(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -319,15 +313,20 @@ class TestSetupGemini:
 
 
 class TestSetupHooks:
-    def test_refuses_without_remote_url(self):
-        """P0 (mnemon #109): setup_hooks without --remote-url must raise.
-
-        The hook code path is HTTP-only; writing hook entries without a
-        configured remote endpoint guarantees a config error on every
-        prompt. Better to refuse loudly than to ship the broken config.
-        """
-        with pytest.raises(SetupError, match="requires --remote-url"):
-            setup_hooks()
+    def test_installs_local_hooks_without_remote_url(self):
+        """P1b: setup_hooks works in local mode now that LocalMemoryClient
+        exists. UserPromptSubmit + Stop are written; SessionStart is
+        skipped (only meaningful for remote cold-start)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_path = Path(tmpdir) / ".claude" / "settings.json"
+            with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)):
+                out = setup_hooks()
+            assert settings_path.exists()
+            settings = json.loads(settings_path.read_text())
+            assert "UserPromptSubmit" in settings["hooks"]
+            assert "Stop" in settings["hooks"]
+            assert "SessionStart" not in settings["hooks"]
+            assert "local (in-process)" in out
 
     def test_writes_hooks_with_session_start_when_remote(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -365,7 +364,13 @@ class TestRunSetup:
         assert "Unknown target" in result
 
     def test_all_targets_registered(self):
-        assert set(TARGETS.keys()) == {"claude-code", "cursor", "gemini", "hooks"}
+        assert set(TARGETS.keys()) == {
+            "claude-code",
+            "claude-desktop",
+            "cursor",
+            "gemini",
+            "hooks",
+        }
 
     def test_passes_remote_url_from_args(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -438,7 +443,8 @@ class TestRunSetup:
                     "claude-code",
                     ["--remote-url", "https://x.fly.dev/mcp", "--skip-doctor"],
                 )
-        assert result.startswith("setup failed:")
+        # Per-target prefix disambiguates in auto-detect mode.
+        assert result.startswith("setup failed (claude-code):")
         assert "cold fly machine" in result
 
     def test_doctor_failure_appends_note_but_does_not_raise(self):
@@ -542,6 +548,148 @@ class TestPreflightRemoteEndpoint:
         finally:
             os.environ.pop("MNEMON_REMOTE_URL", None)
             os.environ.pop("MNEMON_LOCAL_TOKEN", None)
+
+
+class TestSetupClaudeDesktop:
+    def test_writes_platform_config_local_mode(self, tmp_path, monkeypatch):
+        """Claude Desktop has no hook system — only MCP is written."""
+        from mnemon.setup import setup_claude_desktop
+
+        # Force the darwin path so the test is platform-deterministic.
+        monkeypatch.setattr("mnemon.setup.sys.platform", "darwin")
+        monkeypatch.setattr("mnemon.setup.Path.home", lambda: tmp_path)
+
+        out = setup_claude_desktop()
+        expected = (
+            tmp_path
+            / "Library"
+            / "Application Support"
+            / "Claude"
+            / "claude_desktop_config.json"
+        )
+        assert expected.exists()
+        config = json.loads(expected.read_text())
+        assert "mnemon" in config["mcpServers"]
+        # Hooks are not Claude Desktop's concern
+        assert "hooks" not in config
+        assert "Mode: stdio (local)" in out
+
+    def test_remote_mode_writes_http_transport(self, tmp_path, monkeypatch):
+        from mnemon.setup import setup_claude_desktop
+
+        monkeypatch.setattr("mnemon.setup.sys.platform", "darwin")
+        monkeypatch.setattr("mnemon.setup.Path.home", lambda: tmp_path)
+        mnemon_dir = tmp_path / ".mnemon"
+        monkeypatch.setattr("mnemon.setup.MNEMON_DIR", mnemon_dir)
+        monkeypatch.setattr(
+            "mnemon.setup.LOCAL_TOKEN_FILE", mnemon_dir / "local_token"
+        )
+        monkeypatch.setattr(
+            "mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"
+        )
+        with patch("mnemon.setup._preflight_remote_endpoint"):
+            setup_claude_desktop(
+                remote_url="https://x.fly.dev/mcp", token="tok-123"
+            )
+
+        expected = (
+            tmp_path
+            / "Library"
+            / "Application Support"
+            / "Claude"
+            / "claude_desktop_config.json"
+        )
+        config = json.loads(expected.read_text())
+        entry = config["mcpServers"]["mnemon"]
+        assert entry["url"] == "https://x.fly.dev/mcp"
+        assert entry["headers"]["Authorization"] == "Bearer tok-123"
+
+
+class TestDetectInstalledClients:
+    def test_detects_claude_code_only(self, tmp_path, monkeypatch):
+        from mnemon.setup import detect_installed_clients
+
+        monkeypatch.setattr("mnemon.setup.Path.home", lambda: tmp_path)
+        # Force Linux so Claude Desktop probe looks under ~/.config/Claude/
+        monkeypatch.setattr("mnemon.setup.sys.platform", "linux")
+        (tmp_path / ".claude").mkdir()
+        detected = detect_installed_clients()
+        assert detected == ["claude-code"]
+
+    def test_detects_multiple(self, tmp_path, monkeypatch):
+        from mnemon.setup import detect_installed_clients
+
+        monkeypatch.setattr("mnemon.setup.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("mnemon.setup.sys.platform", "linux")
+        (tmp_path / ".claude").mkdir()
+        (tmp_path / ".cursor").mkdir()
+        detected = detect_installed_clients()
+        assert "claude-code" in detected
+        assert "cursor" in detected
+        # Stable order per _AUTODETECT_ORDER
+        assert detected == ["claude-code", "cursor"]
+
+    def test_detects_nothing_when_no_client_dirs(self, tmp_path, monkeypatch):
+        from mnemon.setup import detect_installed_clients
+
+        monkeypatch.setattr("mnemon.setup.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("mnemon.setup.sys.platform", "linux")
+        assert detect_installed_clients() == []
+
+
+class TestRunSetupAutodetect:
+    def test_no_target_no_clients_returns_helpful_message(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr("mnemon.setup.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("mnemon.setup.sys.platform", "linux")
+        out = run_setup(None, ["--skip-doctor"])
+        assert "No MCP clients detected" in out
+        assert "mnemon setup <target>" in out
+
+    def test_no_target_configures_detected_clients(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr("mnemon.setup.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("mnemon.setup.sys.platform", "linux")
+        (tmp_path / ".claude").mkdir()
+        (tmp_path / ".cursor").mkdir()
+        out = run_setup(None, ["--skip-doctor"])
+        assert "Detected MCP clients: claude-code, cursor" in out
+        # Each detected target produced its own block
+        assert "── claude-code ──" in out
+        assert "── cursor ──" in out
+        # Gemini tail is always printed as a manual-step reminder
+        assert "── gemini (manual) ──" in out
+        # Aggregate footer (singular "Next steps:"), not per-target
+        assert out.count("Next steps:") == 1
+        # And the real files were written
+        assert (tmp_path / ".claude" / "settings.json").exists()
+        assert (tmp_path / ".cursor" / "mcp.json").exists()
+
+
+class TestFailOnWarnPropagation:
+    def test_setup_surfaces_doctor_warning_as_failure(
+        self, tmp_path, monkeypatch
+    ):
+        """With fail_on_warn plumbed through, a warning-only doctor run
+        after setup appends the "doctor reported issues" NOTE so users
+        don't ignore it."""
+        monkeypatch.setattr("mnemon.setup.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("mnemon.setup.sys.platform", "linux")
+
+        def _warning_doctor(out, *, fail_on_warn=False, **_):
+            # Simulate a doctor run that warns but doesn't fail. With
+            # fail_on_warn=True, run_doctor returns 1 anyway.
+            out.write("mnemon doctor — local mode\n")
+            out.write("  WARN something: heads up\n")
+            return 1 if fail_on_warn else 0
+
+        with patch("mnemon.doctor.run_doctor", side_effect=_warning_doctor):
+            result = run_setup("claude-code", [])
+
+        assert "doctor reported issues" in result
+        assert "including warnings" in result
 
 
 class TestParseSkipDoctor:


### PR DESCRIPTION
## Summary

- **`mnemon setup` with no target** auto-detects installed MCP clients (Claude Code, Claude Desktop, Cursor) and configures each. Gemini appended as a manual-step reminder.
- **Local-mode hooks re-enabled** — dispatching via P1a's `LocalMemoryClient`. P0 had skipped them because the hook client was HTTP-only; that constraint is gone.
- **New `mnemon setup claude-desktop` target** — MCP only (no hook system on Claude Desktop).
- **`mnemon doctor --fail-on-warn`** — warnings promoted to failures. `run_setup()` auto-invokes doctor with `fail_on_warn=True`, matching the "hard-fail until stabilized" preference.

## Context

P1b from the mnemon simplification plan (`private/mnemon-simplification-plan-260421.md`). Depends on P1a (#67) which merged. After this PR, the documented happy path is:

```
pip install mnemon-memory
mnemon setup        # configures every detected client; hooks work in local mode
```

That's the local-only experience. Users who want mobile/web roaming run `mnemon upgrade web` (P1c, next PR).

## Behavior matrix

| Invocation | Before | After |
|---|---|---|
| `mnemon setup` (no target) | usage error, exit 1 | auto-detect + configure each detected client |
| `mnemon setup claude-code` (no --remote-url) | MCP stdio, **hooks skipped** | MCP stdio + local hooks (LocalMemoryClient) |
| `mnemon setup hooks` (no --remote-url) | raised `SetupError` | installs local hooks |
| `mnemon setup claude-desktop` | unknown target | configures Claude Desktop MCP (new target) |
| `mnemon doctor` after setup | permissive | `fail_on_warn=True` — warnings propagate |
| `mnemon doctor --fail-on-warn` | flag ignored | promotes warnings to failures |

## Test plan

- [x] 22 new tests across `test_setup.py` (Claude Desktop target, `detect_installed_clients`, `run_setup(None)` auto-detect, `fail_on_warn` propagation).
- [x] `test_cli.py` — `mnemon setup` with no target invokes auto-detect; `--fail-on-warn` CLI flag propagates.
- [x] `test_doctor.py` — fail_on_warn promotes warnings to failures; clean runs still pass.
- [x] Full suite: **539 tests pass** (535 unit + 4 integration-remote).
- [ ] Manual: `pip install -e .` on a fresh shell, run `mnemon setup` with no args, confirm it detects ~/.claude and writes local hooks; confirm `mnemon doctor` exits 0.
- [ ] Manual: `mnemon setup --remote-url <prod URL>` on the same shell, confirm it reconfigures to remote with SessionStart pre-warm, and `mnemon doctor` still exits 0.

## Out of scope (P1c+, follow-ups)

- `mnemon upgrade web` command (wraps Fly deploy + S3 sync + config rewrite + archive-on-upgrade).
- `mnemon downgrade local` symmetric counterpart.
- README rewrite to the local + web matrix.
- Layer 2 integration test infra (MinIO + local serve-remote in Docker).

Full plan: `private/mnemon-simplification-plan-260421.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)