### PR TITLE
chore: bump version to 0.6.0rc8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [0.6.0rc8] - 2026-04-29
+
+### Fixed
+
+- **`read_transcript` supports Claude Code's nested message envelope.**
+  Real Claude Code JSONL nests `{role, content}` under
+  `msg.message.role` / `msg.message.content` alongside metadata fields
+  (`parentUuid`, `sessionId`, `timestamp`, `cwd`, etc.). The existing
+  parser only handled the flat top-level `{"role": ..., "content":
+  ...}` format used by synthesized test fixtures, so it silently
+  returned an empty string against every real Claude Code session.
+  Result: `handoff_generator` and `session_extractor` Stop hooks both
+  short-circuit on the `len(transcript) < 200` check before saving
+  anything. Fix accepts both wire formats and tightens content-block
+  parsing so non-text blocks (`tool_use`, `tool_result`, `image`) are
+  explicitly skipped — only `{"type": "text", "text": ...}` blocks
+  contribute. PR #101.
+
+  Diagnosed against a real session JSONL: 1,151 lines, 0 with
+  top-level `role`, 814 with nested `message.role`. Live verified on
+  the same session post-fix: extracted 7,156 chars (was 0). Both Stop
+  hooks now save reliably from real Claude Code usage; the
+  productized auto-handoff infra finally works end-to-end against
+  the wire format Claude Code actually emits.
+
+### Tests
+
+- 6 new regression cases in `TestReadTranscript` using the nested
+  Claude Code wire format (envelope + metadata siblings + content as
+  list-of-blocks + `file-history-snapshot` lines + mixed flat/nested
+  in the same transcript). Test count 675 → 681.
+
 ## [0.6.0rc7] - 2026-04-28
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.6.0rc7"
+version = "0.6.0rc8"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.6.0rc7"
+__version__ = "0.6.0rc8"


### PR DESCRIPTION
Includes the 0.6.0rc7 → rc8 bump for the read_transcript Claude Code nested-envelope fix (PR #101). rc7 shipped 2026-04-28 with the auto-mirror productization; rc8 fixes the silent-since-forever bug in ``read_transcript`` that caused both Stop hooks (handoff_generator + session_extractor) to no-op against every real Claude Code session.

Files updated:
- pyproject.toml: version = "0.6.0rc7" → "0.6.0rc8"
- src/mnemon/__init__.py: __version__ = "0.6.0rc7" → "0.6.0rc8"
- CHANGELOG.md: new [0.6.0rc8] section above [0.6.0rc7]; documents the read_transcript fix + Stop-hook unblock + 6 new regression tests (675 → 681). Historical "added in 0.6.0rc7" references in tests/setup.py left as-is (correct provenance markers).

Test surface unchanged from PR #101 (681 passed; 4 pre-existing sandbox-only PermissionError setup failures in test_integration_ remote.py unrelated).

Companion to PR #101. After merge + reinstall in any active venv, Stop hooks resume saving handoffs + observations against real Claude Code usage automatically — closes the discipline-lapse failure mode that motivated the read_transcript investigation.