### PR TITLE
feat(auto-mirror): PostToolUse hook for client memory writes (0.6.0rc7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## [0.6.0rc7] - 2026-04-28
+
+### Added
+
+- **PostToolUse auto-mirror hook.** Closes the longstanding gap where
+  Claude Code (and any other MCP client with a local auto-memory
+  system) writes memory files to its private store but never
+  propagates them to the central mnemon vault. The hook installed by
+  `mnemon setup` fires on every `Write` / `Edit` / `MultiEdit` tool
+  call, no-ops unless the touched file lives under an auto-memory
+  directory (`~/.claude/projects/*/memory/*.md` or
+  `~/.config/mnemon/auto-memory/*.md`), and otherwise dispatches the
+  file's contents to mnemon via the same `MemoryClient` abstraction
+  used by the existing UserPromptSubmit / Stop hooks. Local + remote
+  modes both supported. Errors are surfaced via stderr per the
+  no-silent-fails posture; the hook never blocks Claude Code's
+  continued operation. Motivated by the 2026-04-28 alpha-test
+  incident where a session handoff written to local memory was never
+  mirrored to mnemon. With auto-mirror installed, `mnemon setup` is
+  the only step required: subsequent client memory writes appear in
+  mnemon automatically.
+- **`mnemon mirror <path> [--auto] [--timeout SEC]`** CLI subcommand
+  that the hook shells out to. Reads the file, parses YAML
+  frontmatter (PyYAML when available, minimal fallback parser
+  otherwise), dispatches `memory_save` with `title` from the `name`
+  frontmatter field, `content_type` from `type` (default `note`),
+  `description` prepended to the body as an italicized line, and
+  `source_client = "mnemon-mirror"`. `--auto` short-circuits when the
+  path doesn't match an auto-memory pattern. Idempotent: SHA-256
+  (title + content) dedup with a 600s window via
+  `~/.mnemon/mirror_dedup.json` so repeat saves of the same content
+  within ten minutes skip cleanly. Sync-loop guard: files with
+  `mnemon_sync_source: <doc_id>` in frontmatter are skipped
+  (placeholder for future `mnemon sync down` integration).
+- **`mnemon.mirror`** module exposing `mirror_path()` for programmatic
+  use and `run_cli()` for the subcommand entry.
+
+### Tests
+
+- 22 new tests in `tests/test_mirror.py` covering the auto-memory
+  path filter, frontmatter parsing, the four save/skip outcomes,
+  error paths, and CLI exit codes.
+- 13 new tests in `tests/test_hooks_auto_mirror.py` for the hook
+  handler — file_path extraction, trigger-tool whitelist
+  (Write/Edit/MultiEdit), unrelated-tool no-op, malformed stdin
+  absorption, expected `MirrorError` surfacing, and unexpected
+  exception swallow with stderr surfacing.
+- 3 new assertions in `tests/test_setup.py` locking the PostToolUse
+  entry shape (matcher = `Write|Edit|MultiEdit`, command points at
+  `mnemon.hooks.auto_mirror`, 12s timeout) in both local and remote
+  modes, plus a `setup_claude_code` integration check that the entry
+  reaches `~/.claude/settings.json`.
+
+Full suite: 675 passed (+38 from this feature; 4 sandbox-only setup
+errors in `tests/test_integration_remote.py` pre-exist on `main`,
+not introduced here).
+
 ## [0.6.0rc6] - 2026-04-26
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.6.0rc6"
+version = "0.6.0rc7"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.6.0rc6"
+__version__ = "0.6.0rc7"

--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -188,6 +188,18 @@ def main() -> None:
             print("  MNEMON_VAULT_NAME  vault name (default: default)")
             sys.exit(1)
 
+    elif command == "mirror":
+        # ``mnemon mirror <path>`` saves the contents of a memory file
+        # to mnemon. The path's frontmatter (``name``, ``description``,
+        # ``type``) drives the mnemon record's title/content/type. Used
+        # by the PostToolUse hook installed by ``mnemon setup`` so any
+        # Claude Code auto-memory write also lands in mnemon — closes
+        # the 2026-04-28 gap where local-memory writes silently
+        # diverged from the central vault. ``--auto`` short-circuits
+        # when the path doesn't match an auto-memory directory pattern.
+        from .mirror import run_cli
+        sys.exit(run_cli(args[1:]))
+
     elif command == "setup":
         # `mnemon setup` with no target auto-detects every installed
         # client and configures each. Explicit target names
@@ -408,6 +420,11 @@ Uninstall (remove all mnemon state from this machine):
 Server:
   mnemon serve              Start MCP server (stdio, local development)
   mnemon serve-remote       Start HTTP server (Streamable HTTP, production)
+
+Auto-mirror (PostToolUse hook installed by `mnemon setup`):
+  mnemon mirror <path>      Save a memory file (frontmatter-aware) to mnemon
+                            [--auto] no-op when path is outside auto-memory dirs
+                            [--timeout SEC] per-call client timeout (default 10)
 
 Local vault (development/server-side only):
   mnemon status             Show local vault health stats

--- a/src/mnemon/hooks/auto_mirror.py
+++ b/src/mnemon/hooks/auto_mirror.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Auto-mirror hook — Claude Code PostToolUse event.
+
+Fires on every Write / Edit / MultiEdit. No-ops unless the touched file
+matches an auto-memory directory pattern (per
+:func:`mnemon.mirror._is_auto_memory_path`). On a match, dispatches the
+file's contents to mnemon via the same path as the
+``mnemon mirror --auto`` CLI subcommand.
+
+Closes the 2026-04-28 gap where Claude Code's local auto-memory writes
+silently diverged from the central vault. Without this hook, every user
+running mnemon has to remember to call ``memory_save`` immediately after
+every local memory write — a discipline failure mode that surfaced on
+day-one of alpha testing.
+
+Hook input shape (Claude Code PostToolUse JSON):
+
+    {
+      "session_id": "...",
+      "transcript_path": "...",
+      "tool_name": "Write" | "Edit" | "MultiEdit",
+      "tool_input": {
+        "file_path": "/abs/path/to/file.md",
+        ...
+      },
+      "tool_response": {...}
+    }
+
+The hook reads ``tool_input.file_path`` and routes to
+:func:`mnemon.mirror.mirror_path` in ``--auto`` mode. Output is JSON on
+stdout (Claude Code ignores the body of the response for PostToolUse,
+but emits ``stderr`` directly into the operator's terminal — so any
+error message becomes visible).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+from .framework import log_hook_error, read_stdin, write_output
+
+# Tools whose Write events should trigger an auto-mirror check.
+# MultiEdit fires once per call regardless of edit count, so a single
+# memory file rewritten via MultiEdit produces one mirror attempt.
+_TOOLS_TRIGGERING_MIRROR = ("Write", "Edit", "MultiEdit")
+
+
+def _extract_file_path(hook_input: dict[str, Any]) -> str | None:
+    """Pull ``tool_input.file_path`` out of the PostToolUse payload.
+
+    Returns None when the payload is malformed, the tool is not in the
+    mirror trigger set, or the file_path field is missing/empty.
+    """
+    tool_name = hook_input.get("tool_name", "")
+    if tool_name not in _TOOLS_TRIGGERING_MIRROR:
+        return None
+
+    tool_input = hook_input.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return None
+
+    file_path = tool_input.get("file_path")
+    if not isinstance(file_path, str) or not file_path:
+        return None
+
+    return file_path
+
+
+def main() -> int:
+    """Hook entry point. Always exits 0 so a mirror failure never blocks
+    Claude Code's continued operation; the error is surfaced via stderr
+    so the operator sees it (and Claude sees it via the harness, per
+    ``feedback_surface_mnemon_unreachable``).
+    """
+    try:
+        hook_input = read_stdin()
+    except Exception as exc:  # noqa: BLE001 — top-level surface
+        log_hook_error("auto_mirror", "stdin parse", exc)
+        return 0
+
+    file_path = _extract_file_path(hook_input)
+    if file_path is None:
+        # Tool not in trigger set, or payload malformed. Silent no-op.
+        write_output({})
+        return 0
+
+    # Defer the mirror_path import so the hook stays cheap on the hot
+    # path (every Write tool call). PyYAML, hashing, and the dedup
+    # state-file IO all live behind this import.
+    from ..mirror import MirrorError, mirror_path
+
+    try:
+        result = mirror_path(Path(file_path), auto=True)
+    except MirrorError as exc:
+        # Expected failure modes (missing frontmatter, empty body,
+        # missing name). Surface to stderr so the operator + Claude
+        # both see the error; never block.
+        log_hook_error("auto_mirror", f"mirror {file_path}", exc)
+        write_output({})
+        return 0
+    except Exception as exc:  # noqa: BLE001 — top-level surface
+        # Unexpected — could be RemoteMemoryClient HTTP failure,
+        # auth problem, dispatch error. Same posture: surface, never
+        # block. Exit 0 so the harness prints the stderr line back to
+        # Claude per feedback_surface_mnemon_unreachable.
+        log_hook_error("auto_mirror", f"mirror {file_path}", exc)
+        write_output({})
+        return 0
+
+    if result.status == "saved":
+        # Brief operator-visible confirmation. PostToolUse hooks emit
+        # nothing user-facing by default; the stderr line is what shows
+        # up in Claude Code's hook activity log.
+        sys.stderr.write(
+            f"mnemon auto_mirror: saved {result.title!r}"
+            + (f" (#{result.doc_id})" if result.doc_id else "")
+            + "\n"
+        )
+        sys.stderr.flush()
+
+    write_output({})
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mnemon/mirror.py
+++ b/src/mnemon/mirror.py
@@ -1,0 +1,411 @@
+"""Mirror a local memory file to mnemon (vault or remote).
+
+Reads a memory file written by Claude Code's auto-memory system (or any
+file with a YAML frontmatter block + body), parses the frontmatter, and
+saves to mnemon via the standard :class:`MemoryClient` abstraction so
+the same code path works in local-stdio + remote-Fly modes.
+
+Two entry points:
+
+- :func:`mirror_path` — programmatic. Returns a structured result dict.
+- :func:`run_cli` — wraps ``mirror_path`` for the ``mnemon mirror`` CLI
+  subcommand and the ``mnemon.hooks.auto_mirror`` PostToolUse hook.
+
+Memory paths recognized in ``--auto`` mode (no-op outside these):
+
+- ``~/.claude/projects/*/memory/*.md`` — Claude Code auto-memory
+- ``~/.cursor/.../memory/*.md`` — Cursor auto-memory (when added)
+- ``~/.config/mnemon/auto-memory/*.md`` — generic local pattern
+
+The 2026-04-28 incident that motivated this module: Claude wrote a
+session handoff to its local auto-memory directory but failed to mirror
+it to mnemon — exactly the gap this hook closes when wired through
+``mnemon setup`` and the PostToolUse hook.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# Regex matching auto-memory directories whose writes should propagate
+# to mnemon. The ``--auto`` CLI flag short-circuits when ``file_path``
+# does not match — the hook fires on every Write tool call but the bulk
+# are unrelated source code edits.
+#
+# Anchored to ``$HOME`` to avoid surprising matches outside the user's
+# tree (e.g. an unrelated checkout that happens to have a ``memory/``
+# folder). Resolved at call time, not import, so per-test ``HOME``
+# overrides take effect.
+_AUTO_MEMORY_PATTERNS = (
+    # Claude Code auto-memory:
+    #   ~/.claude/projects/<encoded-cwd>/memory/<name>.md
+    re.compile(
+        r"^(?P<home>.+?)/\.claude/projects/[^/]+/memory/[^/]+\.md$"
+    ),
+    # Generic mnemon auto-memory location:
+    #   ~/.config/mnemon/auto-memory/<name>.md
+    re.compile(
+        r"^(?P<home>.+?)/\.config/mnemon/auto-memory/[^/]+\.md$"
+    ),
+)
+
+# Frontmatter delimiter: ``---`` on its own line at the start of the
+# file. Matches the format Claude Code's auto-memory uses + standard
+# YAML/Markdown frontmatter conventions.
+_FRONTMATTER_RE = re.compile(
+    r"^---\s*\n(?P<frontmatter>.*?)\n---\s*\n(?P<body>.*)$",
+    re.DOTALL,
+)
+
+# Identity marker injected when a memory file is itself a sync-down from
+# mnemon. The hook MUST skip these — re-mirroring would create an
+# infinite write loop. The presence of this key in the frontmatter is
+# load-bearing; future ``mnemon sync down`` paths should write it.
+_SYNC_SOURCE_KEY = "mnemon_sync_source"
+
+
+class MirrorError(Exception):
+    """Raised on unrecoverable mirror failures (frontmatter missing,
+    file unreadable, dispatch failure). The CLI surfaces the message;
+    the hook surfaces it to stderr so Claude sees it per
+    feedback_surface_mnemon_unreachable."""
+
+
+@dataclass
+class MirrorResult:
+    """Structured result from :func:`mirror_path`. ``status`` is one of:
+
+    - ``"saved"`` — successfully dispatched a ``memory_save`` call.
+    - ``"skipped_no_match"`` — ``--auto`` mode + path doesn't match
+      any auto-memory pattern. Expected for the bulk of Write events.
+    - ``"skipped_sync_source"`` — frontmatter has ``mnemon_sync_source``
+      key, indicating this file was synced *down* from mnemon. Avoids
+      mirror loops.
+    - ``"skipped_duplicate"`` — content hash matches a recent save
+      within the dedup window.
+    """
+
+    status: str
+    title: str | None = None
+    doc_id: int | None = None
+    elapsed_seconds: float | None = None
+    detail: str | None = None
+
+
+def _is_auto_memory_path(path: Path) -> bool:
+    """True iff ``path`` matches one of the auto-memory directory
+    patterns. Used by ``--auto`` mode to no-op on unrelated writes."""
+    s = str(path.expanduser().resolve())
+    return any(pat.match(s) for pat in _AUTO_MEMORY_PATTERNS)
+
+
+def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    """Parse YAML-style frontmatter from a memory file. Returns
+    ``(frontmatter_dict, body)``.
+
+    Implements a minimal subset of YAML — key/value pairs separated by
+    ``:`` — sufficient for memory files written by Claude Code's
+    auto-memory system. Avoids a hard dependency on PyYAML for the
+    common case; users with multi-line YAML in frontmatter can install
+    PyYAML and we'll opportunistically use it.
+
+    Raises :class:`MirrorError` if the frontmatter block is missing —
+    a memory file without a ``name`` is not safely mirrorable.
+    """
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        raise MirrorError(
+            "Memory file is missing the YAML frontmatter block. "
+            "Expected `---\\n...\\n---` at the top of the file."
+        )
+
+    fm_raw = match.group("frontmatter")
+    body = match.group("body")
+
+    # Try PyYAML if available — supports lists, multi-line strings, etc.
+    try:
+        import yaml  # type: ignore[import-not-found]
+
+        parsed = yaml.safe_load(fm_raw) or {}
+        if not isinstance(parsed, dict):
+            raise MirrorError(
+                f"Frontmatter parsed to {type(parsed).__name__}, expected dict."
+            )
+        return parsed, body
+    except ImportError:
+        pass
+
+    # Minimal fallback parser — handles ``key: value`` lines, ignores
+    # blanks + comments. Sufficient for Claude Code's frontmatter format.
+    parsed: dict[str, Any] = {}
+    for line in fm_raw.splitlines():
+        line = line.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        parsed[key.strip()] = value.strip()
+    return parsed, body
+
+
+def _content_hash(title: str, content: str) -> str:
+    """SHA-256 of (title + body), used for idempotent skip on
+    repeated saves of the same file."""
+    h = hashlib.sha256()
+    h.update(title.encode("utf-8"))
+    h.update(b"\x00")
+    h.update(content.encode("utf-8"))
+    return h.hexdigest()
+
+
+def _dedup_state_path() -> Path:
+    """Where mirror dedup state lives. Separate from the hook
+    framework's dedup file so a session_extractor save + a mirror save
+    of the same content don't collide."""
+    return Path.home() / ".mnemon" / "mirror_dedup.json"
+
+
+def _check_and_record_dedup(content_hash: str, window_sec: int = 600) -> bool:
+    """True iff this content_hash was saved within the last
+    ``window_sec`` seconds. Always records the new entry on miss so the
+    next call within the window is a hit."""
+    import time
+
+    path = _dedup_state_path()
+    now = time.time()
+    entries: list[dict[str, Any]] = []
+    if path.exists():
+        try:
+            entries = json.loads(path.read_text()) or []
+        except (json.JSONDecodeError, OSError):
+            entries = []
+
+    # Prune expired
+    entries = [e for e in entries if now - e.get("ts", 0) < window_sec]
+
+    for entry in entries:
+        if entry.get("hash") == content_hash:
+            return True
+
+    entries.append({"hash": content_hash, "ts": now})
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        path.write_text(json.dumps(entries))
+    except OSError:
+        # Read-only home (sandbox, container) — best effort, don't block
+        # the save itself. The mirror still happens; dedup just won't
+        # remember the hit next time.
+        pass
+    return False
+
+
+def mirror_path(
+    path: Path,
+    *,
+    auto: bool = False,
+    client: Any = None,
+    timeout: float = 10.0,
+) -> MirrorResult:
+    """Read ``path``, parse frontmatter, save to mnemon.
+
+    Parameters
+    ----------
+    path
+        Memory file. Must exist; must contain a YAML frontmatter block.
+    auto
+        If True, no-op when ``path`` does not match an auto-memory
+        directory pattern. Used by the PostToolUse hook to ignore the
+        bulk of unrelated Write events.
+    client
+        Optional :class:`MemoryClient` override (test seam). Defaults
+        to :func:`mnemon.hooks._client.get_client` which picks
+        local/remote based on current config.
+    timeout
+        Per-call timeout passed to the client. Local mode ignores this;
+        remote mode uses it.
+
+    Returns
+    -------
+    :class:`MirrorResult` with ``status`` describing the outcome.
+    """
+    path = path.expanduser().resolve()
+
+    if auto and not _is_auto_memory_path(path):
+        return MirrorResult(
+            status="skipped_no_match",
+            detail=f"Path {path} does not match any auto-memory pattern.",
+        )
+
+    if not path.exists():
+        raise MirrorError(f"Memory file does not exist: {path}")
+
+    text = path.read_text(encoding="utf-8")
+    frontmatter, body = _parse_frontmatter(text)
+
+    if frontmatter.get(_SYNC_SOURCE_KEY):
+        return MirrorResult(
+            status="skipped_sync_source",
+            detail=(
+                f"File has '{_SYNC_SOURCE_KEY}' frontmatter — synced down "
+                "from mnemon. Skipping to avoid mirror loop."
+            ),
+        )
+
+    title = (frontmatter.get("name") or "").strip()
+    if not title:
+        raise MirrorError(
+            "Frontmatter is missing a 'name' field; cannot derive a "
+            "memory title. Memory files must declare a name."
+        )
+
+    content_type = (frontmatter.get("type") or "note").strip() or "note"
+    description = (frontmatter.get("description") or "").strip()
+
+    # The mirrored memory's content is the file body. Description
+    # (if present) gets prepended as a single italicized line so it's
+    # visible in mnemon's search results without losing the body
+    # structure.
+    if description:
+        content = f"_{description}_\n\n{body.strip()}"
+    else:
+        content = body.strip()
+
+    if not content:
+        raise MirrorError(
+            f"Memory file body is empty after frontmatter strip: {path}"
+        )
+
+    chash = _content_hash(title, content)
+    if _check_and_record_dedup(chash):
+        return MirrorResult(
+            status="skipped_duplicate",
+            title=title,
+            detail="Identical content was already mirrored within the dedup window.",
+        )
+
+    if client is None:
+        from .hooks._client import get_client
+
+        client = get_client()
+
+    arguments: dict[str, Any] = {
+        "title": title,
+        "content": content,
+        "content_type": content_type,
+        "source_client": "mnemon-mirror",
+    }
+
+    result_text, elapsed = client.call_tool(
+        "memory_save",
+        arguments,
+        timeout=timeout,
+        client_label="mnemon-mirror",
+    )
+
+    # Best-effort doc_id parse — the memory_save tool returns
+    # human-readable text like "Saved memory #281: ...". Surface for
+    # the CLI but never fail on parse errors; the save already happened.
+    doc_id: int | None = None
+    m = re.search(r"#(\d+)", result_text or "")
+    if m:
+        try:
+            doc_id = int(m.group(1))
+        except ValueError:
+            pass
+
+    return MirrorResult(
+        status="saved",
+        title=title,
+        doc_id=doc_id,
+        elapsed_seconds=elapsed,
+        detail=(result_text or "").strip()[:200],
+    )
+
+
+def run_cli(argv: list[str]) -> int:
+    """``mnemon mirror <path> [--auto]`` entry point.
+
+    Returns a Unix-style exit code: 0 on success or expected skip,
+    non-zero on hard failure. The CLI dispatcher in :mod:`mnemon.cli`
+    delegates here.
+    """
+    auto = False
+    path_arg: str | None = None
+    timeout = 10.0
+
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--auto":
+            auto = True
+            i += 1
+        elif a == "--timeout" and i + 1 < len(argv):
+            try:
+                timeout = float(argv[i + 1])
+            except ValueError:
+                print(
+                    f"mnemon mirror: invalid --timeout {argv[i + 1]!r}",
+                    file=__import__("sys").stderr,
+                )
+                return 2
+            i += 2
+        elif a.startswith("--"):
+            print(
+                f"mnemon mirror: unknown flag {a!r}",
+                file=__import__("sys").stderr,
+            )
+            return 2
+        else:
+            if path_arg is not None:
+                print(
+                    "mnemon mirror: too many positional arguments "
+                    "(expected one path)",
+                    file=__import__("sys").stderr,
+                )
+                return 2
+            path_arg = a
+            i += 1
+
+    if path_arg is None:
+        print(
+            "Usage: mnemon mirror <path> [--auto] [--timeout SEC]",
+            file=__import__("sys").stderr,
+        )
+        return 2
+
+    path = Path(path_arg)
+    try:
+        result = mirror_path(path, auto=auto, timeout=timeout)
+    except MirrorError as exc:
+        print(f"mnemon mirror: {exc}", file=__import__("sys").stderr)
+        return 1
+    except Exception as exc:  # noqa: BLE001 — surface every error
+        print(
+            f"mnemon mirror: {type(exc).__name__}: {exc}",
+            file=__import__("sys").stderr,
+        )
+        return 1
+
+    if result.status == "saved":
+        suffix = f" (#{result.doc_id})" if result.doc_id else ""
+        print(f"Mirrored: {result.title!r}{suffix}")
+        return 0
+
+    if result.status.startswith("skipped"):
+        # Quiet by default in --auto mode (the hook fires on every
+        # Write); explicit invocation gets the detail line.
+        if not auto:
+            print(f"{result.status}: {result.detail or ''}".rstrip())
+        return 0
+
+    print(
+        f"mnemon mirror: unexpected status {result.status!r}",
+        file=__import__("sys").stderr,
+    )
+    return 1

--- a/src/mnemon/setup.py
+++ b/src/mnemon/setup.py
@@ -110,6 +110,27 @@ def _hooks_config(remote_url: str | None = None) -> dict:
                 "hooks": user_prompt_hooks,
             },
         ],
