### PR TITLE
feat(server): expose session-routing counters via /health

### DIFF
--- a/src/mnemon/auth.py
+++ b/src/mnemon/auth.py
@@ -96,6 +96,7 @@ class OAuthMiddleware:
         app: ASGIApp,
         config: OAuthConfig,
         as_config: "AuthorizationServerConfig | None" = None,
+        metrics_provider: "Callable[[], dict[str, int]] | None" = None,
     ) -> None:
         self.app = app
         self.config = config
@@ -103,6 +104,10 @@ class OAuthMiddleware:
         # enabled, the middleware serves the AS endpoints and validates
         # bearer JWTs against the local keypair.
         self.as_config = as_config
+        # Optional callable returning a counters dict — surfaced via
+        # /health for cold-stop diagnostics. Failures are swallowed so
+        # /health stays a reliable Fly health check.
+        self._metrics_provider = metrics_provider
 
     async def __call__(
         self, scope: ASGIScope, receive: ASGIReceive, send: ASGISend
@@ -116,7 +121,15 @@ class OAuthMiddleware:
 
         # Unauthenticated endpoints.
         if path == "/health":
-            await _send_json(send, 200, {"status": "ok"})
+            payload: dict[str, object] = {"status": "ok"}
+            if self._metrics_provider is not None:
+                try:
+                    payload["metrics"] = self._metrics_provider()
+                except Exception:  # noqa: BLE001
+                    # Never let a metrics-collection bug 500 the health
+                    # check — Fly relies on /health for liveness.
+                    logger.exception("metrics_provider failed")
+            await _send_json(send, 200, payload)
             return
 
         if path == "/.well-known/oauth-protected-resource":

--- a/src/mnemon/persistent_sessions.py
+++ b/src/mnemon/persistent_sessions.py
@@ -207,6 +207,28 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
         )
         self._session_store = session_store
         self._server_instances = _PersistingInstanceDict(session_store)
