### PR TITLE
chore: bump version to 0.6.0rc5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.6.0rc4"
+version = "0.6.0rc5"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.6.0rc4"
+__version__ = "0.6.0rc5"


### PR DESCRIPTION
## Summary

Bumps `pyproject.toml` + `src/mnemon/__init__.py` from `0.6.0rc4` → `0.6.0rc5`. Picks up PR #85 (session-routing counters via `/health`) for the next PyPI publish + Fly redeploy.

## Test plan

- [ ] Merge
- [ ] `python -m build && twine upload dist/mnemon_memory-0.6.0rc5*`
- [ ] `mnemon upgrade web --app-name mnemon-memory`
- [ ] `curl https://mnemon-memory.fly.dev/health` returns `{"status": "ok", "metrics": {...}}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)