### PR TITLE
feat(server): persist MCP sessions across process restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Persistent MCP Streamable HTTP sessions across process restarts.**
+  Issued `Mcp-Session-Id` values are now stored in SQLite (default at
+  `<vault_dir>/mcp_sessions.sqlite`, 7-day TTL). When a request bearing
+  a previously-issued session ID arrives at a fresh process — for
+  example after a Fly cold-stop, a redeploy, or any other restart — the
+  server transparently resumes the session instead of returning 404,
+  by spawning a new transport keyed to the same ID and running the MCP
+  app `stateless=True` so the server-side session is born already-
+  initialized. The client sees no break.
+
+  Pairs with the `/health` warm-keeper hook from the previous release:
+  the hook minimizes the *frequency* of cold-stops during active use,
+  this change handles the *consequence* when one happens anyway. With
+  both shipped, mnemon survives Fly auto-stop without the "MCP UI says
+  connected, every tool call returns 404" failure mode.
+
+  Caveat: resumed sessions are stateless on the server side. Mnemon
+  uses no client-capability-gated features (sampling, elicitation,
+  roots), so this is a no-op for our toolset, but third-party forks
+  adding those features will need to re-handshake explicitly.
+
 ### Fixed
 
 - **Mid-session disconnects on Fly when `auto_stop_machines = "stop"`.**

--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ The extractor and handoff generator use LLM-based extraction when `mnemon[llm]` 
 
 A self-hosted mnemon Fly app with `auto_stop_machines = "stop"` (the default in `fly.toml.example`) will autostop after a few minutes of idle. The warm-keeper resets Fly's idle timer on every prompt, so the machine stays warm during an active Claude Code session and only autostops once you've been idle for a while. Cost stays the same — Fly bills only running time — but you get reliable mid-session access without paying for an always-on machine. The `|| true` ensures a slow Fly cold-start never blocks your prompt.
 
+### What if a cold-stop happens anyway?
+
+The server persists every issued MCP session ID to `<vault_dir>/mcp_sessions.sqlite` (7-day TTL). When a request bearing a known-but-not-in-memory session ID arrives at a fresh process — typical after a cold-stop or redeploy — the session is transparently resumed: a new transport is spawned with the same ID, and the underlying `ServerSession` is born already-initialized so tool calls succeed without a re-handshake. The MCP client sees no break in continuity. This is the safety net under the warm-keeper, not a replacement for it.
+
 ## Uninstall
 
 Remove mnemon state from this machine. Nothing user-owned in the cloud is touched.

