### PR TITLE
chore: pre-release polish + dual-config UX reframe

### DIFF
--- a/.github/workflows/health-monitor.yml
+++ b/.github/workflows/health-monitor.yml
@@ -9,6 +9,10 @@ on:
     - cron: "5 * * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   health:
     runs-on: ubuntu-latest
@@ -21,8 +25,67 @@ jobs:
           python-version: "3.13"
 
       - name: Check /health
+        id: check
         # exits 1 on hard failures (status drift, stale_session_misses>0,
         # missing metrics keys) → red workflow run. exits 2 on soft
         # warnings (persisted_sessions_total > threshold) → also red so
         # they don't go silent. exit 0 = all green.
-        run: python scripts/check_health.py
+        # tee captures the full output so the issue body below has it.
+        run: |
+          set -o pipefail
+          python scripts/check_health.py 2>&1 | tee /tmp/health.txt
+
+      - name: Open or comment on tracking issue if check failed
+        # On non-zero exit from the check, find an open issue tagged
+        # `health-monitor` (one canonical tracker) and append a comment;
+        # if none exists, open a new one. GitHub emails the maintainer
+        # automatically on issue create + comment, no extra channel
+        # needed. Skipped on PRs to avoid surfacing transient failures
+        # as noisy issues against PR head SHAs.
+        if: failure() && github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          BODY=$(cat <<EOF
+          Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          Trigger: ${{ github.event_name }}
+          Time (UTC): $(date -u +"%Y-%m-%d %H:%M")
+
+          \`\`\`
+          $(cat /tmp/health.txt)
+          \`\`\`
+          EOF
+          )
+          # Idempotently ensure the label exists. `|| true` because
+          # `gh label create` returns 422 if it already exists.
+          gh label create health-monitor \
+            --description "Auto-opened by .github/workflows/health-monitor.yml" \
+            --color FF6B6B 2>/dev/null || true
+
+          # Reuse a single open tracker issue (label `health-monitor`)
+          # so we don't spam one issue per failure.
+          EXISTING=$(gh issue list --label health-monitor --state open --limit 1 --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Appending to existing issue #$EXISTING"
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            echo "Opening new tracker issue"
+            gh issue create \
+              --title "health-monitor: /health check failing" \
+              --label health-monitor \
+              --body "$BODY"
+          fi
+
+      - name: Auto-close tracker issue if check passed
+        # On a green run, close any open `health-monitor` issue with a
+        # comment pointing at the recovering run. Keeps the issue
+        # tracker honest without manual triage.
+        if: success() && github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          for n in $(gh issue list --label health-monitor --state open --json number --jq '.[].number'); do
+            gh issue close "$n" --comment "Resolved — health-monitor run ${{ github.run_id }} green at $(date -u +"%Y-%m-%d %H:%M") UTC."
+          done

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)]()
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-compatible-blueviolet.svg)](https://modelcontextprotocol.io)
-[![PyPI](https://img.shields.io/badge/PyPI-v0.6.0rc1-blue.svg)](https://pypi.org/project/mnemon-memory/)
+[![PyPI](https://img.shields.io/pypi/v/mnemon-memory.svg)](https://pypi.org/project/mnemon-memory/)
 
 > One memory vault. Every MCP client. Self-hosted.
 >

--- a/src/mnemon/persistent_sessions.py
+++ b/src/mnemon/persistent_sessions.py
@@ -209,6 +209,9 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
         self._server_instances = _PersistingInstanceDict(session_store)
         # Process-lifetime counters scraped via /health for cold-stop diagnosis.
         # Single-event-loop server, so plain ints are race-free without a Lock.
+        # NOTE: scripts/check_health.py reads these key names directly. If you
+        # rename, add, or remove a key here, update the GHA monitor in the same
+        # PR — the workflow hard-fails on missing keys ("schema drift").
         self._counters: dict[str, int] = {
             "in_memory_hits": 0,
             "resume_hits": 0,

--- a/src/mnemon/setup.py
+++ b/src/mnemon/setup.py
@@ -201,6 +201,39 @@ def _ensure_local_token(token: str | None = None) -> str:
     return new_token
 
 
+def _claude_ai_shadow_warning_lines(target_label: str) -> list[str]:
+    """Return a list of warning lines if a claude.ai-synced mnemon
+    registration exists, otherwise an empty list.
+
+    The shadow problem: when a user has installed mnemon via the
+    claude.ai web UI (Settings → Connected Apps), that registration
+    syncs to every Anthropic-first-party client signed in to the same
+    account — Claude Code (CLI), Claude Desktop, Claude mobile. The
+    synced entry takes precedence over a local stdio entry written by
+    ``mnemon setup``, so a "setup succeeded" message is misleading
+    until the user removes the claude.ai entry. Cursor + Gemini CLI
+    are not synced from claude.ai and are not affected.
+
+    ``target_label`` is the user-facing name (e.g. ``"Claude Code"``,
+    ``"Claude Desktop"``) shown in the warning text.
+    """
+    from .uninstall import detect_claude_ai_mnemon
+
+    if not detect_claude_ai_mnemon():
+        return []
+
+    return [
+        "",
+        "  ⚠ claude.ai-synced mnemon MCP registration detected.",
+        f"    {target_label} will PREFER that entry over the stdio "
+        f"registration we just added.",
+        f"    To use local for {target_label} too: open claude.ai → "
+        f"Settings → Connected Apps and remove the mnemon entry.",
+        "    (Cursor + Gemini CLI are unaffected — they don't sync "
+        "MCP from claude.ai.)",
+    ]
+
+
 def _refuse_if_remote_configured(target_label: str) -> None:
     """Raise :class:`SetupError` if ``~/.mnemon/remote_url`` exists.
 
@@ -488,30 +521,12 @@ def setup_claude_code(*, remote_url: str | None = None, token: str | None = None
     if remote_url:
         lines.append("  SessionStart: pre-warm polling (90s background)")
 
-    # Warn if a claude.ai-synced mnemon entry exists. It can't be removed
-    # by any `claude mcp remove` command; it'll shadow the stdio
-    # registration we just added. Surface it here so the user knows the
-    # setup "succeeded" but Claude Code will still prefer the remote.
+    # Warn if a claude.ai-synced mnemon entry exists — it'll shadow the
+    # stdio registration we just added and can't be removed by any
+    # `claude mcp remove` command (lives in the user's Anthropic
+    # account, not on disk).
     if remote_url is None:
-        from .uninstall import detect_claude_ai_mnemon
-
-        if detect_claude_ai_mnemon():
-            lines.append("")
-            lines.append(
-                "  ⚠ claude.ai-synced mnemon MCP registration detected."
-            )
-            lines.append(
-                "    Claude Code will PREFER that entry over the stdio "
-                "registration we just added."
-            )
-            lines.append(
-                "    To use local for Claude Code too: open claude.ai → "
-                "Settings → Connected Apps and remove the mnemon entry."
-            )
-            lines.append(
-                "    (Cursor + Claude Desktop are unaffected — they use "
-                "their own local configs.)"
-            )
+        lines.extend(_claude_ai_shadow_warning_lines("Claude Code"))
 
     _write_json(settings_path, settings)
 
@@ -630,11 +645,20 @@ def setup_claude_desktop(
 
     _write_json(desktop_path, config)
 
-    return (
+    summary = (
         f"Claude Desktop MCP configured at {desktop_path}\n"
-        f"  Mode: {mode}\n"
-        "Restart Claude Desktop to activate."
+        f"  Mode: {mode}"
     )
+    # Claude Desktop syncs MCP servers from claude.ai (same Anthropic
+    # account), so the shadow problem applies here too. Only surface
+    # the warning in stdio mode — when configuring remote, the user
+    # already wants the remote.
+    if remote_url is None:
+        shadow_lines = _claude_ai_shadow_warning_lines("Claude Desktop")
+        if shadow_lines:
+            summary += "\n" + "\n".join(shadow_lines)
+    summary += "\nRestart Claude Desktop to activate."
+    return summary
 
 
 def setup_gemini() -> str:

--- a/src/mnemon/setup.py
+++ b/src/mnemon/setup.py
@@ -201,21 +201,25 @@ def _ensure_local_token(token: str | None = None) -> str:
     return new_token
 
 
-def _claude_ai_shadow_warning_lines(target_label: str) -> list[str]:
-    """Return a list of warning lines if a claude.ai-synced mnemon
-    registration exists, otherwise an empty list.
+def _dual_config_info_lines(target_label: str) -> list[str]:
+    """Return a list of info lines when a claude.ai-synced mnemon
+    registration coexists with the stdio one we just wrote.
 
-    The shadow problem: when a user has installed mnemon via the
-    claude.ai web UI (Settings → Connected Apps), that registration
-    syncs to every Anthropic-first-party client signed in to the same
-    account — Claude Code (CLI), Claude Desktop, Claude mobile. The
-    synced entry takes precedence over a local stdio entry written by
-    ``mnemon setup``, so a "setup succeeded" message is misleading
-    until the user removes the claude.ai entry. Cursor + Gemini CLI
-    are not synced from claude.ai and are not affected.
+    This is **not** a problem state — it's a legitimate dual config.
+    When a user has added mnemon via claude.ai (Settings → Connected
+    Apps), that registration syncs to every Anthropic-first-party
+    client on the same account: Claude Code, Claude Desktop, Claude
+    mobile. ``mnemon setup`` writing a stdio entry on top of that just
+    means both are configured. In Claude Code + Claude Desktop, the
+    web (claude.ai-synced) one takes precedence — that's the default.
+    The stdio entry stays on disk and activates automatically if the
+    user later removes the claude.ai entry, with no re-run needed.
 
-    ``target_label`` is the user-facing name (e.g. ``"Claude Code"``,
-    ``"Claude Desktop"``) shown in the warning text.
+    Cursor + Gemini CLI don't sync MCP from claude.ai, so this dual
+    state can't arise there.
+
+    ``target_label`` is the user-facing client name (e.g.
+    ``"Claude Code"``, ``"Claude Desktop"``) used in the message.
     """
     from .uninstall import detect_claude_ai_mnemon
 
@@ -224,13 +228,11 @@ def _claude_ai_shadow_warning_lines(target_label: str) -> list[str]:
 
     return [
         "",
-        "  ⚠ claude.ai-synced mnemon MCP registration detected.",
-        f"    {target_label} will PREFER that entry over the stdio "
-        f"registration we just added.",
-        f"    To use local for {target_label} too: open claude.ai → "
-        f"Settings → Connected Apps and remove the mnemon entry.",
-        "    (Cursor + Gemini CLI are unaffected — they don't sync "
-        "MCP from claude.ai.)",
+        f"  ℹ Both local + web mnemon configured. {target_label} will "
+        "use the web version (claude.ai-synced) by default.",
+        "    To switch to local: open claude.ai → Settings → "
+        "Connected Apps and remove the mnemon entry. The local stdio "
+        "config stays on disk and activates automatically.",
     ]
 
 
@@ -521,12 +523,13 @@ def setup_claude_code(*, remote_url: str | None = None, token: str | None = None
     if remote_url:
         lines.append("  SessionStart: pre-warm polling (90s background)")
 
-    # Warn if a claude.ai-synced mnemon entry exists — it'll shadow the
-    # stdio registration we just added and can't be removed by any
-    # `claude mcp remove` command (lives in the user's Anthropic
-    # account, not on disk).
+    # If a claude.ai-synced mnemon entry exists alongside the stdio
+    # entry we just wrote, surface the dual-config state. Web wins by
+    # default in Claude Code's resolution; the stdio entry stays
+    # on-disk as standby (auto-activates if the user later removes the
+    # claude.ai entry).
     if remote_url is None:
-        lines.extend(_claude_ai_shadow_warning_lines("Claude Code"))
+        lines.extend(_dual_config_info_lines("Claude Code"))
 
     _write_json(settings_path, settings)
 
@@ -649,14 +652,13 @@ def setup_claude_desktop(
         f"Claude Desktop MCP configured at {desktop_path}\n"
         f"  Mode: {mode}"
     )
-    # Claude Desktop syncs MCP servers from claude.ai (same Anthropic
-    # account), so the shadow problem applies here too. Only surface
-    # the warning in stdio mode — when configuring remote, the user
-    # already wants the remote.
+    # Claude Desktop also syncs MCP from claude.ai, so the same
+    # dual-config state can arise. Only surface the info in stdio
+    # mode — when configuring remote, the user already wants remote.
     if remote_url is None:
-        shadow_lines = _claude_ai_shadow_warning_lines("Claude Desktop")
-        if shadow_lines:
-            summary += "\n" + "\n".join(shadow_lines)
+        info_lines = _dual_config_info_lines("Claude Desktop")
+        if info_lines:
+            summary += "\n" + "\n".join(info_lines)
     summary += "\nRestart Claude Desktop to activate."
     return summary
 

--- a/src/mnemon/uninstall.py
+++ b/src/mnemon/uninstall.py
@@ -174,10 +174,19 @@ def _claude_mcp_remove() -> str | None:
     except FileNotFoundError:
         return None
     if out.returncode == 0:
-        return "  claude mcp:    mnemon registration removed"
-    # Non-zero is expected if mnemon was never registered. Still worth
-    # noting so the user sees the attempt happened.
-    return "  claude mcp:    no mnemon registration found (or CLI errored silently)"
+        return "  claude mcp:    user-scope mnemon registration removed"
+    # Non-zero is the common case — the user-scope registration was
+    # already gone (fresh setup, prior uninstall, or claude.ai-only).
+    # Surface stderr if it looks like a real error (anything not in
+    # the "not found" family) so unusual failures aren't swallowed.
+    detail = (out.stderr or out.stdout or "").strip()
+    if detail and not any(
+        marker in detail.lower()
+        for marker in ("not found", "no such", "no mcp server", "does not exist")
+    ):
+        first_line = detail.splitlines()[0]
+        return f"  claude mcp:    skipped — {first_line}"
+    return "  claude mcp:    no user-scope mnemon registration to remove"
 
 
 def _strip_from_json(path: Path, keys_to_strip: dict[str, list[str]]) -> bool:

--- a/src/mnemon/uninstall.py
+++ b/src/mnemon/uninstall.py
@@ -287,16 +287,16 @@ def uninstall(*, yes: bool = False, keep_vault: bool = False) -> str:
     # think the command didn't work.
     if state["claude_ai_registration"]:
         ca_warning = (
-            "⚠ claude.ai-synced mnemon MCP detected.\n"
+            "ℹ claude.ai-synced mnemon MCP also configured.\n"
             "  `claude mcp list` shows a `claude.ai mnemon: …` entry. "
             "This registration lives in your Anthropic account and is "
             "synced to Claude Code from claude.ai — it CANNOT be removed "
             "by `mnemon uninstall` or any `claude mcp remove` command.\n"
             "  To finish the uninstall, open claude.ai → Settings → "
             "Connected Apps and remove the mnemon entry there.\n"
-            "  If you leave it in place: it will shadow any local stdio "
-            "registration from a future `mnemon setup`, and Claude Code "
-            "will keep talking to the remote vault.\n"
+            "  If you leave it in place: any future `mnemon setup` will "
+            "configure both local + web; Claude Code will use the web "
+            "version (claude.ai-synced) by default.\n"
         )
         print(ca_warning, file=sys.stderr)
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -753,39 +753,35 @@ class TestFailOnWarnPropagation:
         assert "including warnings" in result
 
 
-class TestClaudeAiShadowWarning:
-    """Local-mode setup_claude_code now surfaces a warning when a
-    claude.ai-synced mnemon MCP registration is detected. The stdio
-    registration the function just added will be shadowed by the
-    claude.ai one because Claude Code prefers the synced-from-account
-    source. Users need to know the setup technically succeeded but
-    Claude Code behavior won't reflect it until they remove the entry
-    in claude.ai's web UI."""
+class TestDualConfigInfo:
+    """Local-mode setup_claude_code + setup_claude_desktop surface an
+    informational notice when a claude.ai-synced mnemon registration
+    coexists with the stdio one being written. This isn't a problem
+    state — it's a legitimate dual config (web wins by default in
+    Anthropic-first-party clients; the stdio entry stays on-disk as
+    standby). Cursor + Gemini CLI don't sync from claude.ai so this
+    notice never fires for them."""
 
-    def test_warning_surfaced_when_claude_ai_entry_exists(self):
+    def test_info_surfaced_when_claude_ai_entry_exists(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)), \
                  patch("mnemon.uninstall.detect_claude_ai_mnemon", return_value=True):
                 result = setup_claude_code()
-        assert "claude.ai-synced mnemon MCP registration detected" in result
-        assert "Claude Code will PREFER" in result
-        # Cursor + Gemini CLI are the not-synced clients (the unaffected
-        # ones); Claude Desktop DOES sync from claude.ai and is now
-        # warned about separately in setup_claude_desktop.
-        assert "Cursor + Gemini CLI are unaffected" in result
+        assert "Both local + web mnemon configured" in result
+        assert "Claude Code will use the web version (claude.ai-synced)" in result
+        assert "stays on disk and activates automatically" in result
 
-    def test_no_warning_when_no_claude_ai_entry(self):
+    def test_no_info_when_no_claude_ai_entry(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)), \
                  patch("mnemon.uninstall.detect_claude_ai_mnemon", return_value=False):
                 result = setup_claude_code()
-        assert "claude.ai-synced mnemon MCP registration detected" not in result
+        assert "Both local + web mnemon configured" not in result
 
-    def test_no_warning_in_remote_mode(self):
+    def test_no_info_in_remote_mode(self):
         """Remote-mode setup intentionally uses the HTTP MCP via
-        `claude mcp add`. It doesn't matter whether a claude.ai entry
-        also exists — we're explicitly in remote mode. No need for
-        the shadow warning."""
+        `claude mcp add`. The user explicitly chose web — the dual-
+        config notice would be redundant."""
         with tempfile.TemporaryDirectory() as tmpdir:
             mnemon_dir = Path(tmpdir) / ".mnemon"
             with patch("mnemon.setup.Path.home", return_value=Path(tmpdir)), \
@@ -797,14 +793,14 @@ class TestClaudeAiShadowWarning:
                 result = setup_claude_code(
                     remote_url="https://test.fly.dev/mcp", token="tok"
                 )
-        assert "claude.ai-synced mnemon MCP registration detected" not in result
+        assert "Both local + web mnemon configured" not in result
 
-    def test_warning_surfaced_for_claude_desktop_when_entry_exists(
+    def test_info_surfaced_for_claude_desktop_when_entry_exists(
         self, tmp_path, monkeypatch
     ):
         """Claude Desktop syncs MCP from claude.ai (same Anthropic
-        account), so the same shadow problem applies. Warning text
-        names Claude Desktop in the precedence message."""
+        account), so the same dual-config state can arise. Notice
+        names Claude Desktop in the precedence sentence."""
         from mnemon.setup import setup_claude_desktop
 
         monkeypatch.setattr("mnemon.setup.sys.platform", "darwin")
@@ -812,11 +808,10 @@ class TestClaudeAiShadowWarning:
 
         with patch("mnemon.uninstall.detect_claude_ai_mnemon", return_value=True):
             result = setup_claude_desktop()
-        assert "claude.ai-synced mnemon MCP registration detected" in result
-        assert "Claude Desktop will PREFER" in result
-        assert "Cursor + Gemini CLI are unaffected" in result
+        assert "Both local + web mnemon configured" in result
+        assert "Claude Desktop will use the web version (claude.ai-synced)" in result
 
-    def test_no_warning_for_claude_desktop_when_no_entry(
+    def test_no_info_for_claude_desktop_when_no_entry(
         self, tmp_path, monkeypatch
     ):
         from mnemon.setup import setup_claude_desktop
@@ -826,13 +821,13 @@ class TestClaudeAiShadowWarning:
 
         with patch("mnemon.uninstall.detect_claude_ai_mnemon", return_value=False):
             result = setup_claude_desktop()
-        assert "claude.ai-synced mnemon MCP registration detected" not in result
+        assert "Both local + web mnemon configured" not in result
 
-    def test_no_warning_for_claude_desktop_in_remote_mode(
+    def test_no_info_for_claude_desktop_in_remote_mode(
         self, tmp_path, monkeypatch
     ):
-        """As with Claude Code, remote-mode setup explicitly wants the
-        remote — no need for the shadow warning."""
+        """As with Claude Code, remote-mode setup explicitly wants
+        the remote — the dual-config notice would be redundant."""
         from mnemon.setup import setup_claude_desktop
 
         monkeypatch.setattr("mnemon.setup.sys.platform", "darwin")
@@ -850,7 +845,7 @@ class TestClaudeAiShadowWarning:
             result = setup_claude_desktop(
                 remote_url="https://test.fly.dev/mcp", token="tok"
             )
-        assert "claude.ai-synced mnemon MCP registration detected" not in result
+        assert "Both local + web mnemon configured" not in result
 
 
 class TestRefuseIfRemoteConfigured:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -769,7 +769,10 @@ class TestClaudeAiShadowWarning:
                 result = setup_claude_code()
         assert "claude.ai-synced mnemon MCP registration detected" in result
         assert "Claude Code will PREFER" in result
-        assert "Cursor + Claude Desktop are unaffected" in result
+        # Cursor + Gemini CLI are the not-synced clients (the unaffected
+        # ones); Claude Desktop DOES sync from claude.ai and is now
+        # warned about separately in setup_claude_desktop.
+        assert "Cursor + Gemini CLI are unaffected" in result
 
     def test_no_warning_when_no_claude_ai_entry(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -794,6 +797,59 @@ class TestClaudeAiShadowWarning:
                 result = setup_claude_code(
                     remote_url="https://test.fly.dev/mcp", token="tok"
                 )
+        assert "claude.ai-synced mnemon MCP registration detected" not in result
+
+    def test_warning_surfaced_for_claude_desktop_when_entry_exists(
+        self, tmp_path, monkeypatch
+    ):
+        """Claude Desktop syncs MCP from claude.ai (same Anthropic
+        account), so the same shadow problem applies. Warning text
+        names Claude Desktop in the precedence message."""
+        from mnemon.setup import setup_claude_desktop
+
+        monkeypatch.setattr("mnemon.setup.sys.platform", "darwin")
+        monkeypatch.setattr("mnemon.setup.Path.home", lambda: tmp_path)
+
+        with patch("mnemon.uninstall.detect_claude_ai_mnemon", return_value=True):
+            result = setup_claude_desktop()
+        assert "claude.ai-synced mnemon MCP registration detected" in result
+        assert "Claude Desktop will PREFER" in result
+        assert "Cursor + Gemini CLI are unaffected" in result
+
+    def test_no_warning_for_claude_desktop_when_no_entry(
+        self, tmp_path, monkeypatch
+    ):
+        from mnemon.setup import setup_claude_desktop
+
+        monkeypatch.setattr("mnemon.setup.sys.platform", "darwin")
+        monkeypatch.setattr("mnemon.setup.Path.home", lambda: tmp_path)
+
+        with patch("mnemon.uninstall.detect_claude_ai_mnemon", return_value=False):
+            result = setup_claude_desktop()
+        assert "claude.ai-synced mnemon MCP registration detected" not in result
+
+    def test_no_warning_for_claude_desktop_in_remote_mode(
+        self, tmp_path, monkeypatch
+    ):
+        """As with Claude Code, remote-mode setup explicitly wants the
+        remote — no need for the shadow warning."""
+        from mnemon.setup import setup_claude_desktop
+
+        monkeypatch.setattr("mnemon.setup.sys.platform", "darwin")
+        monkeypatch.setattr("mnemon.setup.Path.home", lambda: tmp_path)
+        mnemon_dir = tmp_path / ".mnemon"
+        monkeypatch.setattr("mnemon.setup.MNEMON_DIR", mnemon_dir)
+        monkeypatch.setattr(
+            "mnemon.setup.LOCAL_TOKEN_FILE", mnemon_dir / "local_token"
+        )
+        monkeypatch.setattr(
+            "mnemon.setup.REMOTE_URL_FILE", mnemon_dir / "remote_url"
+        )
+        with patch("mnemon.setup._preflight_remote_endpoint"), \
+             patch("mnemon.uninstall.detect_claude_ai_mnemon", return_value=True):
+            result = setup_claude_desktop(
+                remote_url="https://test.fly.dev/mcp", token="tok"
+            )
         assert "claude.ai-synced mnemon MCP registration detected" not in result
 
 

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -256,7 +256,7 @@ class TestClaudeAiWarnings:
 
         # Pre-action loud warning went to stderr
         err = capsys.readouterr().err
-        assert "claude.ai-synced mnemon MCP detected" in err
+        assert "claude.ai-synced mnemon MCP also configured" in err
         # Post-action summary has the REQUIRED bullet
         assert "REQUIRED" in result
         assert "claude.ai → Settings → Connected Apps" in result
@@ -269,7 +269,7 @@ class TestClaudeAiWarnings:
             result = uninstall(yes=True)
 
         err = capsys.readouterr().err
-        assert "claude.ai-synced mnemon MCP detected" not in err
+        assert "claude.ai-synced mnemon MCP also configured" not in err
         assert "REQUIRED" not in result
         # The generic hypothetical reminder still appears
         assert "If you use claude.ai" in result


### PR DESCRIPTION
Final pass before bumping rc5 → rc6. Bundles 5 small polish items the ROADMAP flagged as "before public release" plus a UX reframe that came out of the review discussion.

## Contents

| Concern | File | What |
|---------|------|------|
| README badge | `README.md` | Static `v0.6.0rc1` (5 RCs stale) → dynamic `shields.io/pypi/v/...` |
| Monitor alerting | `.github/workflows/health-monitor.yml` | Open / comment on / close a tracker GH issue automatically; ensures `health-monitor` label exists; reuses one canonical open issue |
| Uninstall message | `src/mnemon/uninstall.py:_claude_mcp_remove` | Reword the misleading "no mnemon registration found (or CLI errored silently)"; surface real stderr if non-"not found"-family |
| Schema-drift NOTE | `src/mnemon/persistent_sessions.py` counter dict | Comment warning that `scripts/check_health.py` reads these key names |
| Dual-config notice | `src/mnemon/setup.py` + `src/mnemon/uninstall.py` | Extends to Claude Desktop AND reframes from "⚠ shadow" alarm to "ℹ Both local + web configured. Claude Code/Desktop will use the web version (claude.ai-synced) by default." Web-takes-precedence isn't a problem state, it's the actual default behavior. Stdio config stays on disk as standby. |

## Why the reframe

The original "claude.ai-synced mnemon detected — Claude Code will PREFER that entry over the stdio registration we just added" framed a normal dual-config state as alarm ("you did something wrong"). With the helper renamed (`_claude_ai_shadow_warning_lines` → `_dual_config_info_lines`) and copy reworked, the message now reads as state-of-the-world. Behavior unchanged — same detection, same write-to-disk, same activation rules. The local stdio config still becomes active automatically if the user later removes the claude.ai entry.

## Test plan

- [x] Local: `pytest -m "not integration"` → 638 pass (was 635 + 3 new dual-config tests)
- [x] YAML: `yaml.safe_load(...)` parses health-monitor.yml cleanly
- [x] README badge: dynamic URL points at correct PyPI project
- [ ] Post-merge: next scheduled health-monitor run is green (auto-monitor stays quiet)
- [ ] Post-merge: trigger `workflow_dispatch` against an intentionally bad URL once to verify the issue-create path actually works (TBD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)