### PR TITLE
feat(upgrade): idempotent redeploy + test fix + 0.6.0rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.6.0rc3] - 2026-04-22
+
+### Fixed
+
+- **`mnemon upgrade web` is now idempotent.** Rerunning it against an
+  already-deployed Fly app (previously a hard failure / confusing
+  relaunch) now detects the existing app via `flyctl status` and
+  switches to a redeploy-only path: skip S3 push, volume create,
+  secrets set, vault seed, local vault archive, and MCP client
+  reconfigure — all of which are no-ops once the web tier is
+  established. Clients keep their URL and bearer token; the new image
+  is picked up on the next request. First-time deploy flow is
+  unchanged.
+
+  Upgrading to a newer mnemon version is now a two-command flow:
+  `pip install -U 'mnemon-memory[server]'` then
+  `mnemon upgrade web --app-name <existing-app>`.
+
+  Redeploy only requires `flyctl`; AWS creds and an S3 bucket are no
+  longer required for the version-bump case.
+
 ## [0.5.0] - 2026-04-14
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ mnemon upgrade web --app-name my-mnemon
 
 After it finishes, add `https://my-mnemon.fly.dev/mcp` to claude.ai and the Claude mobile app manually (Settings → Connectors / Connected Apps).
 
+### Upgrade to a newer version (already on web)
+
+Rerun the same command after `pip install -U mnemon-memory` — `upgrade web` is idempotent. If the Fly app already exists, it skips the first-time steps (S3 push, volume create, client reconfigure) and just redeploys with the new version pinned. Clients keep their URL and token; the new image is picked up on the next request.
+
+```bash
+pip install -U 'mnemon-memory[server]'
+mnemon upgrade web --app-name my-mnemon
+```
+
 ### Downgrade back to local
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.6.0rc2"
+version = "0.6.0rc3"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.6.0rc2"
+__version__ = "0.6.0rc3"

--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -357,11 +357,15 @@ Setup (configure MCP clients; use --remote-url for web mode):
   mnemon doctor             Run diagnostics (local or remote, auto-detected)
                             [--fail-on-warn] treat warnings as failures
 
-Upgrade local → web (deploys a Fly.io app + reconfigures every client):
+Upgrade local → web (deploys a Fly.io app + reconfigures every client).
+Idempotent: rerun to redeploy an existing app with the current mnemon
+version (clients keep their URL + token):
   mnemon upgrade web --app-name <name> [--s3-bucket NAME] [--token TOKEN]
                              [--region REGION] [--skip-doctor]
-                             Requires: flyctl, aws CLI with credentials,
-                             and an S3 bucket (MNEMON_S3_BUCKET or --s3-bucket).
+                             First-time deploy requires: flyctl, aws CLI
+                             with credentials, and an S3 bucket
+                             (MNEMON_S3_BUCKET or --s3-bucket). Redeploy
+                             against an existing app only needs flyctl.
 
 Downgrade web → local (pull remote vault back, reconfigure clients to stdio):
   mnemon downgrade local    [--destroy-fly-app] [--yes] [--app-name NAME]

--- a/src/mnemon/upgrade.py
+++ b/src/mnemon/upgrade.py
@@ -422,6 +422,101 @@ def _fly_seed_vault(app_name: str) -> None:
     )
 
 
