### PR TITLE
chore: 0.6.0rc2 + Graph empty-state copy fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.6.0rc1"
+version = "0.6.0rc2"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.6.0rc1"
+__version__ = "0.6.0rc2"

--- a/src/mnemon/dashboard/pages/3_Graph.py
+++ b/src/mnemon/dashboard/pages/3_Graph.py
@@ -22,7 +22,7 @@ if vec_data is None:
         st.warning("No memories saved yet. Save a memory to get started.")
     else:
         st.warning(
-            f"{doc_count} memor{'y' if doc_count == 1 else 'ies'} saved but no vectors found — "
+            f"{doc_count} memor{'y' if doc_count == 1 else 'ies'} saved but no embeddings found — "
             "the embedding step did not run or failed silently. "
             "Run `mnemon doctor` to diagnose, then `mnemon rebuild` to re-embed."
         )
@@ -30,11 +30,14 @@ if vec_data is None:
 
 vec_ids, vectors, doc_map = vec_data
 
+# Post-collapse each point = one memory, so count in memory-units here —
+# otherwise the Graph page's "1 vector" contradicts `mnemon status`'s
+# "2 vectors" (raw chunk count: full doc + section per save).
 if len(vec_ids) < 5:
     st.warning(
-        f"Only {len(vec_ids)} vector{'' if len(vec_ids) == 1 else 's'} — "
-        "need at least 5 for a meaningful UMAP projection. "
-        "Add more memories and come back."
+        f"Only {len(vec_ids)} memor{'y' if len(vec_ids) == 1 else 'ies'} — "
+        "need at least 5 memories for a meaningful UMAP projection. "
+        "Add more and come back."
     )
     st.stop()
 


### PR DESCRIPTION
## Summary

- Bumps `pyproject.toml` + `src/mnemon/__init__.py` to **0.6.0rc2** so the CLI/dashboard fixes merged in #79 ship to PyPI.
- Folds in one extra copy fix surfaced during fresh-install retest:

## The copy fix

With 1 memory saved, `mnemon status` reported **2 vectors** (raw chunks — full doc + section, see `embedder.fragmentize`) while the Graph page reported **"Only 1 vector"**. Both are correct in their own terms — post-collapse each Graph point is one document (`load_vectors_collapsed` mean-pools chunks, loaders.py:218) — but using the same word "vector" for two different things reads as a contradiction.

- `3_Graph.py` 5-floor message: "Only {n} vector{s}" → **"Only {n} memor{y\|ies}"**
- `3_Graph.py` silent-failure message: "no vectors found" → **"no embeddings found"**
- Added a brief comment on the post-collapse counting convention so the next reader knows why Graph counts in memory-units.

## Test plan

- [x] `pytest tests/test_dashboard_loaders.py tests/test_cli.py -k "not TestServe"` → 58 passed.
- [x] End-to-end retest from fresh venv + fresh vault: install, `mnemon save`, `mnemon status` (2 vectors), `mnemon rebuild`, Graph page copy rendered correctly against 1-memory state.
- [ ] Reviewer: after merge, bump pre-release on PyPI and verify `pip install --pre --upgrade 'mnemon-memory[ui]'` into a clean venv picks up both this copy fix and the #79 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)