### PR TITLE
fix(uninstall,setup): detect claude.ai-synced mnemon MCP + warn loudly

### DIFF
--- a/src/mnemon/setup.py
+++ b/src/mnemon/setup.py
@@ -464,6 +464,31 @@ def setup_claude_code(*, remote_url: str | None = None, token: str | None = None
     if remote_url:
         lines.append("  SessionStart: pre-warm polling (90s background)")
 
+    # Warn if a claude.ai-synced mnemon entry exists. It can't be removed
+    # by any `claude mcp remove` command; it'll shadow the stdio
+    # registration we just added. Surface it here so the user knows the
+    # setup "succeeded" but Claude Code will still prefer the remote.
+    if remote_url is None:
+        from .uninstall import detect_claude_ai_mnemon
+
+        if detect_claude_ai_mnemon():
+            lines.append("")
+            lines.append(
+                "  ⚠ claude.ai-synced mnemon MCP registration detected."
+            )
+            lines.append(
+                "    Claude Code will PREFER that entry over the stdio "
+                "registration we just added."
+            )
+            lines.append(
+                "    To use local for Claude Code too: open claude.ai → "
+                "Settings → Connected Apps and remove the mnemon entry."
+            )
+            lines.append(
+                "    (Cursor + Claude Desktop are unaffected — they use "
+                "their own local configs.)"
+            )
+
     _write_json(settings_path, settings)
 
     return (

--- a/src/mnemon/uninstall.py
+++ b/src/mnemon/uninstall.py
@@ -91,6 +91,43 @@ def _claude_desktop_config_path() -> Path:
     return Path.home() / ".config" / "Claude" / "claude_desktop_config.json"
 
 
+def detect_claude_ai_mnemon() -> bool:
+    """True if ``claude mcp list`` shows a mnemon entry that originated
+    from the claude.ai web UI (Settings → Connected Apps).
+
+    Claude Code's CLI tags such entries with a ``claude.ai`` prefix:
+
+        claude.ai mnemon: https://mnemon-memory.fly.dev/mcp - ✓ Connected
+
+    Those registrations live in the user's Anthropic account (synced
+    from claude.ai), not in any local filesystem that
+    ``claude mcp remove --scope user`` can reach. This command can
+    detect them but cannot remove them — the user has to delete the
+    mnemon entry in claude.ai's web UI manually.
+
+    Returns False if the ``claude`` CLI isn't on PATH, list fails, or
+    no claude.ai-scoped mnemon entry is present.
+    """
+    try:
+        out = subprocess.run(
+            ["claude", "mcp", "list"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return False
+    if out.returncode != 0:
+        return False
+    for line in out.stdout.splitlines():
+        # Match exactly the prefix Claude Code emits for claude.ai-synced
+        # entries. Narrow match on purpose — don't false-positive on a
+        # server literally named "mnemon" in some other context.
+        if line.lstrip().startswith("claude.ai mnemon:") or line.lstrip().startswith("claude.ai mnemon "):
+            return True
+    return False
+
+
 def _detect_state() -> dict:
     """Return a dict describing what mnemon state is present on this
     machine. Used to build the confirmation prompt and the summary."""
@@ -109,6 +146,7 @@ def _detect_state() -> dict:
         "claude_desktop_config": _claude_desktop_config_path()
         if _claude_desktop_config_path().exists()
         else None,
+        "claude_ai_registration": detect_claude_ai_mnemon(),
     }
     return state
 
@@ -232,6 +270,27 @@ def uninstall(*, yes: bool = False, keep_vault: bool = False) -> str:
         )
         print(warning, file=sys.stderr)
 
+    # Warn loudly if there is a claude.ai-synced mnemon MCP registration.
+    # This command literally cannot remove it — it lives in the user's
+    # Anthropic account, not on this machine. Surfacing the detection
+    # prominently lets the user act on it; otherwise `claude mcp list`
+    # after uninstall would still show mnemon and they'd (reasonably)
+    # think the command didn't work.
+    if state["claude_ai_registration"]:
+        ca_warning = (
+            "⚠ claude.ai-synced mnemon MCP detected.\n"
+            "  `claude mcp list` shows a `claude.ai mnemon: …` entry. "
+            "This registration lives in your Anthropic account and is "
+            "synced to Claude Code from claude.ai — it CANNOT be removed "
+            "by `mnemon uninstall` or any `claude mcp remove` command.\n"
+            "  To finish the uninstall, open claude.ai → Settings → "
+            "Connected Apps and remove the mnemon entry there.\n"
+            "  If you leave it in place: it will shadow any local stdio "
+            "registration from a future `mnemon setup`, and Claude Code "
+            "will keep talking to the remote vault.\n"
+        )
+        print(ca_warning, file=sys.stderr)
+
     # Build the plan so the user knows what's about to happen.
     plan_lines = ["mnemon uninstall will remove:"]
     if state["mnemon_dir"] and not keep_vault:
@@ -324,8 +383,29 @@ def uninstall(*, yes: bool = False, keep_vault: bool = False) -> str:
             "",
             "Next steps:",
             "  • Restart Claude Code / Cursor / Claude Desktop to drop the cached MCP connections.",
-            "  • Remove mnemon MCP entries from claude.ai and the Claude mobile app manually "
-            "(Settings → Connected Apps).",
+        ]
+    )
+    # Promote the claude.ai note to its own bullet when we know one
+    # actually exists. Otherwise it reads as a hypothetical reminder
+    # and users skip it.
+    if state["claude_ai_registration"]:
+        summary.append(
+            "  • ⚠ REQUIRED: remove the mnemon MCP entry in claude.ai → "
+            "Settings → Connected Apps. `mnemon uninstall` cannot touch "
+            "claude.ai-synced registrations (they live in your Anthropic "
+            "account, not on this machine)."
+        )
+        summary.append(
+            "  • Then remove the mnemon entry in the Claude mobile app "
+            "(Settings → Connected Apps) if you use it."
+        )
+    else:
+        summary.append(
+            "  • If you use claude.ai or the Claude mobile app, remove "
+            "any mnemon entry there manually (Settings → Connected Apps)."
+        )
+    summary.extend(
+        [
             "  • `pip uninstall mnemon-memory` to remove the Python package itself.",
             "  • Re-run `mnemon setup` at any time to reinstall from scratch.",
         ]

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -737,6 +737,50 @@ class TestFailOnWarnPropagation:
         assert "including warnings" in result
 
 
+class TestClaudeAiShadowWarning:
+    """Local-mode setup_claude_code now surfaces a warning when a
+    claude.ai-synced mnemon MCP registration is detected. The stdio
+    registration the function just added will be shadowed by the
+    claude.ai one because Claude Code prefers the synced-from-account
+    source. Users need to know the setup technically succeeded but
+    Claude Code behavior won't reflect it until they remove the entry
+    in claude.ai's web UI."""
+
+    def test_warning_surfaced_when_claude_ai_entry_exists(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)), \
+                 patch("mnemon.uninstall.detect_claude_ai_mnemon", return_value=True):
+                result = setup_claude_code()
+        assert "claude.ai-synced mnemon MCP registration detected" in result
+        assert "Claude Code will PREFER" in result
+        assert "Cursor + Claude Desktop are unaffected" in result
+
+    def test_no_warning_when_no_claude_ai_entry(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)), \
+                 patch("mnemon.uninstall.detect_claude_ai_mnemon", return_value=False):
+                result = setup_claude_code()
+        assert "claude.ai-synced mnemon MCP registration detected" not in result
+
+    def test_no_warning_in_remote_mode(self):
+        """Remote-mode setup intentionally uses the HTTP MCP via
+        `claude mcp add`. It doesn't matter whether a claude.ai entry
+        also exists — we're explicitly in remote mode. No need for
+        the shadow warning."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mnemon_dir = Path(tmpdir) / ".mnemon"
+            with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)), \
+                 patch("mnemon.setup.MNEMON_DIR", mnemon_dir), \
+                 patch("mnemon.setup.LOCAL_TOKEN_FILE", mnemon_dir / "local_token"), \
+                 patch("mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"), \
+                 patch("mnemon.setup._preflight_remote_endpoint"), \
+                 patch("mnemon.uninstall.detect_claude_ai_mnemon", return_value=True):
+                result = setup_claude_code(
+                    remote_url="https://test.fly.dev/mcp", token="tok"
+                )
+        assert "claude.ai-synced mnemon MCP registration detected" not in result
+
+
 class TestRefuseIfRemoteConfigured:
     """Guard added 2026-04-21. Running local-mode setup while a remote
     is configured leaves the machine in a split-brain state — MCP goes

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -130,14 +130,25 @@ class TestUninstallHappyPath:
 
 class TestConfirmation:
     def test_no_tty_without_yes_aborts(self, tmp_path):
