### PR TITLE
fix: local Claude Code via `claude mcp add stdio` + refuse-when-remote + `mnemon uninstall`

### DIFF
--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -191,6 +191,20 @@ def main() -> None:
             print(f"upgrade failed: {exc}", file=sys.stderr)
             sys.exit(1)
 
+    elif command == "uninstall":
+        # `mnemon uninstall [--yes] [--keep-vault]` — wipe all mnemon
+        # state from this machine. Useful for testing the full fresh-
+        # install experience or for users who want to exit entirely.
+        flags = args[1:]
+        yes = "--yes" in flags
+        keep_vault = "--keep-vault" in flags
+        from .uninstall import UninstallError, uninstall
+        try:
+            print(uninstall(yes=yes, keep_vault=keep_vault))
+        except UninstallError as exc:
+            print(f"uninstall failed: {exc}", file=sys.stderr)
+            sys.exit(1)
+
     elif command == "downgrade":
         # `mnemon downgrade local [--destroy-fly-app] [--yes] [--skip-doctor]`
         # Symmetric to `mnemon upgrade web`. Pulls the Fly vault state
@@ -307,6 +321,13 @@ Downgrade web → local (pull remote vault back, reconfigure clients to stdio):
   mnemon downgrade local    [--destroy-fly-app] [--yes] [--app-name NAME]
                             [--skip-doctor]
                             Requires MNEMON_S3_BUCKET and aws CLI creds.
+
+Uninstall (remove all mnemon state from this machine):
+  mnemon uninstall          [--yes] [--keep-vault]
+                            Removes vault, client configs, claude mcp
+                            registration. Does NOT touch Fly / S3 / the
+                            pip package. Run `downgrade local` first if
+                            you want to preserve a live web deployment.
 
 Server:
   mnemon serve              Start MCP server (stdio, local development)

--- a/src/mnemon/setup.py
+++ b/src/mnemon/setup.py
@@ -177,6 +177,53 @@ def _ensure_local_token(token: str | None = None) -> str:
     return new_token
 
 
+def _refuse_if_remote_configured(target_label: str) -> None:
+    """Raise :class:`SetupError` if ``~/.mnemon/remote_url`` exists.
+
+    Called by local-mode setup paths. Running local setup while a remote
+    is still configured leaves the machine in a split state: the stdio
+    MCP registration lands, but hooks keep reading the remote URL file
+    and routing through ``RemoteMemoryClient``. The user sees inconsistent
+    behavior ("Cursor went local but Claude Code still shows Fly").
+
+    Refusing here is the arch-correct "no silent split-brain" answer.
+    Users have two clean exits: ``mnemon downgrade local`` (preserves
+    web data by pulling from S3) or ``mnemon uninstall`` (wipes all
+    mnemon state).
+    """
+    # Check env var first (highest priority, matches _remote_client
+    # resolution order); fall through to the file.
+    env_url = os.environ.get("MNEMON_REMOTE_URL", "").strip()
+    file_url: str | None = None
+    if REMOTE_URL_FILE.exists():
+        try:
+            file_url = REMOTE_URL_FILE.read_text().strip() or None
+        except OSError:
+            file_url = None
+
+    if not env_url and not file_url:
+        return
+
+    source = (
+        f"MNEMON_REMOTE_URL={env_url}"
+        if env_url
+        else f"{REMOTE_URL_FILE} ({file_url})"
+    )
+    raise SetupError(
+        f"Refusing local-mode `mnemon setup {target_label}` while a "
+        f"remote is configured ({source}). "
+        "Running local setup now would leave this machine in a split "
+        "state — MCP goes local but hooks keep talking to the remote. "
+        "Pick one of:\n"
+        "  • `mnemon downgrade local` — pull your remote vault back to "
+        "local, reconfigure clients, optionally destroy the Fly app.\n"
+        "  • `mnemon uninstall` — remove ALL mnemon state from this "
+        "machine so you can reinstall from scratch.\n"
+        "  • `mnemon setup claude-code --remote-url <URL>` — "
+        "reconfigure this client to use the existing remote."
+    )
+
+
 def _strip_mnemon_hooks(hooks: dict) -> None:
     """Remove any hook entries whose command references ``mnemon.hooks.*``.
 
@@ -252,15 +299,53 @@ def _preflight_remote_endpoint(remote_url: str, local_token: str) -> None:
             os.environ["MNEMON_LOCAL_TOKEN"] = prior_token
 
 
-def _register_claude_code_mcp(remote_url: str, local_token: str) -> None:
-    """Register the mnemon MCP server with Claude Code via the `claude` CLI.
+def _register_claude_code_mcp_remote(remote_url: str, local_token: str) -> None:
+    """Register the mnemon HTTP MCP server with Claude Code.
 
     Claude Code loads MCP server registrations from its own config
     (managed by ``claude mcp add``), not from ``settings.json.mcpServers``.
-    Writing an HTTP transport entry to ``settings.json`` has no effect — the
-    CLI silently ignores it. Shelling out to ``claude mcp add`` is the only
-    supported registration path.
+    Writing to ``settings.json`` has no effect — the CLI silently ignores
+    mnemon entries there. Shelling out to ``claude mcp add`` is the only
+    supported registration path for BOTH HTTP and stdio transports.
     """