+def _fly_app_exists(app_name: str) -> bool:
+    """Return True if a Fly app with this name is already deployed.
+
+    Uses ``flyctl status --app <name>`` — exit 0 means the app exists
+    and the authenticated user has access to it. Any non-zero exit
+    (not found, not authorized, network error) is treated as "does not
+    exist from our perspective" so the caller falls through to the
+    first-time launch path.
+    """
+    try:
+        subprocess.run(
+            ["flyctl", "status", "--app", app_name],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return True
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+
+
+# ── Redeploy (existing app, version bump) ────────────────────────────────────
+
+
+def _redeploy_web(
+    *,
+    app_name: str,
+    region: str,
+    mnemon_version: str,
+    skip_doctor: bool,
+) -> str:
+    """Redeploy an existing Fly mnemon app pinned to ``mnemon_version``.
+
+    Skips every first-time step that only makes sense for the local →
+    web migration (S3 push, volume create, secrets set, vault seed,
+    local vault archive, MCP client reconfigure). Those are all
+    idempotent no-ops on a redeploy — the web tier already owns the
+    state, clients already point at the same URL, and the Fly secrets
+    + volume persist across deploys.
+
+    Clients keep their existing URL (``https://{app_name}.fly.dev/mcp``)
+    and bearer token, so no client-side action is required — every MCP
+    connection picks up the new image on next request.
+    """
+    with tempfile.TemporaryDirectory(prefix="mnemon-redeploy-") as tdir:
+        workdir = Path(tdir)
+        (workdir / "Dockerfile").write_text(
+            _DOCKERFILE_TEMPLATE.format(mnemon_version=mnemon_version)
+        )
+        (workdir / "fly.toml").write_text(
+            _FLY_TOML_TEMPLATE.format(app_name=app_name, region=region)
+        )
+        _fly_deploy(workdir, app_name)
+
+    remote_url = f"https://{app_name}.fly.dev/mcp"
+    summary_lines = [
+        f"Redeploy complete: {remote_url}",
+        f"  Fly app:       {app_name}",
+        f"  Version:       mnemon-memory=={mnemon_version}",
+        "",
+        "No client-side changes needed — every MCP client keeps its URL",
+        "and bearer token. New image is picked up on the next request.",
+    ]
+
+    if skip_doctor:
+        return "\n".join(summary_lines)
+
+    # Doctor reads MNEMON_REMOTE_URL / MNEMON_LOCAL_TOKEN from env or
+    # from ~/.mnemon/{remote_url,local_token} — both were written by
+    # the original upgrade, so no env wiring is needed here.
+    import io
+
+    from .doctor import run_doctor
+
+    buf = io.StringIO()
+    print("", file=buf)
+    print("Running mnemon doctor against the remote...", file=buf)
+    try:
+        doctor_rc = run_doctor(out=buf, fail_on_warn=True)
+    except Exception as exc:  # noqa: BLE001
+        buf.write(
+            f"\n(doctor invocation crashed: {type(exc).__name__}: {exc})\n"
+        )
+        doctor_rc = 1
+
+    if doctor_rc != 0:
+        buf.write(
+            "\nNOTE: doctor reported issues against the redeployed remote. "
+            "The new image is live, but something in the remote-facing "
+            "config doesn't match. Investigate the failing check(s) above.\n"
+        )
+
+    return "\n".join(summary_lines) + "\n" + buf.getvalue()
+
+
 # ── Public entry point ───────────────────────────────────────────────────────
 
 
@@ -436,7 +531,12 @@ def upgrade_web(
 ) -> str:
     """Upgrade a local mnemon install to a web (Fly-hosted) deployment.
 
-    Steps (each aborts the rest on failure):
+    Idempotent: if ``app_name`` already exists on Fly (user is already
+    on web and is just bumping the mnemon version), switches to a
+    redeploy-only path — see :func:`_redeploy_web`. The full first-time
+    flow below only runs when the app doesn't yet exist.
+
+    First-time steps (each aborts the rest on failure):
       1. Validate flyctl + aws + bucket. Validate app-name shape + not
          colliding with MNEMON_PROD_APP_NAMES.
       2. Push local vault to S3 (establishes the durable backup before
@@ -455,6 +555,30 @@ def upgrade_web(
     """
     _validate_app_name(app_name)
     _require_flyctl()
+
+    # Resolve the mnemon version to pin in the Dockerfile — needed by
+    # both the first-time deploy and the redeploy path.
+    if mnemon_version is None:
+        from . import __version__
+
+        mnemon_version = __version__
+
+    # Idempotent redeploy: if the app already exists on Fly, the user
+    # is bumping the pinned mnemon version, not running the local → web
+    # migration. Skip S3 push, volume create, secret set, vault seed,
+    # local archive, and client reconfigure — none of those are needed
+    # when the web tier is already established.
+    #
+    # MNEMON_FLY_ENDPOINT_OVERRIDE short-circuits detection (Layer 2
+    # integration tests point at a local serve-remote; no "app" exists).
+    if not _fly_endpoint_override() and _fly_app_exists(app_name):
+        return _redeploy_web(
+            app_name=app_name,
+            region=region,
+            mnemon_version=mnemon_version,
+            skip_doctor=skip_doctor,
+        )
+
     _require_aws()
     bucket = _require_bucket(s3_bucket)
 
@@ -466,12 +590,6 @@ def upgrade_web(
 
     local_sqlite = vault_dir() / "default.sqlite"
     local_exists = local_sqlite.exists()
-
-    # Resolve the mnemon version to pin in the Dockerfile.
-    if mnemon_version is None:
-        from . import __version__
-
-        mnemon_version = __version__
 
     local_token = token or secrets.token_urlsafe(32)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -172,6 +172,10 @@ class TestSave:
     def test_save_with_title_and_content(self, MockStore, capsys):
         mock_store = MagicMock()
         mock_store.save.return_value = 7
+        # embed_document is called post-save; returning None from get()
+        # makes the `if doc:` branch skip embedding so this test doesn't
+        # depend on a FastEmbed ONNX model being in the cache.
+        mock_store.get.return_value = None
         MockStore.return_value = mock_store
 
         with patch("sys.argv", ["mnemon", "save", "My Title", "some", "content"]):

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -21,6 +21,7 @@ from mnemon import upgrade
 from mnemon.upgrade import (
     UpgradeError,
     _archive_local_vault,
+    _fly_app_exists,
     _validate_app_name,
     upgrade_web,
 )
@@ -220,6 +221,7 @@ class TestUpgradeWebHappyPath:
             ) as mock_run, \
             patch("mnemon.upgrade._require_flyctl"), \
             patch("mnemon.upgrade._require_aws"), \
+            patch("mnemon.upgrade._fly_app_exists", return_value=False), \
             patch(
                 "mnemon.upgrade._reconfigure_clients",
                 return_value=["claude-code"],
@@ -267,6 +269,7 @@ class TestUpgradeWebHappyPath:
         ), \
             patch("mnemon.upgrade._require_flyctl"), \
             patch("mnemon.upgrade._require_aws"), \
+            patch("mnemon.upgrade._fly_app_exists", return_value=False), \
             patch("mnemon.upgrade.subprocess.run") as mock_run:
             with pytest.raises(UpgradeError, match="S3 push failed"):
                 upgrade_web(
@@ -328,3 +331,198 @@ class TestRequireAwsSecrets:
                 upgrade._fly_set_secrets(
                     "mnemon-test", "some-token", "bucket"
                 )
+
+
+# ── _fly_app_exists detection ────────────────────────────────────────────────
+
+
+class TestFlyAppExists:
+    def test_returns_true_when_status_exits_zero(self):
+        with patch(
+            "mnemon.upgrade.subprocess.run",
+            return_value=_ok_completed(),
+        ) as mock_run:
+            assert _fly_app_exists("mnemon-test") is True
+        args, _kwargs = mock_run.call_args
+        assert args[0] == ["flyctl", "status", "--app", "mnemon-test"]
+
+    def test_returns_false_when_flyctl_missing(self):
+        with patch(
+            "mnemon.upgrade.subprocess.run", side_effect=FileNotFoundError
+        ):
+            assert _fly_app_exists("mnemon-test") is False
+
+    def test_returns_false_when_status_exits_nonzero(self):
+        err = CalledProcessError(
+            1, ["flyctl", "status"], stderr="Could not find App"
+        )
+        with patch("mnemon.upgrade.subprocess.run", side_effect=err):
+            assert _fly_app_exists("mnemon-test") is False
+
+
+# ── upgrade_web redeploy path (idempotent version bump) ──────────────────────
+
+
+class TestUpgradeWebRedeploy:
+    """When the Fly app already exists, ``upgrade_web`` takes a
+    redeploy-only path: skip S3 push, volume create, secrets set, seed,
+    archive, and client reconfigure. Just rebuild + deploy with the new
+    mnemon version pinned."""
+
+    def test_redeploy_skips_every_first_time_step(self, tmp_path, monkeypatch):
+        """Core contract of the idempotent path: when flyctl says the
+        app exists, none of the first-time-only helpers fire. Only
+        ``flyctl deploy`` runs."""
+        monkeypatch.setattr(
+            "mnemon.config.vault_dir", lambda: tmp_path / ".mnemon"
+        )
+
+        with patch("mnemon.upgrade._require_flyctl"), \
+            patch("mnemon.upgrade._fly_app_exists", return_value=True), \
+            patch("mnemon.upgrade._require_aws") as mock_req_aws, \
+            patch("mnemon.upgrade._require_bucket") as mock_req_bucket, \
+            patch("mnemon.sync.push") as mock_push, \
+            patch("mnemon.upgrade._fly_launch") as mock_launch, \
+            patch("mnemon.upgrade._fly_create_volume") as mock_vol, \
+            patch("mnemon.upgrade._fly_set_secrets") as mock_secrets, \
+            patch("mnemon.upgrade._fly_seed_vault") as mock_seed, \
+            patch("mnemon.upgrade._archive_local_vault") as mock_archive, \
+            patch("mnemon.upgrade._reconfigure_clients") as mock_reconfig, \
+            patch("mnemon.upgrade._fly_deploy") as mock_deploy:
+            result = upgrade_web(
+                app_name="mnemon-test-existing",
+                mnemon_version="0.6.0rc3",
+                skip_doctor=True,
+            )
+
+        # First-time-only helpers never called
+        mock_req_aws.assert_not_called()
+        mock_req_bucket.assert_not_called()
+        mock_push.assert_not_called()
+        mock_launch.assert_not_called()
+        mock_vol.assert_not_called()
+        mock_secrets.assert_not_called()
+        mock_seed.assert_not_called()
+        mock_archive.assert_not_called()
+        mock_reconfig.assert_not_called()
+
+        # Only flyctl deploy fired
+        mock_deploy.assert_called_once()
+        _workdir, app_arg = mock_deploy.call_args.args
+        assert app_arg == "mnemon-test-existing"
+
+        assert "Redeploy complete" in result
+        assert "https://mnemon-test-existing.fly.dev/mcp" in result
+        assert "0.6.0rc3" in result
+
+    def test_redeploy_pins_provided_version_in_dockerfile(
+        self, tmp_path, monkeypatch
+    ):
+        """The Dockerfile written to the tempdir pins the exact mnemon
+        version the caller passed — this is the version bump knob."""
+        monkeypatch.setattr(
+            "mnemon.config.vault_dir", lambda: tmp_path / ".mnemon"
+        )
+        captured: dict[str, str] = {}
+
+        def _capture(workdir: Path, app_name: str) -> None:
+            captured["dockerfile"] = (workdir / "Dockerfile").read_text()
+            captured["fly_toml"] = (workdir / "fly.toml").read_text()
+
+        with patch("mnemon.upgrade._require_flyctl"), \
+            patch("mnemon.upgrade._fly_app_exists", return_value=True), \
+            patch("mnemon.upgrade._fly_deploy", side_effect=_capture):
+            upgrade_web(
+                app_name="mnemon-test-existing",
+                mnemon_version="0.6.0rc3",
+                region="iad",
+                skip_doctor=True,
+            )
+
+        assert "mnemon-memory[server]==0.6.0rc3" in captured["dockerfile"]
+        assert 'app = "mnemon-test-existing"' in captured["fly_toml"]
+        assert 'primary_region = "iad"' in captured["fly_toml"]
+
+    def test_redeploy_ignores_missing_aws_and_bucket(
+        self, tmp_path, monkeypatch
+    ):
+        """Users bumping the version shouldn't need AWS creds or an S3
+        bucket — those are only required for the first-time vault seed.
+        A redeploy with neither set must succeed."""
+        monkeypatch.setattr(
+            "mnemon.config.vault_dir", lambda: tmp_path / ".mnemon"
+        )
+        monkeypatch.delenv("MNEMON_S3_BUCKET", raising=False)
+        monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+        monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+
+        with patch("mnemon.upgrade._require_flyctl"), \
+            patch("mnemon.upgrade._fly_app_exists", return_value=True), \
+            patch("mnemon.upgrade._fly_deploy"):
+            result = upgrade_web(
+                app_name="mnemon-test-existing",
+                mnemon_version="0.6.0rc3",
+                skip_doctor=True,
+            )
+
+        assert "Redeploy complete" in result
+
+    def test_redeploy_runs_doctor_when_not_skipped(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "mnemon.config.vault_dir", lambda: tmp_path / ".mnemon"
+        )
+
+        with patch("mnemon.upgrade._require_flyctl"), \
+            patch("mnemon.upgrade._fly_app_exists", return_value=True), \
+            patch("mnemon.upgrade._fly_deploy"), \
+            patch("mnemon.doctor.run_doctor", return_value=0) as mock_doctor:
+            result = upgrade_web(
+                app_name="mnemon-test-existing",
+                mnemon_version="0.6.0rc3",
+                skip_doctor=False,
+            )
+
+        mock_doctor.assert_called_once()
+        _args, kwargs = mock_doctor.call_args
+        assert kwargs.get("fail_on_warn") is True
+        assert "Redeploy complete" in result
+
+    def test_fly_endpoint_override_takes_first_time_path(
+        self, tmp_path, monkeypatch
+    ):
+        """Integration-test override bypasses the existence check so
+        Layer 2 harnesses still exercise the full orchestration. Even
+        if an existing app is "visible", the override means we skip
+        all flyctl and treat the endpoint as the remote."""
+        vdir = tmp_path / ".mnemon"
+        vdir.mkdir()
+        (vdir / "default.sqlite").write_bytes(b"seeded")
+        monkeypatch.setattr("mnemon.config.vault_dir", lambda: vdir)
+        monkeypatch.setenv(
+            "MNEMON_FLY_ENDPOINT_OVERRIDE", "http://localhost:8502/mcp"
+        )
+
+        with patch(
+            "mnemon.sync.push",
+            return_value={"pushed": [], "errors": []},
+        ), \
+            patch("mnemon.upgrade._require_aws"), \
+            patch(
+                "mnemon.upgrade._fly_app_exists", return_value=True
+            ) as mock_exists, \
+            patch(
+                "mnemon.upgrade._reconfigure_clients",
+                return_value=[],
+            ), \
+            patch("mnemon.upgrade._fly_deploy") as mock_deploy, \
+            patch("mnemon.upgrade.subprocess.run"):
+            result = upgrade_web(
+                app_name="mnemon-test",
+                s3_bucket="test-bucket",
+                skip_doctor=True,
+            )
+
+        # Override path doesn't even ask — redeploy branch never reached
+        mock_exists.assert_not_called()
+        mock_deploy.assert_not_called()
+        assert "http://localhost:8502/mcp" in result


### PR DESCRIPTION
## Summary

- **`mnemon upgrade web` is now idempotent.** Rerunning it against an already-deployed Fly app detects the existing app via `flyctl status` and switches to a redeploy-only path: skip S3 push, volume create, secrets set, vault seed, local vault archive, and MCP client reconfigure. Clients keep their URL and bearer token; the new image is picked up on the next request.
- Upgrading to a newer mnemon version is now a two-command flow: `pip install -U 'mnemon-memory[server]'` then `mnemon upgrade web --app-name <existing-app>`.
- Redeploy only requires `flyctl`; AWS creds and an S3 bucket are no longer required for the version-bump case.
- First-time deploy flow is unchanged. `MNEMON_FLY_ENDPOINT_OVERRIDE` still short-circuits detection so Layer 2 integration tests behave identically.
- Pre-existing test fix: `test_cli.py::TestSave::test_save_with_title_and_content` was failing on main because it did not mock `embed_document` (added in #79). Mocked `store.get` to return None so the embed branch skips cleanly.
- Version bump to `0.6.0rc3` + CHANGELOG.

## Motivation

Found while trying to deploy rc2 to the existing `mnemon-memory` Fly app. The simplification arc (#66 through #71) introduced `upgrade web` as a one-shot local to web migration; there was no command for "I'm already on web, just bump the version." The workaround (write a scratch Dockerfile + fly.toml + run `flyctl deploy`) was more friction than a version bump should require. This makes `mnemon upgrade web` the single command for both paths.

## Test plan

- [x] `pytest tests/test_upgrade.py` — 30 passed (22 existing + 8 new)
- [x] `pytest tests/test_cli.py` — 46 passed (includes the fixed test)
- [x] Full suite: 608 passed, 4 sandbox-only errors in `test_integration_remote.py` (port-bind permission, unrelated)
- [ ] Layer 3 smoke: merge, `pip install -U 'mnemon-memory[server]==0.6.0rc3'`, `mnemon upgrade web --app-name mnemon-memory`, verify `https://mnemon-memory.fly.dev` serves rc3 and existing MCP clients still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)