### PR TITLE
feat(setup): /health warm-keeper hook for self-hosted Fly users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Mid-session disconnects on Fly when `auto_stop_machines = "stop"`.**
+  `mnemon setup` (any target with `--remote-url`) now installs a
+  lightweight `/health` warm-keeper as the first `UserPromptSubmit`
+  hook. It pings the Fly app on every prompt, resetting Fly's idle
+  timer so the machine stays warm during active Claude Code sessions
+  and wakes on the first prompt after idle. Independent of MCP session
+  state, so it works even after a cold-stop has invalidated the
+  `Mcp-Session-Id` (which the existing context-surfacing hook's MCP
+  call cannot recover from). `|| true` ensures a slow Fly wake never
+  blocks the user's prompt.
+
+  Previously: machine autostops after ~5 min idle, the open MCP
+  Streamable HTTP session goes stale, and Claude Code's MCP UI keeps
+  showing "connected" while every subsequent tool call returns 404.
+
 ## [0.6.0rc3] - 2026-04-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -177,15 +177,21 @@ Memories with access activity decay slower — each access extends the effective
 
 ## Claude Code Hooks
 
-When configured via `mnemon setup`, three hooks are installed on Claude Code:
+When configured via `mnemon setup`, the following hooks are installed on Claude Code:
 
-| Hook | Event | Timeout | Description |
-|------|-------|---------|-------------|
-| Context surfacing | `UserPromptSubmit` | 8s | Searches vault and injects relevant memories as context |
-| Session extractor | `Stop` | 30s | Extracts decisions, preferences, and observations from the transcript |
-| Handoff generator | `Stop` | 30s | Creates a session summary for the next session |
+| Hook | Event | Timeout | Mode | Description |
+|------|-------|---------|------|-------------|
+| Health warm-keeper | `UserPromptSubmit` | 40s | remote only | `curl /health` to wake/keep the Fly machine warm. Runs first so the MCP call below has a warm machine. |
+| Context surfacing | `UserPromptSubmit` | 8s | both | Searches vault and injects relevant memories as context |
+| Session pre-warm | `SessionStart` | 90s | remote only | Polls `/health` for up to 60s in the background so the first prompt of the session lands on a warm machine |
+| Session extractor | `Stop` | 30s | both | Extracts decisions, preferences, and observations from the transcript |
+| Handoff generator | `Stop` | 30s | both | Creates a session summary for the next session |
 
 The extractor and handoff generator use LLM-based extraction when `mnemon[llm]` is installed, with regex/heuristic fallback otherwise.
+
+### Why a warm-keeper if Fly auto-stops?
+
+A self-hosted mnemon Fly app with `auto_stop_machines = "stop"` (the default in `fly.toml.example`) will autostop after a few minutes of idle. The warm-keeper resets Fly's idle timer on every prompt, so the machine stays warm during an active Claude Code session and only autostops once you've been idle for a while. Cost stays the same — Fly bills only running time — but you get reliable mid-session access without paying for an always-on machine. The `|| true` ensures a slow Fly cold-start never blocks your prompt.
 
 ## Uninstall
 

--- a/src/mnemon/setup.py
+++ b/src/mnemon/setup.py
@@ -61,23 +61,53 @@ def _mcp_config() -> dict:
 def _hooks_config(remote_url: str | None = None) -> dict:
     """Generate Claude Code hooks config.
 
-    When ``remote_url`` is provided, adds a SessionStart polling hook that
-    pre-warms the Fly machine so subsequent hooks don't pay cold-start
-    latency. The polling hook runs in the background and exits 0 in all
-    cases — it never blocks session startup.
+    When ``remote_url`` is provided:
+
+    - Adds a SessionStart polling hook that pre-warms the Fly machine so
+      subsequent hooks don't pay cold-start latency. Runs up to 60s in
+      the background, exits 0 in all cases.
+    - Prepends a UserPromptSubmit ``/health`` warm-keeper that resets
+      Fly's idle timer on every prompt. Runs *before* context_surfacing
+      so Fly is awake before the MCP call. Uses ``curl ... || true`` so
+      a slow wake never blocks the prompt. Independent of MCP session
+      state — it works even after a cold-stop has invalidated the
+      Mcp-Session-Id, which context_surfacing's MCP call cannot.
     """
     py = _python_path()