+    _run_claude_mcp_add(
+        [
+            "--transport", "http",
+            "mnemon",
+            remote_url,
+            "--header", f"Authorization: Bearer {local_token}",
+        ]
+    )
+
+
+def _register_claude_code_mcp_stdio() -> None:
+    """Register the mnemon stdio MCP server with Claude Code.
+
+    Local-mode counterpart to :func:`_register_claude_code_mcp_remote`.
+    Same rationale: settings.json entries are ignored by Claude Code, so
+    the only way to make mnemon tools visible to Claude Code locally is
+    via ``claude mcp add --transport stdio``.
+
+    This was the missing piece that made local-mode setup silently fail
+    for Claude Code users while appearing to succeed (settings.json was
+    written, but Claude Code never read it).
+    """
+    _run_claude_mcp_add(
+        [
+            "--transport", "stdio",
+            "mnemon",
+            "--",
+            _python_path(),
+            "-m",
+            "mnemon",
+            "serve",
+        ]
+    )
+
+
+def _run_claude_mcp_add(add_args: list[str]) -> None:
+    """Shared helper: remove any existing mnemon registration, then add
+    with the supplied args. Both remote and local paths use this."""
     try:
         subprocess.run(
             ["claude", "mcp", "remove", "--scope", "user", "mnemon"],
@@ -268,21 +353,14 @@ def _register_claude_code_mcp(remote_url: str, local_token: str) -> None:
             capture_output=True,
         )
         subprocess.run(
-            [
-                "claude", "mcp", "add",
-                "--scope", "user",
-                "--transport", "http",
-                "mnemon",
-                remote_url,
-                "--header", f"Authorization: Bearer {local_token}",
-            ],
+            ["claude", "mcp", "add", "--scope", "user"] + add_args,
             check=True,
             capture_output=True,
         )
     except FileNotFoundError as exc:
         raise RuntimeError(
             "The `claude` CLI was not found on PATH. Install Claude Code "
-            "before running `mnemon setup claude-code` with --remote-url."
+            "before running `mnemon setup claude-code`."
         ) from exc
     except subprocess.CalledProcessError as exc:
         stderr = (exc.stderr or b"").decode(errors="replace").strip()
@@ -292,24 +370,28 @@ def _register_claude_code_mcp(remote_url: str, local_token: str) -> None:
 
 
 def setup_claude_code(*, remote_url: str | None = None, token: str | None = None) -> str:
-    """Configure Claude Code (MCP server, and hooks only when remote).
+    """Configure Claude Code (MCP server + hooks).
 
     When ``remote_url`` is provided:
       - Preflight the endpoint (aborts setup if unreachable).
       - Write URL + token to ``~/.mnemon/`` config files.
-      - Register the HTTP MCP server via ``claude mcp add``.
+      - Register the HTTP MCP server via ``claude mcp add --transport http``.
       - Install UserPromptSubmit / Stop / SessionStart hooks.
 
     When ``remote_url`` is not provided:
-      - Register a local stdio MCP server in ``settings.json``.
+      - Refuses to run if ``~/.mnemon/remote_url`` is present (you're
+        currently in web mode; use ``mnemon downgrade local`` or
+        ``mnemon uninstall`` to exit first).
+      - Registers the stdio MCP server via ``claude mcp add --transport stdio``.
+        Writing to ``settings.json.mcpServers`` has no effect — Claude Code
+        reads its own registry, not settings.json.
       - Install UserPromptSubmit / Stop hooks (no SessionStart — no
         remote machine to pre-warm). Hooks dispatch in-process via
-        :class:`~mnemon.hooks._client.LocalMemoryClient` (added in P1a).
-
-    Note: P1a removed the constraint that hooks require HTTP. P0 skipped
-    hooks in local mode because the client path was HTTP-only; that's
-    been fixed.
+        :class:`~mnemon.hooks._client.LocalMemoryClient`.
     """
+    if remote_url is None:
+        _refuse_if_remote_configured("claude-code")
+
     settings_path = Path.home() / ".claude" / "settings.json"
     settings = _read_json(settings_path)
 
@@ -323,9 +405,12 @@ def setup_claude_code(*, remote_url: str | None = None, token: str | None = None
         lines.append(f"  Token file: {LOCAL_TOKEN_FILE} (chmod 600)")
         lines.append(f"  Preflight:  OK (memory_status round-trip < {REMOTE_PREFLIGHT_TIMEOUT_SEC:.0f}s)")
 
-        _register_claude_code_mcp(remote_url, local_token)
+        _register_claude_code_mcp_remote(remote_url, local_token)
         lines.append("  MCP server: mnemon (http, remote) — registered via `claude mcp add`")
 
+        # Strip any stdio mnemon entry in settings.json from a prior
+        # local setup. Claude Code ignores the key for mnemon, but
+        # leaving a stale entry is confusing when users inspect the file.
         mcp_servers = settings.get("mcpServers")
         if isinstance(mcp_servers, dict) and "mnemon" in mcp_servers:
             del mcp_servers["mnemon"]
@@ -333,10 +418,18 @@ def setup_claude_code(*, remote_url: str | None = None, token: str | None = None
                 del settings["mcpServers"]
             lines.append("  Cleaned up stale settings.json mcpServers.mnemon entry")
     else:
-        if "mcpServers" not in settings:
-            settings["mcpServers"] = {}
-        settings["mcpServers"]["mnemon"] = _mcp_config()
-        lines.append("  MCP server: mnemon (stdio, local)")
+        _register_claude_code_mcp_stdio()
+        lines.append("  MCP server: mnemon (stdio, local) — registered via `claude mcp add`")
+
+        # Strip any stdio entry in settings.json — leftover from earlier
+        # versions of setup that wrote there. Claude Code ignores it,
+        # but it's confusing to see the mnemon name in two places.
+        mcp_servers = settings.get("mcpServers")
+        if isinstance(mcp_servers, dict) and "mnemon" in mcp_servers:
+            del mcp_servers["mnemon"]
+            if not mcp_servers:
+                del settings["mcpServers"]
+            lines.append("  Cleaned up stale settings.json mcpServers.mnemon entry")
 
     # Hooks: install in both modes. _hooks_config adds SessionStart only
     # when remote_url is supplied (local mode has no cold-start to warm).
@@ -385,7 +478,12 @@ def setup_cursor(*, remote_url: str | None = None, token: str | None = None) -> 
 
     When ``remote_url`` is provided, configures Cursor to use the remote
     mnemon server with bearer token auth. Otherwise falls back to stdio.
+    Refuses local mode if a remote is currently configured (split-brain
+    guard — see :func:`_refuse_if_remote_configured`).
     """
