### PR TITLE
fix(oauth): grace window for rotated refresh tokens

### DIFF
--- a/src/mnemon/oauth_as.py
+++ b/src/mnemon/oauth_as.py
@@ -308,8 +308,19 @@ _AUTH_CODE_TTL_SEC = 600          # 10 min — RFC recommends ≤ 10 min
 _ACCESS_TOKEN_TTL_SEC = 3600      # 1 hour
 _REFRESH_TOKEN_TTL_SEC = 30 * 24 * 3600  # 30 days
 
+# After a refresh token is rotated, the old RT remains exchangeable for
+# the *same* new pair for this many seconds. Covers the case where the
+# token endpoint succeeded but the response didn't reach the client
+# (network blip, Fly cold-start delay, mcp-proxy retry) — the client's
+# retry presents the old RT, gets the same response back, and avoids
+# being kicked into a "reconnect required" state. Replay after this
+# window still returns invalid_grant. OAuth 2.1 recommends exactly this
+# pattern for rotating refresh tokens.
+_REFRESH_TOKEN_GRACE_SEC = 60
+
 _AUTH_CODES_FILENAME = "auth_codes.json"
 _REFRESH_TOKENS_FILENAME = "refresh_tokens.json"
+_ROTATED_TOKENS_FILENAME = "rotated_tokens.json"
 
 # Per-IP rate limit on failed /oauth/authorize passphrase attempts.
 # Deliberately in-memory (resets on restart) — this is best-effort