+        # PostToolUse auto-mirror — added 2026-04-28 (mnemon 0.6.0rc7)
+        # to close the gap surfaced when Claude wrote handoff files to
+        # local auto-memory but failed to mirror them to mnemon. Hook
+        # fires on Write/Edit/MultiEdit, no-ops unless the touched file
+        # matches an auto-memory directory pattern. The hook itself
+        # absorbs all errors (exit 0) and surfaces failures via stderr
+        # so Claude sees them per feedback_surface_mnemon_unreachable.
+        # 12s timeout: the dispatch path is local-fast or remote-fast
+        # via the same MemoryClient abstraction; hookd doesn't queue.
+        "PostToolUse": [
+            {
+                "matcher": "Write|Edit|MultiEdit",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": f"{py} -m mnemon.hooks.auto_mirror",
+                        "timeout": 12,
+                    },
+                ],
+            },
+        ],
         "Stop": [
             {
                 "matcher": "",
@@ -496,6 +517,7 @@ def setup_claude_code(*, remote_url: str | None = None, token: str | None = None
     if "hooks" not in settings:
         settings["hooks"] = {}
     settings["hooks"]["UserPromptSubmit"] = hooks["UserPromptSubmit"]
+    settings["hooks"]["PostToolUse"] = hooks["PostToolUse"]
     settings["hooks"]["Stop"] = hooks["Stop"]
     if "SessionStart" in hooks:
         settings["hooks"]["SessionStart"] = hooks["SessionStart"]
@@ -519,6 +541,7 @@ def setup_claude_code(*, remote_url: str | None = None, token: str | None = None
 
     hook_mode_tag = "remote" if remote_url else "local (in-process)"
     lines.append(f"  UserPromptSubmit: context-surfacing (8s, {hook_mode_tag})")
+    lines.append(f"  PostToolUse: auto-mirror (12s, {hook_mode_tag}) [Write|Edit|MultiEdit]")
     lines.append(f"  Stop: session-extractor (30s), handoff-generator (30s) [{hook_mode_tag}]")
     if remote_url:
         lines.append("  SessionStart: pre-warm polling (90s background)")
@@ -703,6 +726,7 @@ def setup_hooks(*, remote_url: str | None = None, token: str | None = None) -> s
     if "hooks" not in settings:
         settings["hooks"] = {}
     settings["hooks"]["UserPromptSubmit"] = hooks["UserPromptSubmit"]
+    settings["hooks"]["PostToolUse"] = hooks["PostToolUse"]
     settings["hooks"]["Stop"] = hooks["Stop"]
     if "SessionStart" in hooks:
         settings["hooks"]["SessionStart"] = hooks["SessionStart"]
@@ -721,6 +745,7 @@ def setup_hooks(*, remote_url: str | None = None, token: str | None = None) -> s
         ]
     out_lines += [
         "  UserPromptSubmit: context-surfacing (8s)",
+        "  PostToolUse: auto-mirror (12s) [Write|Edit|MultiEdit]",
         "  Stop: session-extractor (30s), handoff-generator (30s)",
     ]
     if remote_url:

--- a/tests/test_hooks_auto_mirror.py
+++ b/tests/test_hooks_auto_mirror.py
@@ -1,0 +1,255 @@
+"""Tests for the PostToolUse auto-mirror hook (0.6.0rc7).
+
+Exercises the JSON-stdin → file_path filter → mirror dispatch path
+with the trigger-tool whitelist (Write/Edit/MultiEdit). Uses the
+shared :func:`mnemon.mirror.mirror_path` so most logic is already
+covered by ``test_mirror.py``; this file locks the hook's integration
+shape.
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from mnemon.hooks import auto_mirror as hook_mod
+from mnemon.hooks.auto_mirror import _extract_file_path, main
+
+
+# ── _extract_file_path filter ───────────────────────────────────────────────
+class TestExtractFilePath:
+    def test_write_tool_extracts_path(self):
+        payload = {
+            "tool_name": "Write",
+            "tool_input": {"file_path": "/abs/path.md", "content": "x"},
+        }
+        assert _extract_file_path(payload) == "/abs/path.md"
+
+    def test_edit_tool_extracts_path(self):
+        payload = {
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "/abs/path.md"},
+        }
+        assert _extract_file_path(payload) == "/abs/path.md"
+
+    def test_multiedit_tool_extracts_path(self):
+        payload = {
+            "tool_name": "MultiEdit",
+            "tool_input": {"file_path": "/abs/path.md"},
+        }
+        assert _extract_file_path(payload) == "/abs/path.md"
+
+    def test_unrelated_tool_returns_none(self):
+        for tool in ("Bash", "Read", "Grep", "Glob", "WebSearch"):
+            payload = {
+                "tool_name": tool,
+                "tool_input": {"file_path": "/abs/path.md"},
+            }
+            assert _extract_file_path(payload) is None
+
+    def test_missing_tool_input_returns_none(self):
+        assert _extract_file_path({"tool_name": "Write"}) is None
+
+    def test_missing_file_path_returns_none(self):
+        payload = {"tool_name": "Write", "tool_input": {"content": "x"}}
+        assert _extract_file_path(payload) is None
+
+    def test_empty_file_path_returns_none(self):
+        payload = {"tool_name": "Write", "tool_input": {"file_path": ""}}
+        assert _extract_file_path(payload) is None
+
+
+# ── main() integration ──────────────────────────────────────────────────────
+def _stub_stdin(monkeypatch, payload):
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+
+
+def _stub_stdout(monkeypatch):
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+    return buf
+
+
+def _stub_stderr(monkeypatch):
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", buf)
+    return buf
+
+
+class TestMainIntegration:
+    def test_write_to_memory_path_triggers_mirror_save(self, tmp_path, monkeypatch):
+        # Build a real auto-memory file the hook can mirror
+        monkeypatch.setenv("HOME", str(tmp_path))
+        memory = tmp_path / ".claude" / "projects" / "x" / "memory" / "h.md"
+        memory.parent.mkdir(parents=True)
+        memory.write_text(
+            "---\nname: HookTest\ntype: handoff\n---\nThe body.\n"
+        )
+
+        # Stub the dispatch client so the test doesn't hit the real vault
+        fake_client = MagicMock()
+        fake_client.call_tool.return_value = (
+            'Saved memory #99: "HookTest"',
+            0.05,
+        )
+        from mnemon.hooks import _client as client_mod
+
+        monkeypatch.setattr(client_mod, "get_client", lambda: fake_client)
+
+        _stub_stdin(
+            monkeypatch,
+            {
+                "tool_name": "Write",
+                "tool_input": {"file_path": str(memory)},
+            },
+        )
+        _stub_stdout(monkeypatch)
+        err = _stub_stderr(monkeypatch)
+
+        rc = main()
+        assert rc == 0
+        # Client was called once with memory_save
+        assert fake_client.call_tool.call_count == 1
+        assert fake_client.call_tool.call_args[0][0] == "memory_save"
+        # Stderr confirms the save
+        assert "saved 'HookTest'" in err.getvalue()
+        assert "#99" in err.getvalue()
+
+    def test_write_to_non_memory_path_is_silent_no_op(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        unrelated = tmp_path / "src" / "main.py"
+        unrelated.parent.mkdir(parents=True)
+        unrelated.write_text("print('hi')\n")
+
+        fake_client = MagicMock()
+        from mnemon.hooks import _client as client_mod
+
+        monkeypatch.setattr(client_mod, "get_client", lambda: fake_client)
+
+        _stub_stdin(
+            monkeypatch,
+            {
+                "tool_name": "Write",
+                "tool_input": {"file_path": str(unrelated)},
+            },
+        )
+        _stub_stdout(monkeypatch)
+        err = _stub_stderr(monkeypatch)
+
+        rc = main()
+        assert rc == 0
+        # The mirror skip-no-match path is silent — no client call, no
+        # stderr output. The bulk of Write events are unrelated source
+        # edits; noisy logs would drown out real saves.
+        assert fake_client.call_tool.call_count == 0
+        assert err.getvalue() == ""
+
+    def test_unrelated_tool_is_no_op(self, tmp_path, monkeypatch):
+        # Bash + Read + Grep all trigger PostToolUse but should never
+        # fire the mirror path.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        fake_client = MagicMock()
+        from mnemon.hooks import _client as client_mod
+
+        monkeypatch.setattr(client_mod, "get_client", lambda: fake_client)
+
+        for tool_name in ("Bash", "Read", "Grep"):
+            _stub_stdin(
+                monkeypatch,
+                {
+                    "tool_name": tool_name,
+                    "tool_input": {"file_path": "/dev/null"},
+                },
+            )
+            _stub_stdout(monkeypatch)
+            _stub_stderr(monkeypatch)
+            rc = main()
+            assert rc == 0
+        assert fake_client.call_tool.call_count == 0
+
+    def test_malformed_stdin_does_not_block(self, monkeypatch):
+        # Hook framework's read_stdin raises on parse error. The hook
+        # must absorb it (exit 0) per "never block Claude Code's
+        # continued operation". Surface the error via stderr.
+        monkeypatch.setattr(sys, "stdin", io.StringIO("not json"))
+        out = _stub_stdout(monkeypatch)
+        err = _stub_stderr(monkeypatch)
+        rc = main()
+        assert rc == 0
+        # Expect a structured error line on stderr
+        assert "auto_mirror" in err.getvalue()
+
+    def test_mirror_error_is_logged_and_does_not_block(
+        self, tmp_path, monkeypatch
+    ):
+        # File matches the memory regex but has invalid frontmatter
+        # → MirrorError. Hook must surface to stderr + exit 0.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        bad = tmp_path / ".claude" / "projects" / "x" / "memory" / "bad.md"
+        bad.parent.mkdir(parents=True)
+        bad.write_text("no frontmatter here at all\n")
+
+        fake_client = MagicMock()
+        from mnemon.hooks import _client as client_mod
+
+        monkeypatch.setattr(client_mod, "get_client", lambda: fake_client)
+
+        _stub_stdin(
+            monkeypatch,
+            {
+                "tool_name": "Write",
+                "tool_input": {"file_path": str(bad)},
+            },
+        )
+        _stub_stdout(monkeypatch)
+        err = _stub_stderr(monkeypatch)
+
+        rc = main()
+        assert rc == 0
+        assert fake_client.call_tool.call_count == 0
+        assert "auto_mirror" in err.getvalue()
+        assert "missing the YAML frontmatter" in err.getvalue()
+
+    def test_unexpected_exception_is_swallowed_and_logged(
+        self, tmp_path, monkeypatch
+    ):
+        # Simulate an unexpected failure (e.g. RemoteMemoryClient timeout
+        # or auth error) — hook must NEVER block Claude. The error should
+        # be surfaced via stderr so the operator + Claude see it per
+        # feedback_surface_mnemon_unreachable.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        good = tmp_path / ".claude" / "projects" / "x" / "memory" / "g.md"
+        good.parent.mkdir(parents=True)
+        good.write_text(
+            "---\nname: G\ntype: note\n---\nbody\n"
+        )
+
+        # Fake client that raises a non-MirrorError
+        class _Boom:
+            def call_tool(self, *args, **kwargs):
+                raise RuntimeError("simulated remote failure")
+
+        from mnemon.hooks import _client as client_mod
+
+        monkeypatch.setattr(client_mod, "get_client", lambda: _Boom())
+
+        _stub_stdin(
+            monkeypatch,
+            {
+                "tool_name": "Write",
+                "tool_input": {"file_path": str(good)},
+            },
+        )
+        _stub_stdout(monkeypatch)
+        err = _stub_stderr(monkeypatch)
+
+        rc = main()
+        assert rc == 0
+        log = err.getvalue()
+        assert "auto_mirror" in log
+        assert "RuntimeError" in log
+        assert "simulated remote failure" in log

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -1,0 +1,269 @@
+"""Tests for ``mnemon.mirror`` and the ``mnemon mirror`` CLI subcommand
+introduced in 0.6.0rc7 to close the 2026-04-28 auto-memory gap (Claude
+wrote to local memory but failed to mirror to mnemon).
+
+Tests the parsing + dispatch logic in isolation (no real network or
+filesystem state outside the temp dir), the auto-mode path filter, the
+sync-source loop guard, the dedup window, and the CLI exit codes.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from mnemon import mirror as mirror_mod
+from mnemon.mirror import (
+    MirrorError,
+    MirrorResult,
+    _is_auto_memory_path,
+    _parse_frontmatter,
+    mirror_path,
+    run_cli,
+)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+@pytest.fixture
+def memory_dir(tmp_path, monkeypatch):
+    """Build a memory dir under ``tmp_path/.claude/projects/.../memory/``
+    so the auto-memory regex matches. Also redirects ``$HOME`` so the
+    dedup state file goes to a temp location instead of the user's real
+    ``~/.mnemon/`` (and so subsequent test runs don't see hits)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    d = tmp_path / ".claude" / "projects" / "myproject" / "memory"
+    d.mkdir(parents=True)
+    return d
+
+
+@pytest.fixture
+def memory_file(memory_dir):
+    """A sample auto-memory file with the standard frontmatter shape
+    Claude Code writes."""
+    p = memory_dir / "handoff_test.md"
+    p.write_text(
+        "---\n"
+        "name: Test handoff\n"
+        "description: A test memory file\n"
+        "type: handoff\n"
+        "---\n"
+        "Body content goes here.\n\n"
+        "Multiple paragraphs are fine.\n"
+    )
+    return p
+
+
+@pytest.fixture
+def fake_client():
+    """A MemoryClient stub that records calls and returns a stub
+    save-result. The real :func:`mirror_path` accepts a client kwarg
+    so tests don't have to monkeypatch the resolver."""
+    client = MagicMock()
+    client.call_tool.return_value = ('Saved memory #42: "Test handoff" [handoff]', 0.05)
+    return client
+
+
+# ── _is_auto_memory_path ────────────────────────────────────────────────────
+class TestAutoMemoryPathFilter:
+    def test_claude_code_memory_path_matches(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        p = tmp_path / ".claude" / "projects" / "x" / "memory" / "h.md"
+        p.parent.mkdir(parents=True)
+        p.write_text("test")
+        assert _is_auto_memory_path(p) is True
+
+    def test_random_source_file_does_not_match(self, tmp_path):
+        p = tmp_path / "src" / "main.py"
+        p.parent.mkdir(parents=True)
+        p.write_text("test")
+        assert _is_auto_memory_path(p) is False
+
+    def test_memory_file_under_other_project_dir_does_not_match(self, tmp_path):
+        # memory subdir but NOT under .claude/projects — must not match.
+        p = tmp_path / "some_repo" / "memory" / "notes.md"
+        p.parent.mkdir(parents=True)
+        p.write_text("test")
+        assert _is_auto_memory_path(p) is False
+
+    def test_generic_mnemon_auto_memory_path_matches(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        p = tmp_path / ".config" / "mnemon" / "auto-memory" / "n.md"
+        p.parent.mkdir(parents=True)
+        p.write_text("test")
+        assert _is_auto_memory_path(p) is True
+
+
+# ── _parse_frontmatter ──────────────────────────────────────────────────────
+class TestFrontmatterParse:
+    def test_parses_basic_keys(self):
+        text = (
+            "---\n"
+            "name: Hello\n"
+            "type: handoff\n"
+            "description: A short summary\n"
+            "---\n"
+            "Body here\n"
+        )
+        fm, body = _parse_frontmatter(text)
+        assert fm["name"] == "Hello"
+        assert fm["type"] == "handoff"
+        assert fm["description"] == "A short summary"
+        assert body.strip() == "Body here"
+
+    def test_missing_frontmatter_raises(self):
+        with pytest.raises(MirrorError, match="missing the YAML frontmatter"):
+            _parse_frontmatter("Just body text, no frontmatter\n")
+
+
+# ── mirror_path: happy paths ────────────────────────────────────────────────
+class TestMirrorPathSaved:
+    def test_saves_with_correct_arguments(self, memory_file, fake_client):
+        result = mirror_path(memory_file, client=fake_client)
+        assert result.status == "saved"
+        assert result.title == "Test handoff"
+        assert result.doc_id == 42
+        # Verify the call shape — arguments must include title, content,
+        # content_type, source_client.
+        args, kwargs = fake_client.call_tool.call_args
+        assert args[0] == "memory_save"
+        payload = args[1]
+        assert payload["title"] == "Test handoff"
+        assert payload["content_type"] == "handoff"
+        assert payload["source_client"] == "mnemon-mirror"
+        # Body must be present; description should also be merged in.
+        assert "Body content goes here." in payload["content"]
+        assert "_A test memory file_" in payload["content"]
+
+    def test_saves_without_description(self, memory_dir, fake_client):
+        p = memory_dir / "h.md"
+        p.write_text(
+            "---\n"
+            "name: NoDesc\n"
+            "type: note\n"
+            "---\n"
+            "Just a body.\n"
+        )
+        result = mirror_path(p, client=fake_client)
+        assert result.status == "saved"
+        payload = fake_client.call_tool.call_args[0][1]
+        assert payload["content"] == "Just a body."
+        # No leading italicized description line
+        assert not payload["content"].startswith("_")
+
+    def test_default_content_type_when_missing(self, memory_dir, fake_client):
+        p = memory_dir / "h.md"
+        p.write_text("---\nname: X\n---\nBody\n")
+        mirror_path(p, client=fake_client)
+        assert fake_client.call_tool.call_args[0][1]["content_type"] == "note"
+
+
+# ── mirror_path: skip paths ─────────────────────────────────────────────────
+class TestMirrorPathSkipped:
+    def test_auto_skips_non_memory_paths(self, tmp_path, fake_client):
+        p = tmp_path / "src" / "module.py"
+        p.parent.mkdir()
+        p.write_text("---\nname: X\n---\nBody")
+        result = mirror_path(p, auto=True, client=fake_client)
+        assert result.status == "skipped_no_match"
+        # Must NOT call the client when skipping
+        assert fake_client.call_tool.call_count == 0
+
+    def test_sync_source_marker_short_circuits(self, memory_dir, fake_client):
+        p = memory_dir / "synced.md"
+        p.write_text(
+            "---\n"
+            "name: Synced\n"
+            "type: note\n"
+            "mnemon_sync_source: 281\n"
+            "---\n"
+            "Body\n"
+        )
+        result = mirror_path(p, client=fake_client)
+        assert result.status == "skipped_sync_source"
+        assert fake_client.call_tool.call_count == 0
+
+    def test_dedup_skips_same_content_within_window(self, memory_file, fake_client):
+        # First call saves
+        first = mirror_path(memory_file, client=fake_client)
+        assert first.status == "saved"
+        # Second call with identical content within the dedup window
+        # should short-circuit
+        second = mirror_path(memory_file, client=fake_client)
+        assert second.status == "skipped_duplicate"
+        assert fake_client.call_tool.call_count == 1
+
+
+# ── mirror_path: error paths ────────────────────────────────────────────────
+class TestMirrorPathErrors:
+    def test_missing_file_raises(self, tmp_path, fake_client):
+        with pytest.raises(MirrorError, match="does not exist"):
+            mirror_path(tmp_path / "no.md", client=fake_client)
+
+    def test_missing_name_raises(self, memory_dir, fake_client):
+        p = memory_dir / "h.md"
+        p.write_text("---\ntype: note\n---\nBody\n")
+        with pytest.raises(MirrorError, match="missing a 'name'"):
+            mirror_path(p, client=fake_client)
+
+    def test_empty_body_raises(self, memory_dir, fake_client):
+        p = memory_dir / "h.md"
+        p.write_text("---\nname: X\n---\n\n")
+        with pytest.raises(MirrorError, match="body is empty"):
+            mirror_path(p, client=fake_client)
+
+
+# ── run_cli (CLI exit codes) ────────────────────────────────────────────────
+class TestRunCli:
+    def test_no_args_prints_usage_and_returns_2(self, capsys):
+        rc = run_cli([])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "Usage:" in err
+
+    def test_unknown_flag_returns_2(self, capsys):
+        rc = run_cli(["--bogus"])
+        assert rc == 2
+
+    def test_too_many_paths_returns_2(self, capsys):
+        rc = run_cli(["a.md", "b.md"])
+        assert rc == 2
+
+    def test_invalid_timeout_returns_2(self, capsys):
+        rc = run_cli(["--timeout", "abc", "a.md"])
+        assert rc == 2
+
+    def test_missing_file_returns_1(self, tmp_path, capsys):
+        rc = run_cli([str(tmp_path / "missing.md")])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "does not exist" in err
+
+    def test_auto_mode_skip_is_quiet(self, tmp_path, capsys, monkeypatch):
+        # Build a non-memory path and run with --auto. Should exit 0
+        # silently — the hook fires on every Write event so verbose
+        # skip-output would be log noise.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        p = tmp_path / "src" / "x.py"
+        p.parent.mkdir(parents=True)
+        p.write_text("---\nname: X\n---\nBody")
+        rc = run_cli(["--auto", str(p)])
+        out = capsys.readouterr()
+        assert rc == 0
+        assert out.out == ""
+        assert out.err == ""
+
+    def test_save_path_returns_0_and_prints_title(
+        self, memory_file, capsys, monkeypatch, fake_client
+    ):
+        # Patch get_client to return our stub
+        from mnemon.hooks import _client as client_mod
+
+        monkeypatch.setattr(client_mod, "get_client", lambda: fake_client)
+        rc = run_cli([str(memory_file)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Mirrored" in out
+        assert "Test handoff" in out
+        assert "#42" in out

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -62,8 +62,35 @@ class TestMcpConfig:
     def test_hooks_config_has_all_events(self):
         hooks = _hooks_config()
         assert "UserPromptSubmit" in hooks
+        assert "PostToolUse" in hooks
         assert "Stop" in hooks
         assert len(hooks["Stop"][0]["hooks"]) == 2  # extractor + handoff
+
+    def test_hooks_config_post_tool_use_targets_write_edit_multiedit(self):
+        """PostToolUse auto-mirror entry must scope to write-class tools
+        (added 0.6.0rc7). A wider matcher (e.g. ``*``) would fire on
+        every Bash/Read/Grep call — large per-prompt overhead and
+        irrelevant work."""
+        hooks = _hooks_config()
+        post = hooks["PostToolUse"]
+        assert len(post) == 1
+        entry = post[0]
+        assert entry["matcher"] == "Write|Edit|MultiEdit"
+        assert len(entry["hooks"]) == 1
+        cmd = entry["hooks"][0]["command"]
+        assert "mnemon.hooks.auto_mirror" in cmd
+        # Timeout sized for both local-vault dispatch and remote HTTP
+        # round-trip without queuing the user-visible Claude Code event
+        # loop.
+        assert entry["hooks"][0]["timeout"] == 12
+
+    def test_hooks_config_post_tool_use_present_in_remote_mode_too(self):
+        """The auto-mirror hook fires in remote mode too — the dispatch
+        path is the same MemoryClient abstraction in both modes."""
+        hooks = _hooks_config(remote_url="https://example.fly.dev/mcp")
+        assert "PostToolUse" in hooks
+        cmd = hooks["PostToolUse"][0]["hooks"][0]["command"]
+        assert "auto_mirror" in cmd
 
     def test_hooks_config_no_session_start_without_remote_url(self):
         hooks = _hooks_config()
@@ -181,6 +208,11 @@ class TestSetupClaudeCode:
             settings = json.loads(settings_path.read_text())
             assert settings.get("mcpServers", {}).get("mnemon") is None
             assert "UserPromptSubmit" in settings["hooks"]
+            assert "PostToolUse" in settings["hooks"]
+            # Auto-mirror hook (0.6.0rc7) — verify the entry shape
+            ptu = settings["hooks"]["PostToolUse"]
+            assert ptu[0]["matcher"] == "Write|Edit|MultiEdit"
+            assert "auto_mirror" in ptu[0]["hooks"][0]["command"]
             assert "Stop" in settings["hooks"]
             assert "SessionStart" not in settings["hooks"]
             assert "local (in-process)" in result


### PR DESCRIPTION
## Summary

Closes the longstanding gap where Claude Code (and other MCP clients with local auto-memory) writes memory files to a private store but never propagates them to mnemon. Surfaced 2026-04-28 in alpha testing: a session handoff was written to local memory but never reached mnemon — the user had to ask Claude after the fact whether the save had landed. With this hook installed, `mnemon setup` is the only step required.

## What lands

**Hook (`src/mnemon/hooks/auto_mirror.py`)**

- Fires on every `Write` / `Edit` / `MultiEdit` tool call (narrowed matcher so unrelated `Bash`/`Read`/`Grep` events don't pay overhead).
- No-ops unless the touched file matches an auto-memory pattern (`~/.claude/projects/*/memory/*.md` or `~/.config/mnemon/auto-memory/*.md`).
- Dispatches via the same `MemoryClient` abstraction as the existing UserPromptSubmit + Stop hooks. Works in both local-stdio and remote-Fly modes.
- Absorbs all errors (exit 0) and surfaces them via stderr per `feedback_surface_mnemon_unreachable`. Never blocks the agent.

**CLI (`mnemon mirror <path>`)**

- Reads file, parses YAML frontmatter (PyYAML when available; minimal key/value fallback otherwise), dispatches `memory_save` with `title` from `name`, `content_type` from `type` (default `note`), `description` prepended as italicized line, `source_client = mnemon-mirror`.
- `--auto` short-circuits when path doesn't match the auto-memory pattern (silent no-op so the hook stays cheap on the bulk of Write events).
- Idempotent: SHA-256(title + content) dedup with 600s window via `~/.mnemon/mirror_dedup.json`.
- Sync-loop guard: files with `mnemon_sync_source: <doc_id>` in frontmatter are skipped (placeholder for future `mnemon sync down`).

**Setup wiring (`src/mnemon/setup.py`)**

`_hooks_config()` adds a PostToolUse entry with matcher `Write|Edit|MultiEdit`, command `python -m mnemon.hooks.auto_mirror`, 12s timeout. Both `setup_claude_code` and `setup_hooks` write the entry to `~/.claude/settings.json`.

## Test plan

- **22 new tests** in `tests/test_mirror.py` — auto-memory path filter, frontmatter parsing, save/skip outcomes, error paths, CLI exit codes
- **13 new tests** in `tests/test_hooks_auto_mirror.py` — file_path extraction, trigger-tool whitelist, unrelated-tool no-op, malformed stdin, expected `MirrorError` surfacing, unexpected exception swallow + stderr surfacing
- **3 new assertions** in `tests/test_setup.py` — PostToolUse entry shape (matcher, command, 12s timeout) in both local and remote modes; `setup_claude_code` integration check that the entry reaches `settings.json`

Full suite: **675 passed** (+38 from this feature). 4 sandbox-only setup errors in `tests/test_integration_remote.py` pre-exist on `main` (verified by checkout + run; unrelated to this change).

## Manual verification (Brian)

After merge + PyPI publish:

```bash
pip install -U 'mnemon-memory[server]==0.6.0rc7'
mnemon upgrade web --app-name mnemon-memory   # if remote mode
# or for local:
mnemon setup claude-code
```

Then in any Claude Code session, write a file under `~/.claude/projects/<encoded-cwd>/memory/<name>.md` with frontmatter. The hook fires, mnemon ingests, mnemon search returns the new memory.

Failure modes to watch for during the soak:

- Hook timeout (>12s) — would log a Cloudflare WAF block or slow Fly cold-start. Visible in Claude Code's hook activity log.
- Frontmatter parse errors — surfaced via stderr with the file path and the specific `MirrorError` message.
- Mirror loop — guarded by the `mnemon_sync_source` frontmatter check; if a future sync-down lands without that key, this hook would re-mirror in a loop. Test enforces the guard.

## Sequencing

This PR opens against `main` (current 0.6.0rc6). After merge I'll build + publish 0.6.0rc7 to PyPI so you can `pip install -U` and start the soak.

## Related

- 2026-04-28 alpha-test incident: handoff written to local memory but not mirrored to mnemon (see ~/.claude/projects/.../memory/handoff_260428_predictor_collapse_arc.md and the mnemon save that landed only after Brian asked "was a mnemon memory saved?")
- `feedback_always_save_to_mnemon.md` — the user-defined preference this hook enforces structurally instead of relying on Claude's attention

🤖 Generated with [Claude Code](https://claude.com/claude-code)