### PR TITLE
feat(ci): emit system-wide deploy changelog entry on push-to-main

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,40 @@
+name: System-wide deploy changelog
+
+# Emits one JSON entry to s3://alpha-engine-research/changelog/ on every
+# push-to-main. See alpha-engine-docs/.github/actions/append-changelog/README.md.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: changelog-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  append:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout (shallow)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Append to system-wide deploy changelog
+        uses: cipher813/alpha-engine-docs/.github/actions/append-changelog@main
+        with:
+          deploy_status: merged
+          deploy_workflow: changelog.yml


### PR DESCRIPTION
Minimal workflow that emits one JSON to `s3://alpha-engine-research/changelog/` on every push-to-main. Calls the `append-changelog` composite action in alpha-engine-docs.

PyPI tag-based deploys can be wired in a follow-up; today's scope is 'every merge logged' across the alpha-engine ecosystem.

Companion: alpha-engine-docs#3 (composite action + aggregator) — **MERGED**; alpha-engine-data#120 (IAM grant) — **MERGED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)