--- a/src/mnemon/persistent_sessions.py
+++ b/src/mnemon/persistent_sessions.py
@@ -1,0 +1,315 @@
+"""Persistent MCP Streamable HTTP session storage.
+
+When a Fly.io machine running mnemon auto-stops on idle, the in-memory
+session dict in ``StreamableHTTPSessionManager._server_instances`` is
+lost. After the machine wakes, any client request bearing a previously-
+issued ``Mcp-Session-Id`` header gets a 404 (per the MCP spec — but the
+spec also says clients SHOULD reinit on 404, which Claude Code's MCP
+client does not reliably do, so the symptom is "MCP UI says connected
+but every tool call fails").
+
+This module sidesteps that by persisting issued session IDs to SQLite,
+so a known-but-not-in-memory session can be transparently resumed on
+the new process. The resumed session is born with ``stateless=True``,
+which makes the underlying ``ServerSession`` skip the init handshake
+and accept tool calls immediately. mnemon does not use any client-
+capability-gated features (sampling, elicitation, roots), so the
+absence of negotiated client capabilities on a resumed session is a
+no-op for our toolset.
+
+The complement on the client side is the ``/health`` warm-keeper hook
+installed by ``mnemon setup`` (see ``setup.py:_hooks_config``). The
+hook keeps Fly warm during active sessions; this module catches the
+edge case where the machine *did* cold-stop anyway (long idle, manual
+stop, deploy).
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+import anyio
+from anyio.abc import TaskStatus
+from mcp.server.lowlevel.server import Server as MCPServer
+from mcp.server.streamable_http import (
+    MCP_SESSION_ID_HEADER,
+    EventStore,
+    StreamableHTTPServerTransport,
+)
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from mcp.server.transport_security import TransportSecuritySettings
+from starlette.requests import Request
+from starlette.types import Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TTL_SECONDS = 7 * 24 * 3600
+
+
+class SessionStore:
+    """SQLite-backed registry of issued MCP Streamable HTTP session IDs.
+
+    Stores ``(session_id, created_at, last_active_at)`` for every session
+    the manager hands out. Entries older than ``ttl_seconds`` are
+    considered expired and treated as unknown.
+
+    The store deliberately holds *no* per-session capability or
+    handshake state — resumed sessions are born stateless on the server
+    side, so there is nothing to persist beyond the ID itself.
+    """
+
+    def __init__(
+        self,
+        db_path: Path | str,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    ) -> None:
+        self.db_path = Path(db_path)
+        self.ttl_seconds = ttl_seconds
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        # isolation_level=None puts SQLite in autocommit; each statement
+        # commits on its own. Suits the single-statement ops below.
+        return sqlite3.connect(str(self.db_path), isolation_level=None)
+
+    def _init_schema(self) -> None:
+        with self._connect() as db:
+            db.execute("PRAGMA journal_mode=WAL")
+            db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mcp_transport_sessions (
+                    session_id TEXT PRIMARY KEY,
+                    created_at REAL NOT NULL,
+                    last_active_at REAL NOT NULL
+                )
+                """
+            )
+
+    def register(self, session_id: str) -> None:
+        """Persist a newly-issued session ID (idempotent)."""
+        now = time.time()
+        with self._connect() as db:
+            db.execute(
+                "INSERT OR IGNORE INTO mcp_transport_sessions"
+                "(session_id, created_at, last_active_at) VALUES (?, ?, ?)",
+                (session_id, now, now),
+            )
+
+    def is_known(self, session_id: str) -> bool:
+        """True if the session ID was issued and is not expired."""
+        cutoff = time.time() - self.ttl_seconds
+        with self._connect() as db:
+            row = db.execute(
+                "SELECT 1 FROM mcp_transport_sessions "
+                "WHERE session_id = ? AND last_active_at > ?",
+                (session_id, cutoff),
+            ).fetchone()
+        return row is not None
+
+    def touch(self, session_id: str) -> None:
+        """Update last-active timestamp on activity."""
+        with self._connect() as db:
+            db.execute(
+                "UPDATE mcp_transport_sessions SET last_active_at = ? "
+                "WHERE session_id = ?",
+                (time.time(), session_id),
+            )
+
+    def expire_old(self) -> int:
+        """Delete entries past TTL. Returns count deleted."""
+        cutoff = time.time() - self.ttl_seconds
+        with self._connect() as db:
+            cur = db.execute(
+                "DELETE FROM mcp_transport_sessions WHERE last_active_at <= ?",
+                (cutoff,),
+            )
+            return cur.rowcount
+
+    def count(self) -> int:
+        """Total persisted (non-expired) sessions. Used by tests + diagnostics."""
+        cutoff = time.time() - self.ttl_seconds
+        with self._connect() as db:
+            row = db.execute(
+                "SELECT COUNT(*) FROM mcp_transport_sessions "
+                "WHERE last_active_at > ?",
+                (cutoff,),
+            ).fetchone()
+        return int(row[0]) if row else 0
+
+
+class _PersistingInstanceDict(dict[str, StreamableHTTPServerTransport]):
+    """Dict subclass that ``register()``s every key on assignment.
+
+    Replaces ``StreamableHTTPSessionManager._server_instances`` so that
+    every newly-minted session ID is durably persisted at the moment it
+    enters the in-memory registry — without us having to reach into the
+    SDK's session-creation code path.
+    """
+
+    def __init__(self, store: SessionStore) -> None:
+        super().__init__()
+        self._store = store
+
+    def __setitem__(self, key: str, value: StreamableHTTPServerTransport) -> None:
+        super().__setitem__(key, value)
+        try:
+            self._store.register(key)
+        except Exception:  # noqa: BLE001
+            # Persistence failure should not block session use — log and
+            # continue; the session will still work in-memory, just won't
+            # survive a restart. Hard-failing here would lose the request.
+            logger.exception("Failed to persist session %s", key)
+
+
+class PersistentSessionManager(StreamableHTTPSessionManager):
+    """Session manager that resumes sessions across process restarts.
+
+    Behavior overlay on the upstream manager:
+
+    1. ``_server_instances`` is replaced with a dict that auto-persists
+       every assignment, so newly-issued session IDs land in SQLite the
+       moment they're handed out.
+    2. ``_handle_stateful_request`` is overridden to add a resume branch:
+       a request with an unknown-in-memory but known-in-SQLite session
+       ID is served by spawning a fresh transport keyed to the same ID,
+       running the MCP app with ``stateless=True`` so the server-side
+       session is born already-initialized and tool calls succeed
+       without a handshake round-trip.
+
+    The upstream new-session and 404 paths are otherwise untouched.
+    """
+
+    def __init__(
+        self,
+        app: MCPServer[Any, Any],
+        *,
+        session_store: SessionStore,
+        event_store: EventStore | None = None,
+        json_response: bool = False,
+        stateless: bool = False,
+        security_settings: TransportSecuritySettings | None = None,
+        retry_interval: int | None = None,
+        session_idle_timeout: float | None = None,
+    ) -> None:
+        super().__init__(
+            app=app,
+            event_store=event_store,
+            json_response=json_response,
+            stateless=stateless,
+            security_settings=security_settings,
+            retry_interval=retry_interval,
+            session_idle_timeout=session_idle_timeout,
+        )
+        self._session_store = session_store
+        self._server_instances = _PersistingInstanceDict(session_store)
+
+    async def _handle_stateful_request(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        request = Request(scope, receive)
+        session_id = request.headers.get(MCP_SESSION_ID_HEADER)
+
+        # In-memory hit: refresh persistence + delegate to upstream.
+        if session_id is not None and session_id in self._server_instances:
+            self._session_store.touch(session_id)
+            await super()._handle_stateful_request(scope, receive, send)
+            return
+
+        # Persisted but not in memory: this is the resume case (post
+        # cold-start, redeploy, or process restart).
+        if session_id is not None and self._session_store.is_known(session_id):
+            logger.info("Resuming persisted MCP session %s", session_id)
+            await self._resume_session(session_id, scope, receive, send)
+            return
+
+        # Either a brand-new session (no header) or an unknown session
+        # ID we never issued / has expired. Upstream handles both — new
+        # session creation will write through _PersistingInstanceDict.
+        await super()._handle_stateful_request(scope, receive, send)
+
+    async def _resume_session(
+        self,
+        session_id: str,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        """Reconstruct an in-memory transport for ``session_id`` and dispatch.
+
+        Mirrors the new-session path in upstream ``_handle_stateful_request``
+        but reuses the supplied session_id instead of minting a fresh one
+        and runs the MCP app stateless so the server-side ServerSession
+        is born already-initialized.
+        """
+        async with self._session_creation_lock:
+            # Race guard: another concurrent request may have already
+            # resumed this session while we were waiting for the lock.
+            if session_id in self._server_instances:
+                self._session_store.touch(session_id)
+                await super()._handle_stateful_request(scope, receive, send)
+                return
+
+            transport = StreamableHTTPServerTransport(
+                mcp_session_id=session_id,
+                is_json_response_enabled=self.json_response,
+                event_store=self.event_store,
+                security_settings=self.security_settings,
+                retry_interval=self.retry_interval,
+            )
+            self._server_instances[session_id] = transport
+            self._session_store.touch(session_id)
+
+            async def run_server(
+                *, task_status: TaskStatus[None] = anyio.TASK_STATUS_IGNORED
+            ) -> None:
+                async with transport.connect() as streams:
+                    read_stream, write_stream = streams
+                    task_status.started()
+                    try:
+                        idle_scope = anyio.CancelScope()
+                        if self.session_idle_timeout is not None:
+                            idle_scope.deadline = (
+                                anyio.current_time() + self.session_idle_timeout
+                            )
+                            transport.idle_scope = idle_scope
+
+                        with idle_scope:
+                            # stateless=True is the resume trick: the
+                            # ServerSession is constructed with
+                            # InitializationState.Initialized so it does
+                            # not block waiting for an InitializeRequest
+                            # the client will never re-send.
+                            await self.app.run(
+                                read_stream,
+                                write_stream,
+                                self.app.create_initialization_options(),
+                                stateless=True,
+                            )
+
+                        if idle_scope.cancelled_caught:
+                            logger.info(
+                                "Resumed session %s idle timeout", session_id
+                            )
+                            self._server_instances.pop(session_id, None)
+                            await transport.terminate()
+                    except Exception:
+                        logger.exception("Resumed session %s crashed", session_id)
+                    finally:
+                        if (
+                            transport.mcp_session_id
+                            and transport.mcp_session_id in self._server_instances
+                            and not transport.is_terminated
+                        ):
+                            del self._server_instances[transport.mcp_session_id]
+
+            assert self._task_group is not None
+            await self._task_group.start(run_server)
+            await transport.handle_request(scope, receive, send)

--- a/src/mnemon/server_remote.py
+++ b/src/mnemon/server_remote.py
@@ -129,6 +129,39 @@ def run_remote() -> None:
         )
         sys.exit(1)
 
+    # Wire the persistent session manager BEFORE streamable_http_app() is
+    # called — FastMCP lazy-initializes the manager on first call and
+    # caches it. By assigning our subclass first, the lazy path is
+    # skipped and our manager handles all requests. This is what lets
+    # MCP sessions survive Fly auto_stop_machines: the in-memory dict
+    # gets replaced with a SQLite-persisted one, and unknown-but-issued
+    # session IDs are transparently resumed instead of 404'd.
+    from .config import vault_dir
+    from .persistent_sessions import PersistentSessionManager, SessionStore
+
+    sessions_db = vault_dir() / "mcp_sessions.sqlite"
+    session_store = SessionStore(sessions_db)
+    expired = session_store.expire_old()
+    if expired:
+        print(
+            f"Pruned {expired} expired MCP session(s) from {sessions_db}",
+            file=sys.stderr,
+        )
+    mcp._session_manager = PersistentSessionManager(
+        app=mcp._mcp_server,
+        session_store=session_store,
+        event_store=mcp._event_store,
+        retry_interval=mcp._retry_interval,
+        json_response=mcp.settings.json_response,
+        stateless=mcp.settings.stateless_http,
+        security_settings=mcp.settings.transport_security,
+    )
+    print(
+        f"MCP sessions persisted to {sessions_db} "
+        f"(survives cold-stops, TTL {session_store.ttl_seconds}s)",
+        file=sys.stderr,
+    )
+
     mcp_app = mcp.streamable_http_app()
     wrapped = OAuthMiddleware(mcp_app, config, as_config=as_config)
     uvicorn.run(wrapped, host="0.0.0.0", port=PORT, log_level="info")

--- a/tests/test_persistent_sessions.py
+++ b/tests/test_persistent_sessions.py
@@ -1,0 +1,238 @@
+"""Tests for the persistent MCP session store and manager subclass."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from mnemon.persistent_sessions import (
+    DEFAULT_TTL_SECONDS,
+    PersistentSessionManager,
+    SessionStore,
+    _PersistingInstanceDict,
+)
+
+
+# ---------------------------------------------------------------------------
+# SessionStore
+# ---------------------------------------------------------------------------
+
+
+class TestSessionStore:
+    def test_register_then_is_known(self, tmp_path):
+        store = SessionStore(tmp_path / "sessions.sqlite")
+        store.register("abc123")
+        assert store.is_known("abc123") is True
+
+    def test_unknown_session_id_returns_false(self, tmp_path):
+        store = SessionStore(tmp_path / "sessions.sqlite")
+        assert store.is_known("never-issued") is False
+
+    def test_register_is_idempotent(self, tmp_path):
+        store = SessionStore(tmp_path / "sessions.sqlite")
+        store.register("abc123")
+        store.register("abc123")
+        assert store.count() == 1
+
+    def test_persists_across_instances(self, tmp_path):
+        """Issued IDs survive a fresh SessionStore (i.e. process restart)."""
+        db = tmp_path / "sessions.sqlite"
+        SessionStore(db).register("survives-restart")
+        assert SessionStore(db).is_known("survives-restart") is True
+
+    def test_expired_session_is_unknown(self, tmp_path):
+        store = SessionStore(tmp_path / "sessions.sqlite", ttl_seconds=1)
+        store.register("ephemeral")
+        assert store.is_known("ephemeral") is True
+        time.sleep(1.1)
+        assert store.is_known("ephemeral") is False
+
+    def test_expire_old_deletes_only_expired(self, tmp_path):
+        store = SessionStore(tmp_path / "sessions.sqlite", ttl_seconds=1)
+        store.register("old")
+        time.sleep(1.1)
+        store.register("new")
+        deleted = store.expire_old()
+        assert deleted == 1
+        assert store.is_known("old") is False
+        assert store.is_known("new") is True
+
+    def test_touch_extends_lifetime(self, tmp_path):
+        store = SessionStore(tmp_path / "sessions.sqlite", ttl_seconds=2)
+        store.register("active")
+        time.sleep(1.5)
+        store.touch("active")
+        time.sleep(1.0)  # original deadline passed; touched deadline has not
+        assert store.is_known("active") is True
+
+    def test_creates_parent_dir(self, tmp_path):
+        nested = tmp_path / "does" / "not" / "exist" / "sessions.sqlite"
+        SessionStore(nested).register("sid")
+        assert nested.exists()
+
+    def test_default_ttl_one_week(self):
+        # Sanity: the default isn't accidentally short.
+        assert DEFAULT_TTL_SECONDS == 7 * 24 * 3600
+
+
+# ---------------------------------------------------------------------------
+# _PersistingInstanceDict
+# ---------------------------------------------------------------------------
+
+
+class TestPersistingInstanceDict:
+    def test_setitem_registers_with_store(self, tmp_path):
+        store = SessionStore(tmp_path / "sessions.sqlite")
+        d = _PersistingInstanceDict(store)
+        d["abc"] = MagicMock(name="transport")
+        assert store.is_known("abc") is True
+
+    def test_setitem_still_stores_value_in_dict(self, tmp_path):
+        store = SessionStore(tmp_path / "sessions.sqlite")
+        d = _PersistingInstanceDict(store)
+        transport = MagicMock(name="transport")
+        d["abc"] = transport
+        assert d["abc"] is transport
+        assert "abc" in d
+
+    def test_persistence_failure_does_not_raise(self, tmp_path, caplog):
+        """A broken store must not block in-memory session creation —
+        sessions failing to persist still need to work in this process."""
+        store = MagicMock(spec=SessionStore)
+        store.register.side_effect = RuntimeError("disk on fire")
+        d = _PersistingInstanceDict(store)
+        # Should not propagate; transport assignment must succeed.
+        d["abc"] = MagicMock()
+        assert "abc" in d
+        assert any(
+            "Failed to persist session" in rec.message
+            for rec in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# PersistentSessionManager construction
+# ---------------------------------------------------------------------------
+
+
+class TestPersistentSessionManagerInit:
+    def test_replaces_server_instances_with_persisting_dict(self, tmp_path):
+        store = SessionStore(tmp_path / "sessions.sqlite")
+        manager = PersistentSessionManager(
+            app=MagicMock(name="mcp_server"),
+            session_store=store,
+        )
+        assert isinstance(manager._server_instances, _PersistingInstanceDict)
+
+    def test_session_assignment_persists(self, tmp_path):
+        """Smoke-test: writing a transport to _server_instances persists."""
+        store = SessionStore(tmp_path / "sessions.sqlite")
+        manager = PersistentSessionManager(
+            app=MagicMock(name="mcp_server"),
+            session_store=store,
+        )
+        manager._server_instances["new-session-id"] = MagicMock(name="transport")
+        assert store.is_known("new-session-id") is True
+
+
+# ---------------------------------------------------------------------------
+# Resume flow integration — the core behavior PR B is shipping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+class TestResumeFlow:
+    @pytest.fixture
+    def anyio_backend(self):
+        return "asyncio"
+
+    async def test_unknown_in_memory_but_persisted_takes_resume_path(
+        self, tmp_path, monkeypatch
+    ):
+        """Simulate the cold-start scenario.
+
+        First "process" registers a session via _PersistingInstanceDict,
+        second "process" gets a request bearing that session ID. The
+        second manager has empty _server_instances but the SessionStore
+        knows the ID — so the resume branch must fire.
+        """
+        db = tmp_path / "sessions.sqlite"
+        # Pretend a session was issued by an earlier process.
+        SessionStore(db).register("survivor-id")
+
+        # New "process": fresh manager, empty in-memory dict, same DB.
+        store = SessionStore(db)
+        manager = PersistentSessionManager(
+            app=MagicMock(name="mcp_server"),
+            session_store=store,
+        )
+        assert "survivor-id" not in manager._server_instances
+
+        # Stub the resume handler so we don't need a full ASGI/transport
+        # round-trip — this test is about the routing decision.
+        called: dict[str, str] = {}
+
+        async def fake_resume(session_id, scope, receive, send):
+            called["session_id"] = session_id
+
+        monkeypatch.setattr(manager, "_resume_session", fake_resume)
+
+        scope = {"type": "http", "method": "POST", "path": "/mcp", "headers": [
+            (b"mcp-session-id", b"survivor-id"),
+        ]}
+
+        async def receive():  # pragma: no cover — never invoked
+            return {"type": "http.disconnect"}
+
+        async def send(_):  # pragma: no cover — never invoked
+            pass
+
+        await manager._handle_stateful_request(scope, receive, send)
+        assert called.get("session_id") == "survivor-id"
+
+    async def test_truly_unknown_session_falls_through_to_super(
+        self, tmp_path, monkeypatch
+    ):
+        """A session ID that was never issued must NOT take the resume
+        branch — it falls through to upstream's 404 behavior."""
+        store = SessionStore(tmp_path / "sessions.sqlite")
+        manager = PersistentSessionManager(
+            app=MagicMock(name="mcp_server"),
+            session_store=store,
+        )
+
+        resume_called = False
+
+        async def fake_resume(*args, **kwargs):
+            nonlocal resume_called
+            resume_called = True
+
+        super_called = False
+
+        async def fake_super(self, scope, receive, send):  # noqa: ANN001
+            nonlocal super_called
+            super_called = True
+
+        monkeypatch.setattr(manager, "_resume_session", fake_resume)
+        # Patch the unbound super method on the class so super() resolves to it.
+        monkeypatch.setattr(
+            "mnemon.persistent_sessions.StreamableHTTPSessionManager."
+            "_handle_stateful_request",
+            fake_super,
+        )
+
+        scope = {"type": "http", "method": "POST", "path": "/mcp", "headers": [
+            (b"mcp-session-id", b"phantom-id"),
+        ]}
+
+        async def receive():  # pragma: no cover
+            return {"type": "http.disconnect"}
+
+        async def send(_):  # pragma: no cover
+            pass
+
+        await manager._handle_stateful_request(scope, receive, send)
+        assert resume_called is False
+        assert super_called is True


### PR DESCRIPTION
## Summary

- New `src/mnemon/persistent_sessions.py`: `SessionStore` (SQLite registry of issued session IDs, 7-day TTL by default, schema in vault dir as `mcp_sessions.sqlite`) + `PersistentSessionManager` subclass of the upstream `StreamableHTTPSessionManager`.
- Subclass overlays two behaviors: (1) `_server_instances` is replaced with a dict that auto-persists every assignment; (2) `_handle_stateful_request` adds a resume branch — a request bearing a known-but-not-in-memory session ID spawns a fresh transport keyed to the same ID and runs the MCP app `stateless=True` so the underlying `ServerSession` is born already-initialized.
- Wired into `server_remote.py` via `mcp._session_manager = ...` *before* `streamable_http_app()` triggers FastMCP's lazy init. Skips the upstream constructor path cleanly.

## Why

Closes the deeper bug behind PR #82 (warm-keeper hook). Even with the warm-keeper, a sufficiently-long idle period (or a redeploy) will auto-stop the Fly machine and kill in-memory session state. After wake, every client request with the old `Mcp-Session-Id` 404s, because Claude Code's MCP client does not reinit on 404 despite the spec saying it SHOULD. With this PR, those requests resume invisibly instead.

The two PRs together close the failure mode end-to-end:
- PR #82 (warm-keeper): minimizes how often cold-stops happen during active sessions
- This PR (persistence): handles the consequence when one happens anyway

## Caveats

Resumed sessions are stateless on the server side — `client_params` is `None`, capability-gated features (sampling, elicitation, roots) won't work. Mnemon uses none of those, so it's a no-op for our toolset. Documented in the module docstring; third-party forks adding those features will need to re-handshake explicitly.

## Test plan

- [x] `pytest tests/test_persistent_sessions.py` passes (16 tests covering SessionStore CRUD, TTL/expiry, cross-instance persistence, the resume routing decision, and the truly-unknown-id fall-through to upstream 404)
- [x] `pytest` full suite passes (630 tests; 614 prior + 16 new)
- [ ] **Live Fly validation** (gating merge): deploy to `mnemon-memory.fly.dev`, get a session ID via Claude Code, force `fly machine stop` then `fly machine start`, verify the same session ID continues to work without `/mcp` reconnect
- [ ] Optional follow-up commit on this PR: end-to-end test that spawns server-1, captures session ID via raw MCP handshake, kills it, spawns server-2 with the same vault dir, sends tools/list with the captured ID, asserts 200. Deferred from this initial commit because each subprocess pays the FastEmbed boot cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)