+    user_prompt_hooks: list[dict] = []
+
+    if remote_url:
+        # Extract base URL (strip /mcp suffix for health endpoint)
+        base_url = remote_url.rstrip("/")
+        if base_url.endswith("/mcp"):
+            base_url = base_url[:-4]
+        health_url = f"{base_url}/health"
+
+        # Warm-keeper: ping /health on every prompt. Resets Fly idle timer
+        # so the machine doesn't autostop mid-session, and wakes it on
+        # first prompt after idle. `|| true` ensures a slow wake never
+        # blocks the prompt.
+        user_prompt_hooks.append(
+            {
+                "type": "command",
+                "command": f"curl -fs --max-time 35 {health_url} > /dev/null || true",
+                "timeout": 40,
+            }
+        )
+
+    user_prompt_hooks.append(
+        {
+            "type": "command",
+            "command": f"{py} -m mnemon.hooks.context_surfacing",
+            "timeout": 8,
+        }
+    )
+
     hooks: dict = {
         "UserPromptSubmit": [
             {
                 "matcher": "",
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": f"{py} -m mnemon.hooks.context_surfacing",
-                        "timeout": 8,
-                    },
-                ],
+                "hooks": user_prompt_hooks,
             },
         ],
         "Stop": [
@@ -100,12 +130,6 @@ def _hooks_config(remote_url: str | None = None) -> dict:
     }
 
     if remote_url:
-        # Extract base URL (strip /mcp suffix for health endpoint)
-        base_url = remote_url.rstrip("/")
-        if base_url.endswith("/mcp"):
-            base_url = base_url[:-4]
-        health_url = f"{base_url}/health"
-
         hooks["SessionStart"] = [
             {
                 "matcher": "",

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -76,6 +76,22 @@ class TestMcpConfig:
         assert "https://example.fly.dev/health" in cmd
         assert "curl" in cmd
 
+    def test_hooks_config_local_mode_has_no_warmkeeper(self):
+        hooks = _hooks_config()
+        ups = hooks["UserPromptSubmit"][0]["hooks"]
+        assert len(ups) == 1
+        assert "context_surfacing" in ups[0]["command"]
+
+    def test_hooks_config_remote_mode_prepends_health_warmkeeper(self):
+        hooks = _hooks_config(remote_url="https://example.fly.dev/mcp")
+        ups = hooks["UserPromptSubmit"][0]["hooks"]
+        assert len(ups) == 2
+        warm = ups[0]
+        assert "curl" in warm["command"]
+        assert "https://example.fly.dev/health" in warm["command"]
+        assert "|| true" in warm["command"]
+        assert "context_surfacing" in ups[1]["command"]
+
 
 class TestEnsureRemoteUrl:
     def test_writes_url_file(self, tmp_path):


### PR DESCRIPTION
## Summary

- Adds a lightweight `curl /health` hook as the first `UserPromptSubmit` entry when `mnemon setup` is run with `--remote-url`. Pings Fly on every prompt, resetting the idle timer so an `auto_stop_machines = \"stop\"` deployment stays warm during active Claude Code sessions.
- Independent of MCP session state — works even after a cold-stop invalidates the `Mcp-Session-Id`, which the existing `context_surfacing` hook's MCP call cannot.
- `|| true` ensures a slow Fly wake never blocks the user's prompt.

## Why

Today's failure mode: Fly autostops after ~5 min idle, the open MCP Streamable HTTP session goes stale, and Claude Code's MCP UI keeps showing \"connected\" while every subsequent tool call returns 404. The warm-keeper closes that gap by keeping the machine alive across an active session.

Companion PR `feat/persist-mcp-sessions` (in progress) addresses the deeper bug: MCP session IDs not surviving cold-stops at all. This PR ships the immediate workaround so existing users benefit on next `pip install -U` + `mnemon setup`.

## Test plan

- [x] `pytest tests/test_setup.py` passes (60 tests, including 2 new)
- [x] `pytest` full suite passes (614 tests)
- [ ] Verify on Brian's live Fly app after merge: settings.json gets the new hook on `mnemon setup claude-code --remote-url <URL>`, `fly logs` shows `/health` hits per prompt, machine doesn't autostop mid-session
- [ ] Verify local-mode setup unchanged (no warm-keeper installed when `--remote-url` omitted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)