-        """Non-interactive context without --yes must not delete data."""
+        """Non-interactive context without --yes must not delete data.
+
+        The detect_claude_ai_mnemon() read-only probe (`claude mcp list`)
+        IS allowed to fire before the confirmation prompt — it's
+        informational. Only destructive subprocess calls (``claude mcp
+        remove``) must be skipped when the user aborts.
+        """
         _seed_full_install(tmp_path)
         with patch("mnemon.uninstall._confirm", return_value=False), \
-             patch("mnemon.uninstall.subprocess.run") as mock_run:
+             patch("mnemon.uninstall.subprocess.run", return_value=_ok(0)) as mock_run:
             result = uninstall(yes=False)
         assert "aborted" in result.lower()
-        # No destructive actions fired
-        mock_run.assert_not_called()
+        # Only the read-only detection probe (`claude mcp list`) is
+        # allowed. No `claude mcp remove` or other destructive calls.
+        destructive_calls = [
+            c for c in mock_run.call_args_list
+            if "remove" in (c.args[0] if c.args else [])
+        ]
+        assert destructive_calls == []
         assert (tmp_path / ".mnemon").exists()
 
     def test_interactive_yes_proceeds(self, tmp_path):
@@ -170,6 +181,98 @@ class TestRemoteWarning:
         err = capsys.readouterr().err
         assert "remote URL is configured" in err
         assert "mnemon downgrade local" in err
