### PR TITLE
ci: add daily pip-audit scan against declared dependencies

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,0 +1,38 @@
+name: pip-audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Daily at 14:00 UTC. CVE feeds publish on rolling cadence; daily
+    # is the smallest cadence that's actually useful (more frequent
+    # would mostly catch the same advisory N times before any fix).
+    - cron: "0 14 * * *"
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install pip-audit
+        run: pip install pip-audit
+
+      - name: Audit project dependencies
+        # `pip-audit . --strict` audits only the deps declared in
+        # pyproject.toml (the things mnemon ships). Distinct from the
+        # default behavior of auditing the entire active environment,
+        # which would also flag the toolchain (pip, setuptools) — useful
+        # signals but not actionable from this repo. Any vulnerability
+        # in a runtime/dev dep fails the workflow. If a transitive dep
+        # has no fix available, file an upstream issue + add
+        # `--ignore-vuln <ID>` here with a comment explaining why.
+        run: pip-audit --strict .


### PR DESCRIPTION
## Summary

New `.github/workflows/pip-audit.yml` runs `pip-audit --strict .` on every push/PR + daily 14:00 UTC schedule. Strict mode treats any known CVE in a runtime/dev dep as a workflow failure.

## Why

SECURITY.md is solid but had no automated CVE scan. First security researcher arriving from a public LinkedIn post will run `pip-audit` themselves; better to ship that signal yourself.

Audits the *project's declared* dependencies (`. --strict`) rather than the active environment. The active-environment default would also flag the toolchain (pip, setuptools) — useful signals but not actionable from this repo's surface. As of today `pip 26.0` itself has an unfixed CVE-2026-3219; env-wide auditing would block the workflow on day 1.

Pairs with the existing gitleaks job — CI now catches both committed secrets AND vulnerable dependencies.

## Test plan

- [x] Local validation: `.venv/bin/pip-audit --strict .` → "No known vulnerabilities found"
- [ ] Post-merge: workflow run on main is green
- [ ] Schedule fires daily at 14:00 UTC starting tomorrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)