### PR TITLE
fix: add rebuild CLI, embed on save, clearer Graph empty state

### DIFF
--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -88,7 +88,53 @@ def main() -> None:
         store = Store()
         doc_id = store.save(title=title, content=content, source_client="cli")
         print(f'Saved memory #{doc_id}: "{title}"')
+        try:
+            from .embedder import embed_document
+            doc = store.get(doc_id)
+            if doc:
+                embed_document(store, doc.hash, title, content)
+        except Exception as exc:  # noqa: BLE001
+            # Loud on the CLI — an interactive save that skipped embedding
+            # means vector search won't find this memory. Exit non-zero so
+            # scripts catch it; `mnemon rebuild` is the recovery path.
+            print(
+                f"Warning: embedding failed ({type(exc).__name__}: {exc}). "
+                f"Memory saved to vault but will not surface in vector "
+                f"search until `mnemon rebuild` runs.",
+                file=sys.stderr,
+            )
+            store.close()
+            sys.exit(2)
         store.close()
+
+    elif command == "rebuild":
+        # Re-embed every non-invalidated document. Surfaces per-doc
+        # failures so users hit real errors here instead of only seeing
+        # them whispered into server logs.
+        from .store import Store
+        try:
+            from .embedder import embed_document
+        except ImportError:
+            print("FastEmbed not installed. Run: pip install fastembed", file=sys.stderr)
+            sys.exit(1)
+        store = Store()
+        docs = store.timeline(10_000)
+        embedded = 0
+        failed = 0
+        for doc in docs:
+            try:
+                embed_document(store, doc.hash, doc.title, doc.content)
+                embedded += 1
+            except Exception as exc:  # noqa: BLE001
+                failed += 1
+                print(
+                    f"  embed failed: doc_id={doc.id} ({type(exc).__name__}: {exc})",
+                    file=sys.stderr,
+                )
+        print(f"Rebuild complete: {embedded} documents embedded, {failed} failed.")
+        store.close()
+        if failed:
+            sys.exit(1)
 
     elif command == "forget":
         if len(args) < 2 or not args[1].isdigit():
@@ -338,6 +384,8 @@ Local vault (development/server-side only):
   mnemon search <query>     Search local vault
   mnemon save <title> <c>   Save to local vault
   mnemon forget <id>        Soft-delete from local vault
+  mnemon rebuild            Re-embed every document (run after a model
+                            change, or to recover from skipped embeddings)
   mnemon sync push          Push local vault to S3
   mnemon sync pull          Pull vault from S3
   mnemon dashboard [port]   Launch web dashboard (default: 8503)

--- a/src/mnemon/dashboard/pages/3_Graph.py
+++ b/src/mnemon/dashboard/pages/3_Graph.py
@@ -5,7 +5,7 @@ import streamlit as st
 st.set_page_config(page_title="Memory Graph — mnemon", layout="wide")
 st.title("Memory Graph")
 
-from mnemon.dashboard.loaders import load_vectors_collapsed, load_umap_coords, load_related
+from mnemon.dashboard.loaders import load_vectors_collapsed, load_umap_coords, load_related, load_status
 from mnemon.dashboard.charts import make_graph_scatter, add_relation_edges
 
 CONTENT_TYPES = ["decision", "preference", "antipattern", "observation", "research", "project", "handoff", "note"]
@@ -15,13 +15,27 @@ CONTENT_TYPES = ["decision", "preference", "antipattern", "observation", "resear
 # points, which read as duplicates.
 vec_data = load_vectors_collapsed()
 if vec_data is None:
-    st.warning("No vectors found. Save some memories with embeddings first.")
+    # Disambiguate: empty vault vs. saved-but-unembedded memories. The
+    # second case is a silent-failure signal — tell the user how to fix it.
+    doc_count = load_status().get("total_documents", 0)
+    if doc_count == 0:
+        st.warning("No memories saved yet. Save a memory to get started.")
+    else:
+        st.warning(
+            f"{doc_count} memor{'y' if doc_count == 1 else 'ies'} saved but no vectors found — "
+            "the embedding step did not run or failed silently. "
+            "Run `mnemon doctor` to diagnose, then `mnemon rebuild` to re-embed."
+        )
     st.stop()
 
 vec_ids, vectors, doc_map = vec_data
 
 if len(vec_ids) < 5:
-    st.warning(f"Only {len(vec_ids)} vectors — need at least 5 for UMAP projection.")
+    st.warning(
+        f"Only {len(vec_ids)} vector{'' if len(vec_ids) == 1 else 's'} — "
+        "need at least 5 for a meaningful UMAP projection. "
+        "Add more memories and come back."
+    )
     st.stop()
 
 # Sidebar controls


### PR DESCRIPTION
## Summary

Three linked issues surfaced while testing the dashboard with a fresh single-memory vault (the Graph page showed "No vectors found" despite a saved memory):

- **`mnemon save` now embeds.** The CLI previously only wrote to SQLite — the embedding step was only wired up in the MCP/api paths, so CLI-saved memories were invisible to vector search and the Graph view. Now embeds inline after the insert; prints a loud stderr warning and exits with code 2 on failure so scripts catch it.
- **`mnemon rebuild` CLI added.** Three existing error messages (`api.py:144`, `server.py:178,397`, `vecstore.py:125,141`) referenced `mnemon rebuild` as the recovery path, but the CLI had no such subcommand — only the MCP tool `memory_rebuild` did. Added the CLI subcommand + usage-text entry, with per-doc failure surfacing to stderr.
- **Graph page empty states are now distinct.** Previously "No vectors found" was shown whether the vault was empty or had memories that silently failed to embed. Now:
  - 0 memories → "save a memory to get started"
  - N memories, 0 vectors → pointer to `mnemon doctor` + `mnemon rebuild`
  - Also fixed pluralization on the 5-vector-floor message.

## Test plan

- [x] `~/mnemon-smoke/bin/python -m pytest tests/test_cli.py tests/test_dashboard_loaders.py` → 44 + 14 passing. (One unrelated `TestServe` failure from a pre-release httpx in the smoke venv; not touched by this PR.)
- [x] End-to-end on a real Intel-Mac vault: `mnemon rebuild` re-embedded an existing orphaned memory and wrote `~/.mnemon/default.vec.npz`.
- [ ] Dashboard Graph page refresh shows the new "$N memories saved but no vectors found" copy when `.vec.npz` is deleted (reviewer sanity check).
- [ ] `mnemon save <t> <c>` with a broken embedder (e.g., no network for model download) exits with code 2 and writes a visible stderr warning (reviewer sanity check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)