+
+
+class TestDetectClaudeAiMnemon:
+    """The `claude.ai mnemon` prefix in `claude mcp list` marks
+    registrations that came through claude.ai's web UI. They're synced
+    from the user's Anthropic account and can't be removed by any
+    `claude mcp remove` invocation. Detection lets us warn loudly."""
+
+    def test_matches_claude_ai_prefix(self):
+        from mnemon.uninstall import detect_claude_ai_mnemon
+
+        fake_out = (
+            "claude.ai mnemon: https://mnemon-memory.fly.dev/mcp - ✓ Connected\n"
+            "other-server: stdio\n"
+        )
+        with patch(
+            "mnemon.uninstall.subprocess.run",
+            return_value=CompletedProcess(
+                args=[], returncode=0, stdout=fake_out, stderr=""
+            ),
+        ):
+            assert detect_claude_ai_mnemon() is True
+
+    def test_does_not_match_user_scope_mnemon(self):
+        """A user-scope mnemon entry (from `claude mcp add`, not claude.ai)
+        is not a claude.ai registration. It starts with `mnemon:` alone,
+        no `claude.ai` prefix."""
+        from mnemon.uninstall import detect_claude_ai_mnemon
+
+        fake_out = "mnemon: stdio (command: python -m mnemon serve)\n"
+        with patch(
+            "mnemon.uninstall.subprocess.run",
+            return_value=CompletedProcess(
+                args=[], returncode=0, stdout=fake_out, stderr=""
+            ),
+        ):
+            assert detect_claude_ai_mnemon() is False
+
+    def test_claude_cli_missing_returns_false(self):
+        from mnemon.uninstall import detect_claude_ai_mnemon
+
+        with patch(
+            "mnemon.uninstall.subprocess.run",
+            side_effect=FileNotFoundError,
+        ):
+            assert detect_claude_ai_mnemon() is False
+
+    def test_list_nonzero_returns_false(self):
+        from mnemon.uninstall import detect_claude_ai_mnemon
+
+        with patch(
+            "mnemon.uninstall.subprocess.run",
+            return_value=CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="auth error"
+            ),
+        ):
+            assert detect_claude_ai_mnemon() is False
+
+
+class TestClaudeAiWarnings:
+    """When a claude.ai mnemon entry exists, uninstall output must
+    surface it prominently — both in the pre-confirmation plan (stderr)
+    and in the post-action summary (stdout/return value). A generic
+    'remove manually' line isn't enough; users need to know the tool
+    KNOWS there's one present."""
+
+    def test_warning_promoted_when_detected(self, tmp_path, capsys):
+        _seed_full_install(tmp_path)
+        with patch(
+            "mnemon.uninstall.detect_claude_ai_mnemon", return_value=True
+        ), patch("mnemon.uninstall.subprocess.run", return_value=_ok(0)):
+            result = uninstall(yes=True)
+
+        # Pre-action loud warning went to stderr
+        err = capsys.readouterr().err
+        assert "claude.ai-synced mnemon MCP detected" in err
+        # Post-action summary has the REQUIRED bullet
+        assert "REQUIRED" in result
+        assert "claude.ai → Settings → Connected Apps" in result
+
+    def test_no_warning_when_not_detected(self, tmp_path, capsys):
+        _seed_full_install(tmp_path)
+        with patch(
+            "mnemon.uninstall.detect_claude_ai_mnemon", return_value=False
+        ), patch("mnemon.uninstall.subprocess.run", return_value=_ok(0)):
+            result = uninstall(yes=True)
+
+        err = capsys.readouterr().err
+        assert "claude.ai-synced mnemon MCP detected" not in err
+        assert "REQUIRED" not in result
+        # The generic hypothetical reminder still appears
+        assert "If you use claude.ai" in result
 
 
 class TestEmptyMachine:


### PR DESCRIPTION
## Summary

Detects `claude.ai`-synced mnemon MCP registrations (from Settings → Connected Apps in claude.ai) and surfaces their presence loudly in both `mnemon uninstall` and `mnemon setup`. Neither command can remove them — they live in the user's Anthropic account, not on the machine. Before this fix, users who ran `mnemon uninstall --yes` then `claude mcp list` and still saw mnemon (as HTTPS) had no way to know why.

## Context

Found during Brian's validation of the P1 arc. After running `mnemon uninstall --yes && mnemon setup`, `claude mcp list` still showed `claude.ai mnemon: https://mnemon-memory.fly.dev/mcp - ✓ Connected`. Diagnosis chain:

1. `claude mcp add --scope user --transport http mnemon ...` on the test machine returned `MCP server mnemon already exists in user config` — so something was already there.
2. `claude mcp list` output had a `claude.ai` prefix we hadn't noticed — that's Claude Code's tag for registrations synced from claude.ai.
3. `mnemon uninstall` runs `claude mcp remove --scope user mnemon`, which only touches user-scope local config. The `claude.ai` scope is a different storage, synced from the Anthropic account.
4. The only way to remove a claude.ai-scoped entry is the claude.ai web UI.

## The fix

- `detect_claude_ai_mnemon()` — parses `claude mcp list` output for the `claude.ai mnemon:` prefix. Read-only.
- **uninstall**: loud stderr warning + a REQUIRED bullet at the top of the post-action summary's Next steps when detected. Without detection, the existing generic hypothetical reminder stays.
- **setup** (local Claude Code path only): warning appended to the claude-code block — "Claude Code will PREFER that entry over the stdio registration we just added. Cursor + Claude Desktop are unaffected."

Remote-mode setup intentionally uses HTTP MCP via `claude mcp add`, so it doesn't need this warning even when a claude.ai entry exists.

## Test plan

- [x] TestDetectClaudeAiMnemon (4 tests): matches prefix, doesn't match user-scope, tolerates missing CLI + non-zero exit.
- [x] TestClaudeAiWarnings (2 tests): warning promoted + REQUIRED bullet when detected; generic reminder when not.
- [x] TestClaudeAiShadowWarning in setup (3 tests): warning in local mode; absent in remote mode.
- [x] Updated `test_no_tty_without_yes_aborts` to allow the read-only detection probe while still gating destructive calls on confirmation.
- [x] Full suite: **600 tests pass** (4 integration outside sandbox).
- [ ] Manual on dev machine: run `mnemon uninstall` with claude.ai entry present, confirm the loud warning fires both pre-confirmation (stderr) and in the summary (stdout).

## Known limitations

- Detection depends on the literal `claude.ai` prefix in `claude mcp list` output. If Anthropic changes that format, detection silently breaks (returns False). Stable enough to rely on for now; worth revisiting if the Claude CLI output format changes.
- This is detection + warning only. We can't automate removal of claude.ai-scoped entries — that requires the user to visit claude.ai in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)