+    if remote_url is None:
+        _refuse_if_remote_configured("cursor")
+
     cursor_path = Path.home() / ".cursor" / "mcp.json"
     config = _read_json(cursor_path)
 
@@ -456,8 +554,12 @@ def setup_claude_desktop(
     Claude Desktop has no hook system — this only writes the MCP entry.
     Config format mirrors Cursor's ``mcp.json``. When ``remote_url`` is
     provided, writes an HTTP transport with bearer auth and preflights
-    the endpoint; otherwise writes a local stdio entry.
+    the endpoint; otherwise writes a local stdio entry. Refuses local
+    mode if a remote is currently configured (split-brain guard).
     """
+    if remote_url is None:
+        _refuse_if_remote_configured("claude-desktop")
+
     desktop_path = _claude_desktop_config_path()
     config = _read_json(desktop_path)
 
@@ -508,8 +610,12 @@ def setup_hooks(*, remote_url: str | None = None, token: str | None = None) -> s
     Works in both modes after P1a: local hooks dispatch in-process via
     :class:`~mnemon.hooks._client.LocalMemoryClient`; remote hooks go
     over HTTP. When ``remote_url`` is supplied, the endpoint is
-    preflighted and a SessionStart pre-warm hook is added.
+    preflighted and a SessionStart pre-warm hook is added. Refuses
+    local mode if a remote is currently configured (split-brain guard).
     """
+    if remote_url is None:
+        _refuse_if_remote_configured("hooks")
+
     settings_path = Path.home() / ".claude" / "settings.json"
     settings = _read_json(settings_path)
 
@@ -621,8 +727,8 @@ def _next_steps_block(target: str, remote_url: str | None) -> str:
     if remote_url is None and target == "claude-code":
         lines.append(
             "  • Want mobile / claude.ai / cross-device memory? "
-            "Run `mnemon upgrade web` (coming soon) or pass "
-            "--remote-url <URL> to enable hooks now."
+            "Run `mnemon upgrade web --app-name <name>` or pass "
+            "--remote-url <URL> to switch this install to remote mode."
         )
     lines.append("  • Run `mnemon doctor` any time to re-verify the setup.")
     return "\n".join(lines)
@@ -693,7 +799,7 @@ def _run_autodetect(parsed: dict) -> str:
     if remote_url is None:
         blocks.append(
             "  • Want mobile / claude.ai / cross-device memory? "
-            "Run `mnemon upgrade web` (coming soon) or rerun with "
+            "Run `mnemon upgrade web --app-name <name>` or rerun with "
             "--remote-url <URL>."
         )
     blocks.append("  • Run `mnemon doctor` any time to re-verify the setup.")

--- a/src/mnemon/uninstall.py
+++ b/src/mnemon/uninstall.py
@@ -1,0 +1,333 @@
+"""Remove all mnemon state from this machine.
+
+Designed for users who want to test the full install-from-scratch
+experience — e.g. to validate the `mnemon setup` happy path after
+previously running `mnemon upgrade web` or a historical setup that
+left stale config behind. Also useful as a clean exit for users who
+decide mnemon isn't for them.
+
+What gets removed
+-----------------
+- ``~/.mnemon/`` — vault (SQLite + vectors), archive/, remote_url,
+  local_token, models cache. Everything. Irreversibly.
+- ``claude mcp remove mnemon`` — drops the Claude Code MCP registration
+  whether it was stdio or http.
+- ``~/.claude/settings.json`` — removes mnemon hook entries and the
+  (never-effective, but confusing) ``mcpServers.mnemon`` entry.
+- ``~/.cursor/mcp.json`` — removes ``mcpServers.mnemon``.
+- Claude Desktop config — removes ``mcpServers.mnemon``.
+
+What does NOT get removed
+-------------------------
+- The ``mnemon-memory`` Python package itself (``pip uninstall`` is
+  the user's package manager's job; we never touch it).
+- Fly.io apps — user-owned infra. If the user had deployed web via
+  ``mnemon upgrade web``, they should run ``mnemon downgrade local
+  --destroy-fly-app`` first to preserve their memories (S3 backup)
+  and destroy the app cleanly. We warn loudly if this state is
+  detected.
+- S3 bucket contents — user-owned; deleting someone's bucket data
+  is never our call.
+- claude.ai / Claude mobile MCP entries — live in Anthropic's UI,
+  can't be auto-removed. Output tells the user to remove manually.
+
+CLI
+---
+``mnemon uninstall [--yes] [--keep-vault]``
+
+``--yes`` bypasses the confirmation prompt (for scripted teardowns).
+``--keep-vault`` removes client configs and ``claude mcp`` registration
+but preserves ``~/.mnemon/`` — useful for "I want to redo setup without
+losing my memories."
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+class UninstallError(Exception):
+    """Raised when uninstall cannot proceed. Message is user-facing."""
+
+
+MNEMON_DIR_DEFAULT = Path.home() / ".mnemon"
+REMOTE_URL_FILE = MNEMON_DIR_DEFAULT / "remote_url"
+
+
+def _mnemon_dir() -> Path:
+    """Honor MNEMON_VAULT_DIR if the user relocated the vault."""
+    override = os.environ.get("MNEMON_VAULT_DIR", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return MNEMON_DIR_DEFAULT
+
+
+def _claude_desktop_config_path() -> Path:
+    """Same logic as setup._claude_desktop_config_path — duplicated here
+    to avoid a circular import and to keep uninstall self-contained."""
+    if sys.platform == "darwin":
+        return (
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / "Claude"
+            / "claude_desktop_config.json"
+        )
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            return Path(appdata) / "Claude" / "claude_desktop_config.json"
+        return (
+            Path.home()
+            / "AppData"
+            / "Roaming"
+            / "Claude"
+            / "claude_desktop_config.json"
+        )
+    return Path.home() / ".config" / "Claude" / "claude_desktop_config.json"
+
+
+def _detect_state() -> dict:
+    """Return a dict describing what mnemon state is present on this
+    machine. Used to build the confirmation prompt and the summary."""
+    mdir = _mnemon_dir()
+    state = {
+        "mnemon_dir": mdir if mdir.exists() else None,
+        "remote_url_configured": (mdir / "remote_url").exists(),
+        "claude_code_settings": (
+            Path.home() / ".claude" / "settings.json"
+        )
+        if (Path.home() / ".claude" / "settings.json").exists()
+        else None,
+        "cursor_config": (Path.home() / ".cursor" / "mcp.json")
+        if (Path.home() / ".cursor" / "mcp.json").exists()
+        else None,
+        "claude_desktop_config": _claude_desktop_config_path()
+        if _claude_desktop_config_path().exists()
+        else None,
+    }
+    return state
+
+
+def _confirm(prompt: str) -> bool:
+    """y/N confirmation. Stdin-aware: no TTY → False (force --yes)."""
+    if not sys.stdin.isatty():
+        return False
+    try:
+        return input(prompt).strip().lower() in {"y", "yes"}
+    except EOFError:
+        return False
+
+
+def _claude_mcp_remove() -> str | None:
+    """Run ``claude mcp remove mnemon``. Returns a status line or None
+    if the claude CLI isn't on PATH."""
+    try:
+        out = subprocess.run(
+            ["claude", "mcp", "remove", "--scope", "user", "mnemon"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return None
+    if out.returncode == 0:
+        return "  claude mcp:    mnemon registration removed"
+    # Non-zero is expected if mnemon was never registered. Still worth
+    # noting so the user sees the attempt happened.
+    return "  claude mcp:    no mnemon registration found (or CLI errored silently)"
+
+
+def _strip_from_json(path: Path, keys_to_strip: dict[str, list[str]]) -> bool:
+    """Remove nested keys from a JSON file. Returns True if anything
+    was actually removed (i.e. the file was modified).
+
+    ``keys_to_strip`` maps top-level key → list of subkeys to delete.
+    Top-level keys that become empty after stripping are also removed
+    so the resulting file doesn't accumulate empty containers.
+    """
+    import json
+
+    if not path.exists():
+        return False
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return False
+    if not isinstance(data, dict):
+        return False
+
+    changed = False
+    for top_key, subkeys in keys_to_strip.items():
+        container = data.get(top_key)
+        if not isinstance(container, dict):
+            continue
+        for sub in subkeys:
+            if sub in container:
+                del container[sub]
+                changed = True
+        if not container:
+            del data[top_key]
+            changed = True
+
+    # Also strip mnemon hook entries from Claude Code settings.json hooks.
+    # Hooks are a nested shape: hooks.<EventName>[{hooks: [{command: ...}]}].
+    # We delete any inner hook dict whose command references mnemon.
+    hooks = data.get("hooks")
+    if isinstance(hooks, dict):
+        for event in list(hooks.keys()):
+            entries = hooks[event]
+            if not isinstance(entries, list):
+                continue
+            filtered = []
+            for entry in entries:
+                inner = [
+                    h
+                    for h in entry.get("hooks", [])
+                    if "mnemon" not in (h.get("command") or "")
+                ]
+                if inner:
+                    filtered.append({**entry, "hooks": inner})
+                else:
+                    changed = True
+            if filtered:
+                hooks[event] = filtered
+            else:
+                del hooks[event]
+                changed = True
+        if not hooks:
+            del data["hooks"]
+            changed = True
+
+    if changed:
+        path.write_text(__import__("json").dumps(data, indent=2) + "\n")
+    return changed
+
+
+def uninstall(*, yes: bool = False, keep_vault: bool = False) -> str:
+    """Remove all mnemon state from this machine.
+
+    Returns a user-facing summary. Raises :class:`UninstallError` only
+    for genuine failures — the "nothing to remove" case is handled as
+    a normal return with a no-op summary.
+    """
+    state = _detect_state()
+
+    # Warn if this looks like a web install — user should downgrade
+    # first to preserve their remote vault.
+    if state["remote_url_configured"] and not keep_vault:
+        warning = (
+            "⚠ A remote URL is configured at ~/.mnemon/remote_url. "
+            "This machine may have a live Fly deployment whose vault "
+            "you are about to wipe locally. If you want to preserve "
+            "that data:\n"
+            "  1. Abort now (Ctrl-C).\n"
+            "  2. Run `mnemon downgrade local --destroy-fly-app` to "
+            "pull the remote vault back and destroy the Fly app.\n"
+            "  3. Then run `mnemon uninstall` to remove everything.\n"
+        )
+        print(warning, file=sys.stderr)
+
+    # Build the plan so the user knows what's about to happen.
+    plan_lines = ["mnemon uninstall will remove:"]
+    if state["mnemon_dir"] and not keep_vault:
+        plan_lines.append(
+            f"  • Vault directory: {state['mnemon_dir']} "
+            "(SQLite vault, vectors, archive, models, config files)"
+        )
+    elif state["mnemon_dir"] and keep_vault:
+        plan_lines.append(
+            f"  • Vault directory: {state['mnemon_dir']} — KEPT "
+            "(--keep-vault specified)"
+        )
+    plan_lines.append(
+        "  • Claude Code MCP registration (`claude mcp remove mnemon`)"
+    )
+    if state["claude_code_settings"]:
+        plan_lines.append(
+            f"  • mnemon hook + mcpServers entries in {state['claude_code_settings']}"
+        )
+    if state["cursor_config"]:
+        plan_lines.append(
+            f"  • mnemon entry in {state['cursor_config']}"
+        )
+    if state["claude_desktop_config"]:
+        plan_lines.append(
+            f"  • mnemon entry in {state['claude_desktop_config']}"
+        )
+    plan_lines.append("")
+    plan_lines.append("What this command does NOT touch:")
+    plan_lines.append("  • The `mnemon-memory` Python package (use `pip uninstall` separately)")
+    plan_lines.append("  • Any Fly.io apps you own")
+    plan_lines.append("  • Any S3 bucket contents")
+    plan_lines.append("  • claude.ai / Claude mobile MCP entries (remove manually in Anthropic's UI)")
+
+    print("\n".join(plan_lines), file=sys.stderr)
+
+    if not yes:
+        if not _confirm("\nProceed? [y/N]: "):
+            return "Uninstall aborted by user."
+
+    # Execute plan.
+    summary: list[str] = ["Uninstall complete."]
+
+    # 1. Claude Code MCP registration.
+    line = _claude_mcp_remove()
+    if line:
+        summary.append(line)
+    else:
+        summary.append(
+            "  claude mcp:    skipped (claude CLI not on PATH)"
+        )
+
+    # 2. Claude Code settings.json — strip mnemon mcpServers + hooks.
+    cc_settings = Path.home() / ".claude" / "settings.json"
+    if _strip_from_json(
+        cc_settings, {"mcpServers": ["mnemon"]}
+    ):
+        summary.append(
+            f"  Claude Code:   scrubbed mnemon entries in {cc_settings}"
+        )
+
+    # 3. Cursor.
+    cursor = Path.home() / ".cursor" / "mcp.json"
+    if _strip_from_json(cursor, {"mcpServers": ["mnemon"]}):
+        summary.append(
+            f"  Cursor:        scrubbed mnemon entry in {cursor}"
+        )
+
+    # 4. Claude Desktop.
+    cdesktop = _claude_desktop_config_path()
+    if _strip_from_json(cdesktop, {"mcpServers": ["mnemon"]}):
+        summary.append(
+            f"  Claude Desktop: scrubbed mnemon entry in {cdesktop}"
+        )
+
+    # 5. Vault directory.
+    if not keep_vault:
+        mdir = _mnemon_dir()
+        if mdir.exists():
+            try:
+                shutil.rmtree(mdir)
+                summary.append(f"  Vault:         removed {mdir}")
+            except OSError as exc:
+                raise UninstallError(
+                    f"Failed to remove vault directory {mdir}: {exc}"
+                ) from exc
+
+    summary.extend(
+        [
+            "",
+            "Next steps:",
+            "  • Restart Claude Code / Cursor / Claude Desktop to drop the cached MCP connections.",
+            "  • Remove mnemon MCP entries from claude.ai and the Claude mobile app manually "
+            "(Settings → Connected Apps).",
+            "  • `pip uninstall mnemon-memory` to remove the Python package itself.",
+            "  • Re-run `mnemon setup` at any time to reinstall from scratch.",
+        ]
+    )
+    return "\n".join(summary)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -464,6 +464,37 @@ class TestDoctorCli:
         mock_doctor.assert_called_once_with(fail_on_warn=True)
 
 
+class TestUninstallCli:
+    @patch("mnemon.uninstall.uninstall")
+    def test_happy_path_passes_flags(self, mock_uninstall, capsys):
+        mock_uninstall.return_value = "uninstall output"
+        with patch(
+            "sys.argv",
+            ["mnemon", "uninstall", "--yes", "--keep-vault"],
+        ):
+            main()
+        mock_uninstall.assert_called_once_with(yes=True, keep_vault=True)
+        assert "uninstall output" in capsys.readouterr().out
+
+    @patch("mnemon.uninstall.uninstall")
+    def test_no_flags_defaults_are_false(self, mock_uninstall):
+        mock_uninstall.return_value = ""
+        with patch("sys.argv", ["mnemon", "uninstall"]):
+            main()
+        mock_uninstall.assert_called_once_with(yes=False, keep_vault=False)
+
+    @patch("mnemon.uninstall.uninstall")
+    def test_uninstall_error_surfaces_as_exit_1(self, mock_uninstall, capsys):
+        from mnemon.uninstall import UninstallError
+
+        mock_uninstall.side_effect = UninstallError("disk full")
+        with patch("sys.argv", ["mnemon", "uninstall", "--yes"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1
+        assert "uninstall failed: disk full" in capsys.readouterr().err
+
+
 class TestDowngradeCli:
     @patch("mnemon.downgrade.downgrade_local")
     def test_happy_path_passes_parsed_flags(self, mock_downgrade, capsys):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -26,6 +26,33 @@ from mnemon.setup import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _isolate_setup_env(monkeypatch, tmp_path_factory):
+    """Guard every setup test against real-world side effects.
+
+    - Point ``REMOTE_URL_FILE`` at a scratch path so the refuse-if-
+      remote-configured guard (added 2026-04-21) doesn't block local-
+      mode tests on a developer machine that has a real Fly install.
+    - Stub ``subprocess.run`` so local-mode setup's
+      ``claude mcp add --transport stdio`` call doesn't exec the real
+      Claude CLI. Tests that assert specific subprocess calls can still
+      use their own explicit ``patch("mnemon.setup.subprocess.run")``.
+    """
+    scratch = tmp_path_factory.mktemp("mnemon-remote-url-sentinel")
+    monkeypatch.setattr(
+        "mnemon.setup.REMOTE_URL_FILE", scratch / "remote_url"
+    )
+    monkeypatch.delenv("MNEMON_REMOTE_URL", raising=False)
+
+    import subprocess as _sp
+
+    def _ok(*_args, **_kw):
+        return MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr("mnemon.setup.subprocess.run", _ok)
+    yield
+
+
 class TestMcpConfig:
     def test_mcp_config_uses_current_python(self):
         config = _mcp_config()
@@ -110,19 +137,33 @@ class TestParseSetupArgs:
 
 class TestSetupClaudeCode:
     def test_creates_settings_file_local_mode_installs_local_hooks(self):
-        """P1b: local-mode setup installs UserPromptSubmit + Stop hooks
-        that dispatch via :class:`LocalMemoryClient`. P0 skipped them
-        because the hook client was HTTP-only; P1a fixed that.
+        """Local-mode setup: UserPromptSubmit + Stop hooks in settings.json,
+        MCP server registered via ``claude mcp add`` (NOT in settings.json —
+        Claude Code ignores settings.json.mcpServers for mnemon). The
+        2026-04-21 fix moved local-mode MCP registration to the CLI
+        registry for the same reason remote mode uses it.
+
         SessionStart is intentionally omitted in local mode — no remote
         machine to pre-warm."""
         with tempfile.TemporaryDirectory() as tmpdir:
             settings_path = Path(tmpdir) / ".claude" / "settings.json"
-            with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)):
+            with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)), \
+                 patch("mnemon.setup.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
                 result = setup_claude_code()
 
+            # `claude mcp add --transport stdio mnemon -- <py> -m mnemon serve`
+            add_calls = [c for c in mock_run.call_args_list if "add" in c.args[0]]
+            assert len(add_calls) == 1
+            cmd = add_calls[0].args[0]
+            assert cmd[:3] == ["claude", "mcp", "add"]
+            assert "--transport" in cmd and "stdio" in cmd
+            assert "serve" in cmd
+
+            # settings.json has hooks but NOT mcpServers.mnemon (moved to CLI registry)
             assert settings_path.exists()
             settings = json.loads(settings_path.read_text())
-            assert "mnemon" in settings["mcpServers"]
+            assert settings.get("mcpServers", {}).get("mnemon") is None
             assert "UserPromptSubmit" in settings["hooks"]
             assert "Stop" in settings["hooks"]
             assert "SessionStart" not in settings["hooks"]
@@ -258,6 +299,10 @@ class TestSetupClaudeCode:
             assert "https://test.fly.dev/health" in cmd
 
     def test_preserves_existing_settings(self):
+        """Non-mnemon mcpServers entries and unrelated top-level keys
+        must survive local-mode setup. The mnemon MCP registration
+        itself is in the `claude mcp` registry after the 2026-04-21
+        fix, not in settings.json."""
         with tempfile.TemporaryDirectory() as tmpdir:
             settings_path = Path(tmpdir) / ".claude" / "settings.json"
             settings_path.parent.mkdir(parents=True)
@@ -270,8 +315,8 @@ class TestSetupClaudeCode:
                 setup_claude_code()
 
             settings = json.loads(settings_path.read_text())
-            assert "other-server" in settings["mcpServers"]
-            assert "mnemon" in settings["mcpServers"]
+            assert settings["mcpServers"]["other-server"] == {"command": "other"}
+            assert "mnemon" not in settings["mcpServers"]
             assert settings["customSetting"] is True
 
 
@@ -690,6 +735,64 @@ class TestFailOnWarnPropagation:
 
         assert "doctor reported issues" in result
         assert "including warnings" in result
+
+
+class TestRefuseIfRemoteConfigured:
+    """Guard added 2026-04-21. Running local-mode setup while a remote
+    is configured leaves the machine in a split-brain state — MCP goes
+    local, but hooks keep reading ~/.mnemon/remote_url and route through
+    RemoteMemoryClient. The guard raises loudly so the user has to pick
+    a clean exit (downgrade or uninstall) first."""
+
+    def test_env_var_triggers_refuse(self, monkeypatch):
+        monkeypatch.setenv(
+            "MNEMON_REMOTE_URL", "https://x.fly.dev/mcp"
+        )
+        with pytest.raises(SetupError, match="Refusing local-mode"):
+            setup_claude_code()
+
+    def test_file_triggers_refuse(self, monkeypatch, tmp_path):
+        url_file = tmp_path / "remote_url"
+        url_file.write_text("https://x.fly.dev/mcp\n")
+        monkeypatch.setattr("mnemon.setup.REMOTE_URL_FILE", url_file)
+        with pytest.raises(SetupError, match="Refusing local-mode"):
+            setup_claude_code()
+
+    def test_refuse_error_points_at_recovery_commands(
+        self, monkeypatch, tmp_path
+    ):
+        url_file = tmp_path / "remote_url"
+        url_file.write_text("https://x.fly.dev/mcp\n")
+        monkeypatch.setattr("mnemon.setup.REMOTE_URL_FILE", url_file)
+        with pytest.raises(SetupError) as exc_info:
+            setup_claude_code()
+        msg = str(exc_info.value)
+        # Three recovery options should be mentioned explicitly so the
+        # user knows how to get out of the split-brain state.
+        assert "downgrade local" in msg
+        assert "uninstall" in msg
+        assert "--remote-url" in msg
+
+    def test_guard_does_not_fire_in_remote_mode(
+        self, monkeypatch, tmp_path
+    ):
+        """When --remote-url is passed, the guard should not fire even
+        if a remote is already configured — this is how a user
+        reconfigures to a DIFFERENT remote URL."""
+        url_file = tmp_path / "remote_url"
+        url_file.write_text("https://old.fly.dev/mcp\n")
+        mnemon_dir = tmp_path / ".mnemon"
+        monkeypatch.setattr("mnemon.setup.REMOTE_URL_FILE", url_file)
+        monkeypatch.setattr("mnemon.setup.MNEMON_DIR", mnemon_dir)
+        monkeypatch.setattr(
+            "mnemon.setup.LOCAL_TOKEN_FILE", mnemon_dir / "local_token"
+        )
+        with patch("mnemon.setup._preflight_remote_endpoint"), \
+             patch("mnemon.setup.Path.home", return_value=tmp_path):
+            # This call should not raise — remote-mode setup is fine
+            # when a remote is configured (that's the whole point of
+            # running setup in remote mode).
+            setup_claude_code(remote_url="https://new.fly.dev/mcp", token="t")
 
 
 class TestParseSkipDoctor:

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -1,0 +1,181 @@
+"""Tests for ``mnemon uninstall``.
+
+Covers: plan detection, confirmation behavior, JSON scrubbing (mcpServers
++ hooks), vault removal, --keep-vault preserves memories, --yes bypasses
+prompt, non-TTY stdin defaults to abort, claude CLI missing is tolerated.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+import pytest
+
+from mnemon import uninstall as un_mod
+from mnemon.uninstall import UninstallError, uninstall
+
+
+def _ok(returncode: int = 0) -> CompletedProcess:
+    return CompletedProcess(args=[], returncode=returncode, stdout="", stderr="")
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    monkeypatch.setattr("mnemon.uninstall.Path.home", lambda: tmp_path)
+    monkeypatch.setenv("MNEMON_VAULT_DIR", str(tmp_path / ".mnemon"))
+    yield
+
+
+def _seed_full_install(tmp_path, *, with_remote: bool = False) -> dict:
+    """Create a machine in a 'fully installed' state so we can assert
+    the uninstall scrubs every expected location."""
+    mdir = tmp_path / ".mnemon"
+    mdir.mkdir()
+    (mdir / "default.sqlite").write_bytes(b"stub vault")
+    if with_remote:
+        (mdir / "remote_url").write_text("https://x.fly.dev/mcp")
+        (mdir / "local_token").write_text("tok-abc")
+
+    # Claude Code settings.json with mnemon hooks + stale mcpServers
+    cc = tmp_path / ".claude" / "settings.json"
+    cc.parent.mkdir()
+    cc.write_text(json.dumps({
+        "mcpServers": {
+            "mnemon": {"command": "python", "args": ["-m", "mnemon", "serve"]},
+            "other": {"command": "keepme"},
+        },
+        "hooks": {
+            "UserPromptSubmit": [
+                {"matcher": "", "hooks": [
+                    {"type": "command",
+                     "command": "python -m mnemon.hooks.context_surfacing"},
+                ]},
+            ],
+            "Stop": [
+                {"matcher": "", "hooks": [
+                    {"type": "command",
+                     "command": "python -m mnemon.hooks.session_extractor"},
+                    {"type": "command", "command": "other-tool"},
+                ]},
+            ],
+        },
+        "customSetting": True,
+    }))
+
+    # Cursor
+    cursor = tmp_path / ".cursor" / "mcp.json"
+    cursor.parent.mkdir()
+    cursor.write_text(json.dumps({
+        "mcpServers": {
+            "mnemon": {"url": "https://x.fly.dev/mcp"},
+            "another": {"command": "keepme"},
+        }
+    }))
+
+    return {"mnemon_dir": mdir, "cc": cc, "cursor": cursor}
+
+
+class TestUninstallHappyPath:
+    def test_removes_everything_with_yes(self, tmp_path):
+        seeded = _seed_full_install(tmp_path)
+
+        with patch(
+            "mnemon.uninstall.subprocess.run", return_value=_ok(0)
+        ) as mock_run:
+            result = uninstall(yes=True)
+
+        # Vault gone
+        assert not seeded["mnemon_dir"].exists()
+        # claude mcp remove mnemon was called
+        assert any(
+            "remove" in c.args[0] and "mnemon" in c.args[0]
+            for c in mock_run.call_args_list
+        )
+        # Claude Code settings.json scrubbed of mnemon; other keys survive
+        cc_after = json.loads(seeded["cc"].read_text())
+        assert "mnemon" not in cc_after.get("mcpServers", {})
+        assert cc_after["mcpServers"]["other"] == {"command": "keepme"}
+        assert cc_after["customSetting"] is True
+        assert "UserPromptSubmit" not in cc_after.get("hooks", {})
+        # The Stop entry's non-mnemon inner hook should survive
+        stop = cc_after["hooks"]["Stop"]
+        assert len(stop) == 1
+        assert stop[0]["hooks"][0]["command"] == "other-tool"
+        # Cursor: mnemon gone, other survives
+        cursor_after = json.loads(seeded["cursor"].read_text())
+        assert "mnemon" not in cursor_after["mcpServers"]
+        assert cursor_after["mcpServers"]["another"] == {"command": "keepme"}
+
+        assert "Uninstall complete" in result
+        assert "Restart Claude Code" in result
+
+    def test_keep_vault_preserves_memories(self, tmp_path, capsys):
+        seeded = _seed_full_install(tmp_path)
+        with patch("mnemon.uninstall.subprocess.run", return_value=_ok(0)):
+            result = uninstall(yes=True, keep_vault=True)
+        # Vault directory still exists
+        assert seeded["mnemon_dir"].exists()
+        assert (seeded["mnemon_dir"] / "default.sqlite").exists()
+        # Client configs scrubbed
+        cc_after = json.loads(seeded["cc"].read_text())
+        assert "mnemon" not in cc_after.get("mcpServers", {})
+        assert "Uninstall complete" in result
+        # The "KEPT" marker is in the plan printed to stderr before the
+        # action, not the post-action summary.
+        assert "KEPT" in capsys.readouterr().err
+
+
+class TestConfirmation:
+    def test_no_tty_without_yes_aborts(self, tmp_path):
+        """Non-interactive context without --yes must not delete data."""
+        _seed_full_install(tmp_path)
+        with patch("mnemon.uninstall._confirm", return_value=False), \
+             patch("mnemon.uninstall.subprocess.run") as mock_run:
+            result = uninstall(yes=False)
+        assert "aborted" in result.lower()
+        # No destructive actions fired
+        mock_run.assert_not_called()
+        assert (tmp_path / ".mnemon").exists()
+
+    def test_interactive_yes_proceeds(self, tmp_path):
+        _seed_full_install(tmp_path)
+        with patch("mnemon.uninstall._confirm", return_value=True), \
+             patch("mnemon.uninstall.subprocess.run", return_value=_ok(0)):
+            result = uninstall(yes=False)
+        assert "Uninstall complete" in result
+        assert not (tmp_path / ".mnemon").exists()
+
+
+class TestClaudeCliMissing:
+    def test_tolerates_missing_claude_cli(self, tmp_path):
+        _seed_full_install(tmp_path)
+        with patch(
+            "mnemon.uninstall.subprocess.run", side_effect=FileNotFoundError
+        ):
+            result = uninstall(yes=True)
+        # Should still clean everything else
+        assert not (tmp_path / ".mnemon").exists()
+        assert "claude CLI not on PATH" in result
+
+
+class TestRemoteWarning:
+    def test_warns_when_remote_configured(self, tmp_path, capsys):
+        _seed_full_install(tmp_path, with_remote=True)
+        with patch("mnemon.uninstall.subprocess.run", return_value=_ok(0)):
+            uninstall(yes=True)
+        # Warning goes to stderr, not the return value
+        err = capsys.readouterr().err
+        assert "remote URL is configured" in err
+        assert "mnemon downgrade local" in err
+
+
+class TestEmptyMachine:
+    def test_nothing_installed_completes_cleanly(self, tmp_path):
+        """A machine with no mnemon state should complete with no
+        destructive actions and no errors."""
+        with patch("mnemon.uninstall.subprocess.run", return_value=_ok(0)):
+            result = uninstall(yes=True)
+        assert "Uninstall complete" in result


### PR DESCRIPTION
## Summary

Four follow-up fixes surfaced during validation of the P1 arc:

1. **Local `setup_claude_code` was silently non-functional** — wrote `mcpServers.mnemon` to `settings.json`, which Claude Code ignores. Now uses `claude mcp add --transport stdio` (same pattern remote mode uses).
2. **Split-brain guard** — `_refuse_if_remote_configured` raises loudly if you try to run local-mode setup while `~/.mnemon/remote_url` is configured. Points at three clean exits.
3. **"(coming soon)" string removed** from `_next_steps_block` — `mnemon upgrade web` has shipped.
4. **New `mnemon uninstall`** — wipes all mnemon state (vault + client configs + `claude mcp` registration). `--keep-vault` preserves memories. Warns loudly if a remote is configured (user should `mnemon downgrade local --destroy-fly-app` first).

## The bug that kicked this off

After merging P0 through P1e, validation surfaced that Claude Code was still pointing at the user's Fly deployment while Cursor had gone local. Root cause: local-mode setup wrote to `settings.json.mcpServers` — Claude Code doesn't read that for mnemon. Meanwhile `~/.mnemon/remote_url` was still present, so hooks kept dispatching over HTTP regardless. Two independent bugs combining into one confusing symptom.

The `claude mcp add --transport stdio` fix closes one. The refuse-when-remote guard closes the other by forcing the user to pick a clean exit (downgrade or uninstall) before running local setup.

## `mnemon uninstall` contract

Removes:
- `~/.mnemon/` (vault, remote_url, local_token, archive, models)
- `claude mcp remove mnemon`
- `~/.claude/settings.json` mnemon hook + mcpServers entries
- `~/.cursor/mcp.json` mnemon entry
- Claude Desktop mnemon entry

Does NOT touch:
- The `mnemon-memory` pip package (user's package manager)
- Fly.io apps / S3 bucket contents (user-owned)
- claude.ai / mobile MCP entries (Anthropic's UI — output tells the user to remove manually)

## Test plan

- [x] 4 new `TestRefuseIfRemoteConfigured` tests (env var + file sources, recovery commands surfaced, remote mode bypass).
- [x] 7 new `TestUninstall*` tests (happy path, `--keep-vault`, no-TTY abort, interactive confirm, claude CLI missing tolerated, remote-configured warning, empty-machine no-op).
- [x] 3 new `TestUninstallCli` tests.
- [x] Updated 2 stale assertions that checked the old `settings.json.mcpServers.mnemon` path.
- [x] Autouse fixture in `test_setup.py` isolates `REMOTE_URL_FILE` + `subprocess.run` from real-machine state.
- [x] Full suite: **591 tests pass** (4 integration outside sandbox).
- [ ] Manual validation after merge: `mnemon uninstall --yes` on the dev machine, then `pip install -e . && mnemon setup`, confirm Claude Code picks up the stdio registration.

## Follow-up (not in this PR)

Once this merges, PyPI release (version bump + publish) unblocks `mnemon upgrade web` for outside users — the embedded Dockerfile pins `mnemon-memory[server]=={version}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)