+        # Process-lifetime counters scraped via /health for cold-stop diagnosis.
+        # Single-event-loop server, so plain ints are race-free without a Lock.
+        self._counters: dict[str, int] = {
+            "in_memory_hits": 0,
+            "resume_hits": 0,
+            "fresh_inits": 0,
+            "stale_session_misses": 0,
+        }
+
+    def metrics(self) -> dict[str, int]:
+        """Snapshot of session-routing counters for /health introspection.
+
+        ``stale_session_misses`` counts requests bearing a session ID that
+        is neither in memory nor in SQLite — the actual "Session not found"
+        surface. ``resume_hits`` counts the cold-stop recovery path firing.
+        Persistent across process lifetime; resets on cold-stop.
+        """
+        return {
+            **self._counters,
+            "persisted_sessions_total": self._session_store.count(),
+            "in_memory_sessions_current": len(self._server_instances),
+        }
 
     async def _handle_stateful_request(
         self,
@@ -219,6 +241,7 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
 
         # In-memory hit: refresh persistence + delegate to upstream.
         if session_id is not None and session_id in self._server_instances:
+            self._counters["in_memory_hits"] += 1
             self._session_store.touch(session_id)
             await super()._handle_stateful_request(scope, receive, send)
             return
@@ -226,6 +249,7 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
         # Persisted but not in memory: this is the resume case (post
         # cold-start, redeploy, or process restart).
         if session_id is not None and self._session_store.is_known(session_id):
+            self._counters["resume_hits"] += 1
             logger.info("Resuming persisted MCP session %s", session_id)
             await self._resume_session(session_id, scope, receive, send)
             return
@@ -233,6 +257,18 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
         # Either a brand-new session (no header) or an unknown session
         # ID we never issued / has expired. Upstream handles both — new
         # session creation will write through _PersistingInstanceDict.
+        if session_id is None:
+            self._counters["fresh_inits"] += 1
+        else:
+            # Stale: client sent a session ID we never issued or that
+            # expired. Upstream returns 404 — this is the actual
+            # "Session not found" surface seen by clients.
+            self._counters["stale_session_misses"] += 1
+            logger.warning(
+                "Stale session_id %s — not in memory, not in SQLite. "
+                "Upstream will return 404 per MCP spec.",
+                session_id,
+            )
         await super()._handle_stateful_request(scope, receive, send)
 
     async def _resume_session(

--- a/src/mnemon/server_remote.py
+++ b/src/mnemon/server_remote.py
@@ -163,5 +163,10 @@ def run_remote() -> None:
     )
 
     mcp_app = mcp.streamable_http_app()
-    wrapped = OAuthMiddleware(mcp_app, config, as_config=as_config)
+    wrapped = OAuthMiddleware(
+        mcp_app,
+        config,
+        as_config=as_config,
+        metrics_provider=mcp._session_manager.metrics,
+    )
     uvicorn.run(wrapped, host="0.0.0.0", port=PORT, log_level="info")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -127,6 +127,38 @@ async def test_health_works_with_no_auth_configured(no_auth_config):
     assert status == 200
 
 
+@pytest.mark.asyncio
+async def test_health_includes_metrics_when_provider_wired(local_token_config):
+    """Health surfaces session-routing counters when a provider is supplied."""
+    app = _stub_downstream_factory([])
+    mw = OAuthMiddleware(
+        app,
+        local_token_config,
+        metrics_provider=lambda: {"resume_hits": 7, "stale_session_misses": 2},
+    )
+    status, _, body = await _call_middleware(mw, "/health")
+    payload = json.loads(body)
+    assert status == 200
+    assert payload["status"] == "ok"
+    assert payload["metrics"] == {"resume_hits": 7, "stale_session_misses": 2}
+
+
+@pytest.mark.asyncio
+async def test_health_swallows_metrics_provider_failure(local_token_config, caplog):
+    """A broken metrics_provider must NOT 500 the health check."""
+    app = _stub_downstream_factory([])
+
+    def boom():
+        raise RuntimeError("counters on fire")
+
+    mw = OAuthMiddleware(app, local_token_config, metrics_provider=boom)
+    with caplog.at_level("ERROR", logger="mnemon.auth"):
+        status, _, body = await _call_middleware(mw, "/health")
+    assert status == 200
+    assert json.loads(body) == {"status": "ok"}
+    assert any("metrics_provider failed" in rec.message for rec in caplog.records)
+
+
 # --- Pass-through mode (no auth configured) --------------------------------
 
 

--- a/tests/test_persistent_sessions.py
+++ b/tests/test_persistent_sessions.py
@@ -236,3 +236,116 @@ class TestResumeFlow:
         await manager._handle_stateful_request(scope, receive, send)
         assert resume_called is False
         assert super_called is True
+
+
+# ---------------------------------------------------------------------------
+# Counters / metrics surface — feeds /health for cold-stop diagnostics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+class TestMetricsCounters:
+    @pytest.fixture
+    def anyio_backend(self):
+        return "asyncio"
+
+    @staticmethod
+    def _make_manager(tmp_path):
+        store = SessionStore(tmp_path / "sessions.sqlite")
+        return PersistentSessionManager(
+            app=MagicMock(name="mcp_server"),
+            session_store=store,
+        )
+
+    @staticmethod
+    def _scope(session_id: bytes | None):
+        headers = []
+        if session_id is not None:
+            headers.append((b"mcp-session-id", session_id))
+        return {"type": "http", "method": "POST", "path": "/mcp", "headers": headers}
+
+    @staticmethod
+    async def _noop_receive():  # pragma: no cover — never invoked
+        return {"type": "http.disconnect"}
+
+    @staticmethod
+    async def _noop_send(_):  # pragma: no cover — never invoked
+        pass
+
+    def test_metrics_initial_state(self, tmp_path):
+        manager = self._make_manager(tmp_path)
+        m = manager.metrics()
+        assert m["in_memory_hits"] == 0
+        assert m["resume_hits"] == 0
+        assert m["fresh_inits"] == 0
+        assert m["stale_session_misses"] == 0
+        assert m["persisted_sessions_total"] == 0
+        assert m["in_memory_sessions_current"] == 0
+
+    async def test_in_memory_hit_increments_counter(self, tmp_path, monkeypatch):
+        manager = self._make_manager(tmp_path)
+        manager._server_instances["live-id"] = MagicMock(name="transport")
+
+        async def fake_super(self, scope, receive, send):  # noqa: ANN001
+            pass
+
+        monkeypatch.setattr(
+            "mnemon.persistent_sessions.StreamableHTTPSessionManager."
+            "_handle_stateful_request",
+            fake_super,
+        )
+        await manager._handle_stateful_request(
+            self._scope(b"live-id"), self._noop_receive, self._noop_send
+        )
+        assert manager.metrics()["in_memory_hits"] == 1
+
+    async def test_resume_hit_increments_counter(self, tmp_path, monkeypatch):
+        manager = self._make_manager(tmp_path)
+        manager._session_store.register("survivor")
+
+        async def fake_resume(*args, **kwargs):
+            pass
+
+        monkeypatch.setattr(manager, "_resume_session", fake_resume)
+        await manager._handle_stateful_request(
+            self._scope(b"survivor"), self._noop_receive, self._noop_send
+        )
+        assert manager.metrics()["resume_hits"] == 1
+
+    async def test_fresh_init_increments_counter(self, tmp_path, monkeypatch):
+        manager = self._make_manager(tmp_path)
+
+        async def fake_super(self, scope, receive, send):  # noqa: ANN001
+            pass
+
+        monkeypatch.setattr(
+            "mnemon.persistent_sessions.StreamableHTTPSessionManager."
+            "_handle_stateful_request",
+            fake_super,
+        )
+        await manager._handle_stateful_request(
+            self._scope(None), self._noop_receive, self._noop_send
+        )
+        assert manager.metrics()["fresh_inits"] == 1
+
+    async def test_stale_session_miss_increments_counter_and_warns(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        manager = self._make_manager(tmp_path)
+
+        async def fake_super(self, scope, receive, send):  # noqa: ANN001
+            pass
+
+        monkeypatch.setattr(
+            "mnemon.persistent_sessions.StreamableHTTPSessionManager."
+            "_handle_stateful_request",
+            fake_super,
+        )
+        with caplog.at_level("WARNING", logger="mnemon.persistent_sessions"):
+            await manager._handle_stateful_request(
+                self._scope(b"phantom"), self._noop_receive, self._noop_send
+            )
+        assert manager.metrics()["stale_session_misses"] == 1
+        assert any(
+            "Stale session_id phantom" in rec.message for rec in caplog.records
+        )


### PR DESCRIPTION
## Summary

- Adds in-memory counters to `PersistentSessionManager` — `in_memory_hits`, `resume_hits`, `fresh_inits`, `stale_session_misses` — plus snapshots of `persisted_sessions_total` and `in_memory_sessions_current`.
- `OAuthMiddleware` accepts an optional `metrics_provider` callable; when wired in `server_remote.py`, `/health` returns `{"status": "ok", "metrics": {...}}`.
- Backward compatible: `doctor.py` only inspects `status`; clients that don't know about `metrics` ignore the new field.

## Why

PR #83's resume path has fired **0 times** in 19 h of v21 production traffic despite 12 sessions accumulating in `/data/mcp_sessions.sqlite`. We can't tell whether (a) the Anthropic mcp-proxy ever sends a stale session ID after Fly cold-stops (→ resume path is doing real work), or (b) it always fresh-handshakes (→ PR #83 is dead code in the claude.ai connector path) — and Fly's log buffer rotates after ~1 h so retrospective greps don't go far back enough.

Counters reset on cold-stop, which is exactly the boundary we care about. `/health` is already pinged on every prompt by the warm-keeper hook installed by PR #82, so capture is essentially free — periodic `curl https://mnemon-memory.fly.dev/health` calls will surface the routing pattern.

After this is deployed, a 24-48 h observation window will tell us:
- `resume_hits > 0` ever → PR #83 is helping; keep it
- `resume_hits == 0` while `fresh_inits` keeps climbing → PR #83 doesn't fire under the claude.ai mcp-proxy; reconsider whether it's worth keeping
- `stale_session_misses > 0` ever → that's the actual "Session not found" surface; we have a count

## Test plan

- [x] 4 new metrics-counter tests in `test_persistent_sessions.py` cover all 4 routing branches
- [x] 2 new `/health` tests in `test_auth.py` cover the metrics surface + provider-failure-swallowing
- [x] Full suite: 633 unit + 4 integration tests all pass
- [ ] After merge + deploy: `curl https://mnemon-memory.fly.dev/health` returns the new shape; observe counters over 24-48 h

🤖 Generated with [Claude Code](https://claude.com/claude-code)