### PR TITLE
chore: bump version to 0.6.0rc1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)]()
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-compatible-blueviolet.svg)](https://modelcontextprotocol.io)
-[![PyPI](https://img.shields.io/badge/PyPI-v0.5.0-blue.svg)](https://pypi.org/project/mnemon-memory/)
+[![PyPI](https://img.shields.io/badge/PyPI-v0.6.0rc1-blue.svg)](https://pypi.org/project/mnemon-memory/)
 
 > One memory vault. Every MCP client. Self-hosted.
 >

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.5.0"
+version = "0.6.0rc1"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0rc1"


### PR DESCRIPTION
## Summary

First release candidate since 0.5.0, bundling the April 2026 simplification arc (#66–#76).

\`rc1\` rather than stable \`0.6.0\` so \`pip install mnemon-memory\` keeps returning 0.5.0 for default users until we've validated upgrade/downgrade against real Fly + AWS. \`pip install mnemon-memory==0.6.0rc1\` or \`--pre\` pulls the new build.

## Changes

- \`src/mnemon/__init__.py\` → \`__version__ = \"0.6.0rc1\"\`
- \`pyproject.toml\` → \`version = \"0.6.0rc1\"\`
- \`README.md\` PyPI badge → v0.6.0rc1

## Post-merge actions (manual)

\`\`\`bash
git checkout main && git pull
git tag v0.6.0rc1
git push origin v0.6.0rc1
python -m build
twine upload dist/mnemon_memory-0.6.0rc1*
\`\`\`

Then \`pip install mnemon-memory==0.6.0rc1\` picks up the new code for real testing.

## Test plan

- [x] Local suite: 600 tests pass.
- [x] \`python -c 'import mnemon; print(mnemon.__version__)'\` reports \`0.6.0rc1\`.
- [ ] After tag + publish: run through the Layer 3 e2e runbook against test-scoped Fly + S3.