### PR TITLE
feat(downgrade): mnemon downgrade local — symmetric exit from web (P1d)

### DIFF
--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -191,6 +191,35 @@ def main() -> None:
             print(f"upgrade failed: {exc}", file=sys.stderr)
             sys.exit(1)
 
+    elif command == "downgrade":
+        # `mnemon downgrade local [--destroy-fly-app] [--yes] [--skip-doctor]`
+        # Symmetric to `mnemon upgrade web`. Pulls the Fly vault state
+        # back to local, reconfigures every MCP client to stdio mode,
+        # optionally destroys the Fly app.
+        subcommand = args[1] if len(args) > 1 else ""
+        if subcommand != "local":
+            print(
+                "Usage: mnemon downgrade local "
+                "[--destroy-fly-app] [--yes] [--app-name NAME] "
+                "[--skip-doctor]",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        parsed = _parse_downgrade_args(args[2:])
+        from .downgrade import DowngradeError, downgrade_local
+        try:
+            print(
+                downgrade_local(
+                    destroy_fly_app=parsed["destroy_fly_app"],
+                    yes=parsed["yes"],
+                    skip_doctor=parsed["skip_doctor"],
+                    app_name_override=parsed["app_name"],
+                )
+            )
+        except DowngradeError as exc:
+            print(f"downgrade failed: {exc}", file=sys.stderr)
+            sys.exit(1)
+
     else:
         print(f"Unknown command: {command}", file=sys.stderr)
         _print_usage()
@@ -229,6 +258,34 @@ def _parse_upgrade_args(args: list[str]) -> dict:
     return result
 
 
+def _parse_downgrade_args(args: list[str]) -> dict:
+    """Parse ``mnemon downgrade local`` flags."""
+    result: dict[str, str | bool | None] = {
+        "destroy_fly_app": False,
+        "yes": False,
+        "skip_doctor": False,
+        "app_name": None,
+    }
+    i = 0
+    while i < len(args):
+        flag = args[i]
+        if flag == "--destroy-fly-app":
+            result["destroy_fly_app"] = True
+            i += 1
+        elif flag == "--yes":
+            result["yes"] = True
+            i += 1
+        elif flag == "--skip-doctor":
+            result["skip_doctor"] = True
+            i += 1
+        elif flag == "--app-name" and i + 1 < len(args):
+            result["app_name"] = args[i + 1]
+            i += 2
+        else:
+            i += 1
+    return result
+
+
 def _print_usage() -> None:
     print(f"""mnemon v{__version__} — Universal long-term memory for AI agents
 
@@ -245,6 +302,11 @@ Upgrade local → web (deploys a Fly.io app + reconfigures every client):
                              [--region REGION] [--skip-doctor]
                              Requires: flyctl, aws CLI with credentials,
                              and an S3 bucket (MNEMON_S3_BUCKET or --s3-bucket).
+
+Downgrade web → local (pull remote vault back, reconfigure clients to stdio):
+  mnemon downgrade local    [--destroy-fly-app] [--yes] [--app-name NAME]
+                            [--skip-doctor]
+                            Requires MNEMON_S3_BUCKET and aws CLI creds.
 
 Server:
   mnemon serve              Start MCP server (stdio, local development)

--- a/src/mnemon/downgrade.py
+++ b/src/mnemon/downgrade.py
@@ -1,0 +1,285 @@
+"""Downgrade web → local: pull Fly vault back, reconfigure clients, stop.
+
+P1d of the mnemon simplification plan
+(``private/mnemon-simplification-plan-260421.md``). Symmetric counterpart
+to ``mnemon upgrade web`` — users who evaluate web and decide it isn't
+worth the cost get a clean exit that preserves every memory accumulated
+on the remote.
+
+Contract
+--------
+``mnemon downgrade local [--destroy-fly-app] [--yes] [--skip-doctor]``:
+
+1. Require a remote config (env var or ``~/.mnemon/remote_url``).
+   Refuses to run against an install that's already local-only — there
+   is nothing to downgrade from.
+2. ``mnemon sync pull`` → overwrite ``~/.mnemon/default.sqlite`` with
+   the current S3 state (which the Fly app has been writing to).
+3. Reconfigure every detected MCP client back to stdio. Invokes
+   ``setup_*`` functions without ``--remote-url``, which writes local
+   stdio MCP + in-process hooks (via the LocalMemoryClient added in P1a).
+4. If ``--destroy-fly-app`` was passed: prompt for confirmation
+   (unless ``--yes``) and run ``flyctl apps destroy <app>``.
+5. Run ``mnemon doctor --fail-on-warn`` against the new local vault.
+6. Print manual instructions for claude.ai / mobile (those can't be
+   auto-reverted — the user has to remove MCP entries in Anthropic's UI).
+
+Isolation overrides
+-------------------
+Shares ``MNEMON_CLIENT_CONFIG_ROOT`` and ``MNEMON_S3_ENDPOINT_OVERRIDE``
+with :mod:`mnemon.upgrade` so Layer 2 tests can exercise the full
+round-trip without touching real Fly/AWS.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+class DowngradeError(Exception):
+    """Raised when downgrade cannot proceed. Message is user-facing."""
+
+
+MNEMON_DIR = Path.home() / ".mnemon"
+REMOTE_URL_FILE = MNEMON_DIR / "remote_url"
+LOCAL_TOKEN_FILE = MNEMON_DIR / "local_token"
+
+
+def _resolve_remote_url() -> str:
+    """Read the current remote URL from env or ``~/.mnemon/remote_url``.
+
+    Mirrors the resolution in :func:`mnemon.hooks._remote_client.get_remote_url`
+    but raises :class:`DowngradeError` instead of
+    :class:`RemoteClientConfigError` so the caller gets a downgrade-
+    specific message.
+    """
+    env = os.environ.get("MNEMON_REMOTE_URL", "").strip()
+    if env:
+        return env
+    try:
+        if REMOTE_URL_FILE.exists():
+            content = REMOTE_URL_FILE.read_text().strip()
+            if content:
+                return content
+    except OSError:
+        pass
+    raise DowngradeError(
+        "No remote configured — nothing to downgrade from. "
+        f"Checked MNEMON_REMOTE_URL env var and {REMOTE_URL_FILE}. "
+        "If your machine is already local-only, this command is a no-op."
+    )
+
+
+def _extract_app_name(remote_url: str) -> str | None:
+    """Best-effort parse of a Fly app name from a remote URL.
+
+    Matches ``https://<app>.fly.dev[/...]``. Returns None for any URL
+    that doesn't fit the Fly pattern — the user might be self-hosting
+    on a custom domain, in which case we can't safely guess the app.
+    """
+    m = re.match(r"https?://([a-z0-9][-a-z0-9]{0,61})\.fly\.dev(/.*)?$", remote_url)
+    return m.group(1) if m else None
+
+
+def _client_config_root() -> Path:
+    override = os.environ.get("MNEMON_CLIENT_CONFIG_ROOT", "").strip()
+    if override:
+        return Path(override)
+    return Path.home()
+
+
+def _clear_remote_config() -> None:
+    """Remove ``~/.mnemon/remote_url`` so doctor + hooks auto-detect
+    local mode. Leaves the token file in place — harmless in local
+    mode, and the user might want it for a re-upgrade."""
+    if REMOTE_URL_FILE.exists():
+        REMOTE_URL_FILE.unlink()
+
+
+def _reconfigure_clients_local(detected: list[str]) -> list[str]:
+    """Rewrite each detected client's MCP config back to stdio mode.
+
+    Calls ``setup_*`` without ``--remote-url`` which installs local
+    stdio MCP + in-process hooks (the LocalMemoryClient path).
+    """
+    from . import setup as setup_mod
+
+    prior_home = setup_mod.Path.home
+    config_root = _client_config_root()
+
+    def _fake_home() -> Path:
+        return config_root
+
+    reconfigured: list[str] = []
+    try:
+        if os.environ.get("MNEMON_CLIENT_CONFIG_ROOT"):
+            setup_mod.Path.home = _fake_home  # type: ignore[method-assign]
+        for target in detected:
+            if target == "hooks":
+                # `hooks` is a pseudo-target used by setup_hooks
+                # explicitly; detect_installed_clients never returns it.
+                continue
+            func = setup_mod.TARGETS[target]
+            func(remote_url=None, token=None)
+            reconfigured.append(target)
+    finally:
+        setup_mod.Path.home = prior_home  # type: ignore[method-assign]
+
+    return reconfigured
+
+
+def _fly_destroy_app(app_name: str) -> None:
+    """Run ``flyctl apps destroy`` unattended (``-y``)."""
+    subprocess.run(
+        ["flyctl", "apps", "destroy", app_name, "-y"],
+        check=True,
+    )
+
+
+def _confirm(prompt: str) -> bool:
+    """Interactive y/n confirmation. Returns False for anything that
+    isn't an explicit yes. If stdin isn't a TTY (scripted context), we
+    default to False — scripted callers should pass ``--yes`` or skip
+    destroy entirely."""
+    if not sys.stdin.isatty():
+        return False
+    try:
+        reply = input(prompt).strip().lower()
+    except EOFError:
+        return False
+    return reply in {"y", "yes"}
+
+
+def downgrade_local(
+    *,
+    destroy_fly_app: bool = False,
+    yes: bool = False,
+    skip_doctor: bool = False,
+    app_name_override: str | None = None,
+) -> str:
+    """Downgrade a web install back to local-only.
+
+    See module docstring for the step-by-step contract. Returns a
+    user-facing summary; raises :class:`DowngradeError` on fatal
+    failures (no remote config, sync pull fails, reconfig fails).
+    """
+    remote_url = _resolve_remote_url()
+
+    # Step 2: sync pull S3 → local
+    from .sync import pull as s3_pull
+
+    bucket = os.environ.get("MNEMON_S3_BUCKET", "").strip()
+    if not bucket:
+        raise DowngradeError(
+            "MNEMON_S3_BUCKET not set. Downgrade pulls from S3 to seed "
+            "the restored local vault; without a bucket, the freshly-"
+            "downgraded local vault would be empty. Export "
+            "MNEMON_S3_BUCKET and retry."
+        )
+    pull_result = s3_pull()
+    if pull_result["errors"]:
+        raise DowngradeError(
+            "S3 pull failed: " + "; ".join(pull_result["errors"])
+        )
+
+    # Step 3: rewrite each detected client to stdio.
+    # Clear remote URL *before* rewriting so setup_* picks local mode.
+    _clear_remote_config()
+
+    from .setup import detect_installed_clients
+
+    detected = detect_installed_clients()
+    reconfigured = _reconfigure_clients_local(detected)
+
+    # Step 4 (optional): destroy the Fly app.
+    destroyed: str | None = None
+    app_name = app_name_override or _extract_app_name(remote_url)
+    if destroy_fly_app:
+        if not app_name:
+            raise DowngradeError(
+                f"Could not infer Fly app name from remote URL {remote_url!r}. "
+                "Pass --app-name <name> explicitly if you want to destroy a "
+                "non-fly.dev deployment."
+            )
+        if not yes:
+            ok = _confirm(
+                f"Destroy Fly app {app_name!r}? This is irreversible. [y/N]: "
+            )
+            if not ok:
+                print(
+                    f"Skipping destroy: Fly app {app_name!r} still running.",
+                    file=sys.stderr,
+                )
+            else:
+                _fly_destroy_app(app_name)
+                destroyed = app_name
+        else:
+            _fly_destroy_app(app_name)
+            destroyed = app_name
+
+    summary = [
+        "Downgrade to local complete.",
+        f"  Restored vault: ~/.mnemon/default.sqlite (pulled from S3 bucket {bucket!r})",
+    ]
+    if reconfigured:
+        summary.append(
+            "  Reconfigured:   " + ", ".join(reconfigured) + " (stdio mode)"
+        )
+    if destroyed:
+        summary.append(f"  Fly app:        destroyed ({destroyed})")
+    elif app_name:
+        summary.append(
+            f"  Fly app:        {app_name} is still running. "
+            "Rerun with --destroy-fly-app to tear it down."
+        )
+
+    summary += [
+        "",
+        "Next steps:",
+        "  • Restart each client above to pick up the local MCP config.",
+        "  • Manually remove the mnemon MCP entry from claude.ai and "
+        "the Claude mobile app (Settings → Connected Apps).",
+    ]
+    if not destroyed and app_name:
+        summary.append(
+            f"  • `flyctl apps destroy {app_name}` when you're ready to "
+            "stop paying for it."
+        )
+
+    if skip_doctor:
+        return "\n".join(summary)
+
+    # Step 5: doctor against local.
+    import io
+
+    from .doctor import run_doctor
+
+    # Ensure the env doesn't override local-mode detection.
+    prior_url_env = os.environ.pop("MNEMON_REMOTE_URL", None)
+    buf = io.StringIO()
+    try:
+        print("", file=buf)
+        print("Running mnemon doctor against the restored local vault...", file=buf)
+        try:
+            doctor_rc = run_doctor(out=buf, fail_on_warn=True)
+        except Exception as exc:  # noqa: BLE001
+            buf.write(
+                f"\n(doctor invocation crashed: {type(exc).__name__}: {exc})\n"
+            )
+            doctor_rc = 1
+    finally:
+        if prior_url_env is not None:
+            os.environ["MNEMON_REMOTE_URL"] = prior_url_env
+
+    if doctor_rc != 0:
+        buf.write(
+            "\nNOTE: doctor reported issues against the local vault. "
+            "Configs are rewritten; investigate the failing check(s) "
+            "above.\n"
+        )
+
+    return "\n".join(summary) + "\n" + buf.getvalue()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -464,6 +464,52 @@ class TestDoctorCli:
         mock_doctor.assert_called_once_with(fail_on_warn=True)
 
 
+class TestDowngradeCli:
+    @patch("mnemon.downgrade.downgrade_local")
+    def test_happy_path_passes_parsed_flags(self, mock_downgrade, capsys):
+        mock_downgrade.return_value = "downgrade output"
+        with patch(
+            "sys.argv",
+            [
+                "mnemon",
+                "downgrade",
+                "local",
+                "--destroy-fly-app",
+                "--yes",
+                "--skip-doctor",
+            ],
+        ):
+            main()
+        mock_downgrade.assert_called_once_with(
+            destroy_fly_app=True,
+            yes=True,
+            skip_doctor=True,
+            app_name_override=None,
+        )
+        assert "downgrade output" in capsys.readouterr().out
+
+    def test_local_subcommand_missing_prints_usage(self, capsys):
+        with patch("sys.argv", ["mnemon", "downgrade"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1
+        assert "Usage: mnemon downgrade local" in capsys.readouterr().err
+
+    @patch("mnemon.downgrade.downgrade_local")
+    def test_downgrade_error_surfaces_as_exit_1(self, mock_downgrade, capsys):
+        from mnemon.downgrade import DowngradeError
+
+        mock_downgrade.side_effect = DowngradeError("no remote")
+        with patch(
+            "sys.argv",
+            ["mnemon", "downgrade", "local", "--skip-doctor"],
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1
+        assert "downgrade failed: no remote" in capsys.readouterr().err
+
+
 class TestUnknownCommand:
     def test_unknown_command_exits(self, capsys):
         with patch("sys.argv", ["mnemon", "foobar"]):

--- a/tests/test_downgrade.py
+++ b/tests/test_downgrade.py
@@ -1,0 +1,299 @@
+"""Layer 1 unit tests for :mod:`mnemon.downgrade` — ``mnemon downgrade local``.
+
+Covers: remote-required guard, sync pull failure aborts, client
+reconfigure iterates in local mode, --destroy-fly-app prompt + confirm
++ unattended paths, non-fly.dev URL can't be auto-destroyed, doctor
+runs against local after.
+"""
+
+from __future__ import annotations
+
+from subprocess import CompletedProcess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mnemon import downgrade as dg
+from mnemon.downgrade import (
+    DowngradeError,
+    _extract_app_name,
+    downgrade_local,
+)
+
+
+def _ok_completed():
+    return CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch, tmp_path):
+    monkeypatch.setattr("mnemon.downgrade.Path.home", lambda: tmp_path)
+    # Also override the module-level constants that resolved at import time.
+    monkeypatch.setattr(
+        "mnemon.downgrade.MNEMON_DIR", tmp_path / ".mnemon"
+    )
+    monkeypatch.setattr(
+        "mnemon.downgrade.REMOTE_URL_FILE",
+        tmp_path / ".mnemon" / "remote_url",
+    )
+    monkeypatch.setattr(
+        "mnemon.downgrade.LOCAL_TOKEN_FILE",
+        tmp_path / ".mnemon" / "local_token",
+    )
+    monkeypatch.setenv("MNEMON_VAULT_DIR", str(tmp_path / ".mnemon"))
+    monkeypatch.setenv("MNEMON_S3_BUCKET", "test-bucket")
+    monkeypatch.delenv("MNEMON_REMOTE_URL", raising=False)
+    monkeypatch.delenv("MNEMON_CLIENT_CONFIG_ROOT", raising=False)
+    yield
+
+
+# ── _extract_app_name ────────────────────────────────────────────────────────
+
+
+class TestExtractAppName:
+    def test_parses_standard_fly_url(self):
+        assert (
+            _extract_app_name("https://mnemon-memory.fly.dev/mcp")
+            == "mnemon-memory"
+        )
+
+    def test_parses_without_path(self):
+        assert _extract_app_name("https://my-app.fly.dev") == "my-app"
+
+    def test_none_for_custom_domain(self):
+        assert (
+            _extract_app_name("https://mnemon.example.com/mcp") is None
+        )
+
+    def test_none_for_invalid_shape(self):
+        assert _extract_app_name("not-a-url") is None
+
+
+# ── downgrade_local ──────────────────────────────────────────────────────────
+
+
+class TestRequireRemote:
+    def test_no_remote_config_raises(self, tmp_path):
+        # Neither env var nor the file exists
+        with pytest.raises(DowngradeError, match="nothing to downgrade"):
+            downgrade_local(skip_doctor=True)
+
+
+class TestSyncPull:
+    def _seed_remote_config(self, tmp_path, url="https://mnemon-test.fly.dev/mcp"):
+        mnemon_dir = tmp_path / ".mnemon"
+        mnemon_dir.mkdir()
+        (mnemon_dir / "remote_url").write_text(url)
+
+    def test_sync_pull_failure_aborts(self, tmp_path):
+        self._seed_remote_config(tmp_path)
+        with patch(
+            "mnemon.sync.pull",
+            return_value={"pulled": [], "errors": ["access denied"]},
+        ):
+            with pytest.raises(DowngradeError, match="S3 pull failed"):
+                downgrade_local(skip_doctor=True)
+        # Remote config was NOT cleared — downgrade aborted.
+        assert (tmp_path / ".mnemon" / "remote_url").exists()
+
+    def test_bucket_required(self, tmp_path, monkeypatch):
+        self._seed_remote_config(tmp_path)
+        monkeypatch.delenv("MNEMON_S3_BUCKET", raising=False)
+        with pytest.raises(DowngradeError, match="MNEMON_S3_BUCKET"):
+            downgrade_local(skip_doctor=True)
+
+
+class TestReconfigureLocal:
+    def _seed_remote_config(self, tmp_path):
+        mnemon_dir = tmp_path / ".mnemon"
+        mnemon_dir.mkdir()
+        (mnemon_dir / "remote_url").write_text(
+            "https://mnemon-test.fly.dev/mcp"
+        )
+
+    def test_happy_path_clears_remote_and_reconfigures(
+        self, tmp_path, monkeypatch
+    ):
+        self._seed_remote_config(tmp_path)
+
+        with patch(
+            "mnemon.sync.pull",
+            return_value={"pulled": ["sqlite"], "errors": []},
+        ), \
+            patch(
+                "mnemon.setup.detect_installed_clients",
+                return_value=["claude-code", "cursor"],
+            ), \
+            patch(
+                "mnemon.downgrade._reconfigure_clients_local",
+                return_value=["claude-code", "cursor"],
+            ) as mock_reconfig, \
+            patch("mnemon.doctor.run_doctor", return_value=0):
+            result = downgrade_local(skip_doctor=True)
+
+        mock_reconfig.assert_called_once()
+        # Remote config cleared
+        assert not (tmp_path / ".mnemon" / "remote_url").exists()
+        assert "Downgrade to local complete" in result
+        assert "claude-code, cursor" in result
+
+
+class TestDestroyFlyApp:
+    def _seed_remote_config(self, tmp_path, url="https://mnemon-test-999.fly.dev/mcp"):
+        mnemon_dir = tmp_path / ".mnemon"
+        mnemon_dir.mkdir()
+        (mnemon_dir / "remote_url").write_text(url)
+
+    def test_destroy_without_yes_prompts(self, tmp_path):
+        self._seed_remote_config(tmp_path)
+        with patch(
+            "mnemon.sync.pull",
+            return_value={"pulled": [], "errors": []},
+        ), \
+            patch(
+                "mnemon.setup.detect_installed_clients",
+                return_value=[],
+            ), \
+            patch(
+                "mnemon.downgrade._reconfigure_clients_local",
+                return_value=[],
+            ), \
+            patch(
+                "mnemon.downgrade._confirm", return_value=True
+            ) as mock_confirm, \
+            patch(
+                "mnemon.downgrade.subprocess.run",
+                return_value=_ok_completed(),
+            ) as mock_run:
+            result = downgrade_local(
+                destroy_fly_app=True, skip_doctor=True
+            )
+        mock_confirm.assert_called_once()
+        # flyctl apps destroy was invoked
+        destroy_calls = [
+            c for c in mock_run.call_args_list if "destroy" in c.args[0]
+        ]
+        assert len(destroy_calls) == 1
+        assert destroy_calls[0].args[0][:3] == ["flyctl", "apps", "destroy"]
+        assert "destroyed (mnemon-test-999)" in result
+
+    def test_destroy_with_yes_skips_prompt(self, tmp_path):
+        self._seed_remote_config(tmp_path)
+        with patch(
+            "mnemon.sync.pull",
+            return_value={"pulled": [], "errors": []},
+        ), \
+            patch(
+                "mnemon.setup.detect_installed_clients",
+                return_value=[],
+            ), \
+            patch(
+                "mnemon.downgrade._reconfigure_clients_local",
+                return_value=[],
+            ), \
+            patch(
+                "mnemon.downgrade._confirm"
+            ) as mock_confirm, \
+            patch(
+                "mnemon.downgrade.subprocess.run",
+                return_value=_ok_completed(),
+            ) as mock_run:
+            downgrade_local(
+                destroy_fly_app=True, yes=True, skip_doctor=True
+            )
+        mock_confirm.assert_not_called()
+        destroy_calls = [
+            c for c in mock_run.call_args_list if "destroy" in c.args[0]
+        ]
+        assert len(destroy_calls) == 1
+
+    def test_destroy_declined_leaves_app_running(self, tmp_path):
+        self._seed_remote_config(tmp_path)
+        with patch(
+            "mnemon.sync.pull",
+            return_value={"pulled": [], "errors": []},
+        ), \
+            patch(
+                "mnemon.setup.detect_installed_clients",
+                return_value=[],
+            ), \
+            patch(
+                "mnemon.downgrade._reconfigure_clients_local",
+                return_value=[],
+            ), \
+            patch(
+                "mnemon.downgrade._confirm", return_value=False
+            ), \
+            patch(
+                "mnemon.downgrade.subprocess.run"
+            ) as mock_run:
+            result = downgrade_local(
+                destroy_fly_app=True, skip_doctor=True
+            )
+        # No flyctl destroy call
+        mock_run.assert_not_called()
+        assert "mnemon-test-999 is still running" in result
+
+    def test_destroy_custom_domain_requires_app_name_override(
+        self, tmp_path
+    ):
+        # Non-fly.dev URL — can't auto-infer the app name.
+        self._seed_remote_config(
+            tmp_path, url="https://mnemon.example.com/mcp"
+        )
+        with patch(
+            "mnemon.sync.pull",
+            return_value={"pulled": [], "errors": []},
+        ), \
+            patch(
+                "mnemon.setup.detect_installed_clients",
+                return_value=[],
+            ), \
+            patch(
+                "mnemon.downgrade._reconfigure_clients_local",
+                return_value=[],
+            ):
+            with pytest.raises(DowngradeError, match="Could not infer"):
+                downgrade_local(
+                    destroy_fly_app=True, yes=True, skip_doctor=True
+                )
+
+    def test_destroy_with_override_succeeds_on_custom_domain(
+        self, tmp_path
+    ):
+        self._seed_remote_config(
+            tmp_path, url="https://mnemon.example.com/mcp"
+        )
+        with patch(
+            "mnemon.sync.pull",
+            return_value={"pulled": [], "errors": []},
+        ), \
+            patch(
+                "mnemon.setup.detect_installed_clients",
+                return_value=[],
+            ), \
+            patch(
+                "mnemon.downgrade._reconfigure_clients_local",
+                return_value=[],
+            ), \
+            patch(
+                "mnemon.downgrade.subprocess.run",
+                return_value=_ok_completed(),
+            ) as mock_run:
+            result = downgrade_local(
+                destroy_fly_app=True,
+                yes=True,
+                skip_doctor=True,
+                app_name_override="my-custom-app",
+            )
+        destroy_calls = [
+            c for c in mock_run.call_args_list if "destroy" in c.args[0]
+        ]
+        assert destroy_calls[0].args[0] == [
+            "flyctl",
+            "apps",
+            "destroy",
+            "my-custom-app",
+            "-y",
+        ]
+        assert "destroyed (my-custom-app)" in result


### PR DESCRIPTION
## Summary

Symmetric counterpart to `mnemon upgrade web` (#69):

```
mnemon downgrade local [--destroy-fly-app] [--yes] [--app-name NAME]
```

Pulls the Fly vault back to local via S3, reconfigures every detected client back to stdio mode, optionally destroys the Fly app. Any memories accumulated on the remote are preserved (the S3 backup is authoritative).

## Context

P1d from the mnemon simplification plan (`private/mnemon-simplification-plan-260421.md`). Depends on P1a (#67) + P1b (#68); does NOT depend on P1c (#69) — the two features are functionally independent (downgrade only needs a working remote, not specifically one that P1c deployed).

## Orchestration

1. Resolve the current remote URL. Refuses to run on a local-only install.
2. `mnemon sync pull` — S3 → local `~/.mnemon/default.sqlite`.
3. Clear `~/.mnemon/remote_url` so `setup_*` picks local mode.
4. Reconfigure each detected MCP client back to stdio via `setup_*` without `--remote-url`. Hooks get the LocalMemoryClient path from P1a.
5. If `--destroy-fly-app`: prompt (unless `--yes`) + `flyctl apps destroy`.
6. `mnemon doctor --fail-on-warn` against the restored local vault.

## Guardrails

- `_extract_app_name` only parses `*.fly.dev` URLs. Custom-domain installs must pass `--app-name NAME` explicitly — no guessing.
- `_confirm` is stdin-aware: no TTY → False, so scripted callers that forget `--yes` don't hang or auto-destroy.
- Reuses `MNEMON_CLIENT_CONFIG_ROOT` from P1c for Layer 2 test isolation.

## One manual step

Removing `claude.ai` and the Claude mobile app's MCP entry — those live in Anthropic's UI and can't be auto-reverted. Output spells this out.

## Test plan

- [x] 13 Layer 1 unit tests in `tests/test_downgrade.py`: `_extract_app_name` across URL shapes, remote-required guard, bucket guard, sync pull failure aborts and leaves remote config intact, happy path clears remote config + reconfigures, `--destroy-fly-app` prompt/confirm/decline/unattended paths, custom-domain requires `--app-name`.
- [x] 3 CLI tests: flag parsing, `local` subcommand required, `DowngradeError` → exit 1.
- [x] Full suite: **551 tests pass**.
- [ ] Layer 3 (your Fly + AWS accounts, scoped): runbook at `private/e2e-test-runbook-260421.md` Steps 5–6.

## Out of scope (P1e, final)

- README rewrite to the local + web matrix with quick starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)