@@ -373,6 +384,23 @@ def _save_auth_codes(
 
 def _load_refresh_tokens(config: AuthorizationServerConfig) -> dict[str, dict[str, Any]]:
     return _load_token_file(_refresh_tokens_path(config), "refresh_tokens.json")
+
+
+def _rotated_tokens_path(config: AuthorizationServerConfig) -> Path:
+    return config.key_dir / _ROTATED_TOKENS_FILENAME
+
+
+def _load_rotated_tokens(config: AuthorizationServerConfig) -> dict[str, dict[str, Any]]:
+    """Load the rotated-RT idempotency cache, pruning entries past their
+    grace window. Used by /oauth/token to return the same new pair for a
+    retried refresh of an already-rotated RT."""
+    return _load_token_file(_rotated_tokens_path(config), "rotated_tokens.json")
+
+
+def _save_rotated_tokens(
+    config: AuthorizationServerConfig, entries: dict[str, dict[str, Any]]
+) -> None:
+    _save_token_file(_rotated_tokens_path(config), entries)
 
 
 def _save_refresh_tokens(
@@ -985,10 +1013,22 @@ async def _token_refresh(
         return
 
     # Rotation: consume the old refresh token regardless of outcome so a
-    # leaked token can only be used once.
+    # leaked token can only be used once. A small grace window (see
+    # _REFRESH_TOKEN_GRACE_SEC) lets a retried refresh of an already-
+    # rotated RT return the same new pair — without it, a network blip
+    # between the token endpoint and the client (claude.ai's mcp-proxy,
+    # in particular) silently bricks the connector.
     tokens = _load_refresh_tokens(config)
     record = tokens.pop(refresh_token, None)
     if record is None:
+        # Not in the live set. Check the rotated-RT cache: if this RT was
+        # rotated within the grace window, return the same pair we
+        # issued then (idempotent retry).
+        rotated = _load_rotated_tokens(config)
+        cached = rotated.get(refresh_token)
+        if cached is not None:
+            await _send_json(send, 200, cached["response"])
+            return
         await _send_json(send, 400, {
             "error": "invalid_grant",
             "error_description": "unknown, expired, or already-rotated refresh token",
@@ -1002,13 +1042,24 @@ async def _token_refresh(
         })
         return
 
-    tokens = _issue_token_pair(
+    new_pair = _issue_token_pair(
         config,
         subject=record["subject"],
         scope=record["scope"],
         client_id=record["client_id"],
     )
-    await _send_json(send, 200, tokens)
+
+    # Cache the response keyed by the *old* RT so a retried request with
+    # that RT gets the same pair back. expires_at drives the prune in
+    # _load_token_file, so the entry self-cleans after the grace window.
+    rotated = _load_rotated_tokens(config)
+    rotated[refresh_token] = {
+        "response": new_pair,
+        "expires_at": _now() + _REFRESH_TOKEN_GRACE_SEC,
+    }
+    _save_rotated_tokens(config, rotated)
+
+    await _send_json(send, 200, new_pair)
 
 
 # ── /oauth/register — Dynamic Client Registration (RFC 7591) ────────────────

--- a/tests/test_oauth_as.py
+++ b/tests/test_oauth_as.py
@@ -830,12 +830,143 @@ class TestServeTokenRefreshGrant:
         assert second["access_token"] != first["access_token"]
         assert second["refresh_token"] != first["refresh_token"]
 
-        # Old refresh token is now invalid.
+        # Old refresh token still works *within the grace window*, but
+        # returns the same new pair (idempotent retry support — see
+        # _REFRESH_TOKEN_GRACE_SEC). Replay after the window is rejected;
+        # that case is exercised in test_refresh_token_replay_after_grace_rejected.
         status3, _, body3 = await _run_asgi(
             serve_token, as_config, method="POST", body=refresh_form
         )
-        assert status3 == 400
-        assert b"invalid_grant" in body3
+        assert status3 == 200
+        third = json.loads(body3)
+        assert third == second
+
+    @pytest.mark.asyncio
+    async def test_refresh_token_replay_within_grace_returns_same_pair(
+        self, as_config, registered_client
+    ):
+        """A retried /oauth/token call presenting an already-rotated RT
+        within the grace window must return the exact same response —
+        same access_token, same refresh_token. This is the bug that
+        spontaneously disconnected the claude.ai mnemon connector when
+        a network blip caused mcp-proxy to retry a successful refresh."""
+        from mnemon.oauth_as import serve_token
+
+        code, verifier, params = await _issue_code(as_config, registered_client["client_id"])
+        from urllib.parse import urlencode
+        code_form = urlencode({
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": params["redirect_uri"],
+            "client_id": params["client_id"],
+            "code_verifier": verifier,
+        }).encode()
+        _, _, body1 = await _run_asgi(serve_token, as_config, method="POST", body=code_form)
+        first = json.loads(body1)
+
+        refresh_form = urlencode({
+            "grant_type": "refresh_token",
+            "refresh_token": first["refresh_token"],
+        }).encode()
+        _, _, body2 = await _run_asgi(serve_token, as_config, method="POST", body=refresh_form)
+        rotated_pair = json.loads(body2)
+
+        # Three more retries with the *same* old RT — all within the
+        # grace window — must each return the same rotated pair.
+        for _ in range(3):
+            status, _, body = await _run_asgi(
+                serve_token, as_config, method="POST", body=refresh_form
+            )
+            assert status == 200
+            assert json.loads(body) == rotated_pair
+
+    @pytest.mark.asyncio
+    async def test_refresh_token_replay_after_grace_rejected(
+        self, as_config, registered_client, monkeypatch
+    ):
+        """Replay of an already-rotated RT *after* the grace window
+        expires must fail with invalid_grant — the grace window is for
+        idempotent retries, not indefinite token reuse."""
+        import mnemon.oauth_as as oauth_as
+        from mnemon.oauth_as import serve_token
+
+        code, verifier, params = await _issue_code(as_config, registered_client["client_id"])
+        from urllib.parse import urlencode
+        code_form = urlencode({
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": params["redirect_uri"],
+            "client_id": params["client_id"],
+            "code_verifier": verifier,
+        }).encode()
+        _, _, body1 = await _run_asgi(serve_token, as_config, method="POST", body=code_form)
+        first = json.loads(body1)
+
+        refresh_form = urlencode({
+            "grant_type": "refresh_token",
+            "refresh_token": first["refresh_token"],
+        }).encode()
+        await _run_asgi(serve_token, as_config, method="POST", body=refresh_form)
+
+        # Advance the clock past the grace window. The cached entry's
+        # expires_at < now means _load_token_file's prune drops it on
+        # next read, so the replay falls through to invalid_grant.
+        real_now = oauth_as._now
+        monkeypatch.setattr(
+            oauth_as, "_now", lambda: real_now() + oauth_as._REFRESH_TOKEN_GRACE_SEC + 1
+        )
+        status, _, body = await _run_asgi(
+            serve_token, as_config, method="POST", body=refresh_form
+        )
+        assert status == 400
+        assert b"invalid_grant" in body
+
+    @pytest.mark.asyncio
+    async def test_rotation_grace_persists_across_restart(
+        self, as_config, registered_client
+    ):
+        """The rotation cache lives in rotated_tokens.json on the same
+        volume as refresh_tokens.json, so a Fly cold-start between the
+        original rotation and the retry must still serve the cached
+        pair. Without persistence, a wake-on-request retry would brick
+        the connector — exactly the regression we're guarding against."""
+        from mnemon.oauth_as import (
+            serve_token,
+            _load_rotated_tokens,
+            _save_rotated_tokens,
+        )
+
+        code, verifier, params = await _issue_code(as_config, registered_client["client_id"])
+        from urllib.parse import urlencode
+        code_form = urlencode({
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": params["redirect_uri"],
+            "client_id": params["client_id"],
+            "code_verifier": verifier,
+        }).encode()
+        _, _, body1 = await _run_asgi(serve_token, as_config, method="POST", body=code_form)
+        first = json.loads(body1)
+
+        refresh_form = urlencode({
+            "grant_type": "refresh_token",
+            "refresh_token": first["refresh_token"],
+        }).encode()
+        _, _, body2 = await _run_asgi(serve_token, as_config, method="POST", body=refresh_form)
+        rotated_pair = json.loads(body2)
+
+        # Simulate a process restart by round-tripping the rotated cache
+        # through the on-disk file. If persistence is broken, the retry
+        # below will fail with invalid_grant.
+        cache = _load_rotated_tokens(as_config)
+        assert first["refresh_token"] in cache
+        _save_rotated_tokens(as_config, cache)
+
+        status, _, body = await _run_asgi(
+            serve_token, as_config, method="POST", body=refresh_form
+        )
+        assert status == 200
+        assert json.loads(body) == rotated_pair
 
     @pytest.mark.asyncio
     async def test_unknown_refresh_token_rejected(self, as_config):


### PR DESCRIPTION
## Summary

- Adds a 60s grace window so a retried `/oauth/token` presenting an already-rotated refresh token returns the *same* new pair (idempotent retry) instead of `invalid_grant`.
- Cache is persisted to `{key_dir}/rotated_tokens.json` so it survives Fly cold-starts — the case where the bug bites hardest.
- Replay after the window still fails `invalid_grant` (the leaked-token defense is preserved).

## Why

Brian's claude.ai connector to `mnemon-memory.fly.dev` has been spontaneously disconnecting and requiring manual reconnect. Today's investigation found the cause:

1. `min_machines_running: 0` + Claude Desktop has no warm-keeper hook → Fly machine auto-stops after idle (today: stopped 05:01 PT, woke 05:46 PT).
2. When claude.ai's mcp-proxy refreshes its access token during/after a wake, a transient error or cold-start delay can cause it to retry the `/oauth/token` call.
3. Today's `_token_refresh` in `oauth_as.py` is single-use only: the first request rotated the RT successfully, but the retry hit `tokens.pop()` → `None` → `invalid_grant` → claude.ai marks the connector dead.

This pattern is documented in OAuth 2.1 — RT rotation should accept replay within a small grace window precisely to handle network-induced double-submit. We didn't.

The fly server's `clients.json` shows three `client_name: "Claude"` DCR entries (issued 4/13, 4/13, and today) — confirming this has happened at least twice before today.

## Test plan
- [x] 87/87 OAuth tests pass (`pytest tests/test_oauth_as.py`)
- [x] 688/688 full suite passes (`pytest`)
- [x] New: `test_refresh_token_replay_within_grace_returns_same_pair`
- [x] New: `test_refresh_token_replay_after_grace_rejected`
- [x] New: `test_rotation_grace_persists_across_restart` (Fly cold-start scenario)
- [x] Updated: `test_refresh_token_rotates` to reflect new replay-within-grace behavior
- [ ] After merge + Fly redeploy: monitor `/health` + Fly access logs for spontaneous reconnects; expect zero new `POST /oauth/register` from `client_name: "Claude"` over the next ~week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)