### PR TITLE
chore: bump version to 0.6.0rc4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.6.0rc4] - 2026-04-25
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.6.0rc3"
+version = "0.6.0rc4"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.6.0rc3"
+__version__ = "0.6.0rc4"


### PR DESCRIPTION
## Summary

- Bumps `pyproject.toml` and `src/mnemon/__init__.py` to `0.6.0rc4`.
- Moves CHANGELOG `[Unreleased]` → `[0.6.0rc4] - 2026-04-25`.

## What ships in 0.6.0rc4

- **#82** — `/health` warm-keeper hook on UserPromptSubmit (keeps Fly machine warm during active sessions).
- **#83** — Persistent MCP sessions across process restarts (transparent resume after cold-stop, no more 404s).

Together: closes the "MCP UI says connected, every tool call returns 404 after Fly cold-stop" failure mode while preserving `auto_stop_machines = \"stop\"` cost posture (~\$0/month).

## Post-merge checklist (for Brian)

1. `python -m build && twine upload dist/*` to publish to PyPI.
2. In a separate terminal: `pip install -U 'mnemon-memory[server]==0.6.0rc4'`
3. `mnemon upgrade web --app-name mnemon-memory` to redeploy Fly.
4. Live validation: `fly machine stop -a mnemon-memory` then `start`, send a tool call from open Claude Code session — should succeed without `/mcp` reconnect.

## Test plan

- [x] `pytest` passes (630 tests, no regressions from version bump)
- [ ] PyPI publish succeeds
- [ ] Fly redeploy succeeds
- [ ] Cold-start resume validated live

🤖 Generated with [Claude Code](https://claude.com/claude-code)