### PR TITLE
feat(cli): add --mnemon-version flag to mnemon upgrade web

### DIFF
--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -214,11 +214,15 @@ def main() -> None:
             print(
                 "Usage: mnemon upgrade web --app-name <name> "
                 "[--s3-bucket NAME] [--token TOKEN] [--region REGION] "
-                "[--skip-doctor]",
+                "[--mnemon-version VER] [--skip-doctor]",
                 file=sys.stderr,
             )
             sys.exit(1)
-        parsed = _parse_upgrade_args(args[2:])
+        try:
+            parsed = _parse_upgrade_args(args[2:])
+        except ValueError as exc:
+            print(f"upgrade failed: {exc}", file=sys.stderr)
+            sys.exit(1)
         if not parsed["app_name"]:
             print("--app-name is required.", file=sys.stderr)
             sys.exit(1)
@@ -230,6 +234,7 @@ def main() -> None:
                     s3_bucket=parsed["s3_bucket"],
                     token=parsed["token"],
                     region=parsed["region"] or "sjc",
+                    mnemon_version=parsed["mnemon_version"],
                     skip_doctor=parsed["skip_doctor"],
                 )
             )
@@ -287,12 +292,20 @@ def main() -> None:
 
 
 def _parse_upgrade_args(args: list[str]) -> dict:
-    """Parse ``mnemon upgrade web`` flags."""
+    """Parse ``mnemon upgrade web`` flags.
+
+    Raises ``ValueError`` if ``--mnemon-version`` is malformed — the
+    string is interpolated into a Dockerfile shell context, so we
+    refuse anything outside ``[A-Za-z0-9._+-]``.
+    """
+    import re
+
     result: dict[str, str | bool | None] = {
         "app_name": None,
         "s3_bucket": None,
         "token": None,
         "region": None,
+        "mnemon_version": None,
         "skip_doctor": False,
     }
     i = 0
@@ -309,6 +322,15 @@ def _parse_upgrade_args(args: list[str]) -> dict:
             i += 2
         elif flag == "--region" and i + 1 < len(args):
             result["region"] = args[i + 1]
+            i += 2
+        elif flag == "--mnemon-version" and i + 1 < len(args):
+            value = args[i + 1]
+            if not re.fullmatch(r"[A-Za-z0-9._+-]+", value):
+                raise ValueError(
+                    f"--mnemon-version must match [A-Za-z0-9._+-]+; "
+                    f"got: {value!r}"
+                )
+            result["mnemon_version"] = value
             i += 2
         elif flag == "--skip-doctor":
             result["skip_doctor"] = True
@@ -361,11 +383,15 @@ Upgrade local → web (deploys a Fly.io app + reconfigures every client).
 Idempotent: rerun to redeploy an existing app with the current mnemon
 version (clients keep their URL + token):
   mnemon upgrade web --app-name <name> [--s3-bucket NAME] [--token TOKEN]
-                             [--region REGION] [--skip-doctor]
+                             [--region REGION] [--mnemon-version VER]
+                             [--skip-doctor]
                              First-time deploy requires: flyctl, aws CLI
                              with credentials, and an S3 bucket
                              (MNEMON_S3_BUCKET or --s3-bucket). Redeploy
                              against an existing app only needs flyctl.
+                             --mnemon-version pins a specific PyPI version
+                             in the deployed Dockerfile (defaults to the
+                             locally-installed __version__).
 
 Downgrade web → local (pull remote vault back, reconfigure clients to stdio):
   mnemon downgrade local    [--destroy-fly-app] [--yes] [--app-name NAME]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -404,9 +404,55 @@ class TestUpgradeCli:
             s3_bucket="my-bucket",
             token=None,
             region="sjc",
+            mnemon_version=None,
             skip_doctor=True,
         )
         assert "upgrade output" in capsys.readouterr().out
+
+    @patch("mnemon.upgrade.upgrade_web")
+    def test_mnemon_version_flag_passes_through(self, mock_upgrade, capsys):
+        """--mnemon-version pins the version in the deployed Dockerfile,
+        sidestepping the local-install-must-match-PyPI gotcha."""
+        mock_upgrade.return_value = "ok"
+        with patch(
+            "sys.argv",
+            [
+                "mnemon",
+                "upgrade",
+                "web",
+                "--app-name",
+                "mnemon-test-cli",
+                "--mnemon-version",
+                "0.6.0rc5",
+                "--skip-doctor",
+            ],
+        ):
+            main()
+        kwargs = mock_upgrade.call_args.kwargs
+        assert kwargs["mnemon_version"] == "0.6.0rc5"
+        assert kwargs["app_name"] == "mnemon-test-cli"
+
+    def test_malformed_mnemon_version_exits_1(self, capsys):
+        """Refuse anything outside [A-Za-z0-9._+-] — the string is
+        interpolated into a Dockerfile shell context."""
+        with patch(
+            "sys.argv",
+            [
+                "mnemon",
+                "upgrade",
+                "web",
+                "--app-name",
+                "mnemon-test",
+                "--mnemon-version",
+                "0.6.0'; rm -rf /; '",
+            ],
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "upgrade failed" in err
+        assert "--mnemon-version must match" in err
 
     def test_web_subcommand_missing_prints_usage(self, capsys):
         with patch("sys.argv", ["mnemon", "upgrade"]):


### PR DESCRIPTION
## Summary

`mnemon upgrade web` now accepts `--mnemon-version <ver>` to explicitly pin the version in the deployed Dockerfile. When omitted, behavior is unchanged (reads from local `__version__`).

## Why

Caught 2026-04-26 deploying 0.6.0rc5: published the new RC to PyPI, ran `mnemon upgrade web`, and the Dockerfile silently pinned `==0.6.0rc4` because the local `.venv` hadn't been `pip install -U`'d yet. Re-deployed twice before noticing. Real first-time users following the README's web flow will hit the same trap.

The internal `_redeploy_existing_app(mnemon_version: str)` already took the arg; this just exposes it. Closes one of the alpha-tester onboarding items from the stability hardening list.

## Validation

- Validates value against `[A-Za-z0-9._+-]+` since it's interpolated into a Dockerfile shell context. Anything containing single quotes / shell metas / spaces is rejected with `upgrade failed: --mnemon-version must match ...`.

## Test plan

- [x] Existing happy-path test updated to assert `mnemon_version=None` when flag omitted
- [x] New test: `--mnemon-version 0.6.0rc5` passes through to `upgrade_web()`
- [x] New test: malformed version (e.g. `"0.6.0'; rm -rf /; '"`) exits 1 with clear error
- [x] Full non-integration suite: 635 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)