### PR TITLE
ci: add hourly /health monitor for Fly deployment

### DIFF
--- a/.github/workflows/health-monitor.yml
+++ b/.github/workflows/health-monitor.yml
@@ -1,0 +1,28 @@
+name: Health Monitor
+
+on:
+  schedule:
+    # Hourly. Catches stale_session_misses regressions within ~1h of the
+    # offending request. Adjust upward if GitHub Actions minute usage
+    # becomes a concern (free tier is 2,000/mo on private repos; public
+    # repos are unmetered).
+    - cron: "5 * * * *"
+  workflow_dispatch:
+
+jobs:
+  health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Check /health
+        # exits 1 on hard failures (status drift, stale_session_misses>0,
+        # missing metrics keys) → red workflow run. exits 2 on soft
+        # warnings (persisted_sessions_total > threshold) → also red so
+        # they don't go silent. exit 0 = all green.
+        run: python scripts/check_health.py

--- a/scripts/check_health.py
+++ b/scripts/check_health.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Health-check script for the public mnemon Fly deployment.
+
+Designed to run from GitHub Actions on a schedule. Exit non-zero on any
+condition the alpha-test watch list flags as "investigation-worthy" so
+the workflow run shows red and you see it in the GitHub UI.
+
+Usage::
+
+    python scripts/check_health.py [--url https://mnemon-memory.fly.dev/health]
+
+Exit codes:
+    0 — all checks passed
+    1 — hard failure (status != ok, stale_session_misses > 0, schema drift)
+    2 — soft warning (persisted_sessions_total above threshold)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+
+DEFAULT_URL = "https://mnemon-memory.fly.dev/health"
+
+# Soft cap. SessionStore.expire_old() runs only at startup, so this drifts
+# up during long uptime between Fly cold-stops; an unbounded climb means
+# either pruning is broken or the TTL is too long for the request rate.
+PERSISTED_SESSIONS_WARN_THRESHOLD = 5_000
+
+
+def fetch_health(url: str, timeout: float = 10.0) -> dict:
+    req = urllib.request.Request(url, headers={"User-Agent": "mnemon-health-monitor/1"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"non-200 status from {url}: {resp.status}")
+        return json.loads(resp.read())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--url", default=DEFAULT_URL)
+    args = parser.parse_args()
+
+    try:
+        payload = fetch_health(args.url)
+    except (urllib.error.URLError, RuntimeError, TimeoutError) as e:
+        print(f"FAIL: could not fetch {args.url}: {type(e).__name__}: {e}")
+        return 1
+
+    if payload.get("status") != "ok":
+        print(f"FAIL: status field is {payload.get('status')!r}, expected 'ok'")
+        print(f"  full payload: {json.dumps(payload)}")
+        return 1
+
+    metrics = payload.get("metrics")
+    if metrics is None:
+        # Pre-PR-#85 deployments don't expose metrics. Treat as warning, not
+        # failure — the deploy might be a temporary rollback.
+        print("WARN: /health did not return a 'metrics' field — server may be on pre-rc5")
+        print(f"  full payload: {json.dumps(payload)}")
+        return 2
+
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    stale = metrics.get("stale_session_misses")
+    if stale is None:
+        failures.append("metrics.stale_session_misses missing — schema drift")
+    elif stale > 0:
+        failures.append(
+            f"metrics.stale_session_misses = {stale} (>0 means an unrecoverable "
+            f"'Session not found' was returned to a client; investigate "
+            f"persistent_sessions.py registration path)"
+        )
+
+    persisted = metrics.get("persisted_sessions_total")
+    if persisted is None:
+        failures.append("metrics.persisted_sessions_total missing — schema drift")
+    elif persisted >= PERSISTED_SESSIONS_WARN_THRESHOLD:
+        warnings.append(
+            f"metrics.persisted_sessions_total = {persisted} "
+            f"(>= {PERSISTED_SESSIONS_WARN_THRESHOLD}); SessionStore.expire_old() "
+            f"runs only at startup — long uptime drifts this up. Consider "
+            f"adding a periodic prune."
+        )
+
+    print(f"OK: status={payload['status']}, metrics={json.dumps(metrics)}")
+
+    if failures:
+        print()
+        for line in failures:
+            print(f"FAIL: {line}")
+        return 1
+
+    if warnings:
+        print()
+        for line in warnings:
+            print(f"WARN: {line}")
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- New GitHub Actions cron at `.github/workflows/health-monitor.yml` that hits `https://mnemon-memory.fly.dev/health` hourly.
- `scripts/check_health.py` parses the JSON and asserts on the new metrics surface (added by PR #85). Hard-fails (exit 1, red workflow) on `stale_session_misses > 0`, missing keys, or status drift; soft-warns (exit 2, also red) on `persisted_sessions_total >= 5000`.

## Why

PR #85 added counters to `/health`; this is the consumer. Without it, regressions to the cold-start fix would only surface when a tester reports them. Hourly cron catches `stale_session_misses` regressions within ~1h.

The mnemon-private alpha-test watch list (kept in `private/ROADMAP.md`) tracks what *isn't* covered yet — auth × resume layered failures, "Resumed session crashed" log lines, multi-worker uvicorn breakage, etc. — to revisit before public release.

## Test plan

- [x] Local smoke: `python scripts/check_health.py` against prod returns exit 0 and prints `metrics={"in_memory_hits":24, "resume_hits":2, "fresh_inits":4, "stale_session_misses":0, "persisted_sessions_total":24, "in_memory_sessions_current":6}`
- [ ] After merge: confirm the workflow appears in the Actions tab and the first scheduled run executes within the hour
- [ ] After merge: trigger `workflow_dispatch` manually to verify a green run before relying on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)