### PR TITLE
chore: bump version to 0.6.0rc9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [0.6.0rc9] - 2026-05-02
+
+### Fixed
+
+- **OAuth refresh-token rotation grace window.** A retried `/oauth/token`
+  call presenting an already-rotated refresh token within 60 seconds
+  now returns the *same* new pair (idempotent retry) instead of
+  `invalid_grant`. Closes a class of spontaneous claude.ai connector
+  disconnects: when Fly auto-stops the machine and a wake-on-request
+  cold-start delays the response, claude.ai's mcp-proxy retries the
+  refresh; the original request had already rotated the RT, so the
+  retry would brick the connector and force the user to manually
+  reconnect. The cache (`{key_dir}/rotated_tokens.json`) is persisted
+  to the same volume as `refresh_tokens.json` so it survives the very
+  Fly restarts that trigger the bug. Replay after the grace window
+  still returns `invalid_grant` — leaked-token defense preserved.
+  PR #107.
+
+### Tests
+
+- 3 new tests in `TestServeTokenRefreshGrant`: replay-within-grace
+  returns identical pair (covering 3 retries), replay-after-grace
+  rejected, and rotation-cache persists across simulated restart
+  (the Fly cold-start scenario). 1 existing test updated to reflect
+  the new replay-within-grace behavior. 684 → 688 passing.
+
 ## [0.6.0rc8] - 2026-04-29
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.6.0rc8"
+version = "0.6.0rc9"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.6.0rc8"
+__version__ = "0.6.0rc9"


### PR DESCRIPTION
## Summary

- rc8 → rc9 for the OAuth refresh-token rotation grace window shipped in #107.
- Files: `pyproject.toml`, `src/mnemon/__init__.py`, `CHANGELOG.md`.

## Soak plan

Once merged, push-to-main triggers Fly redeploy automatically. Monitor for ~7 days:
- `/health` metrics (resume_hits, stale_session_misses) stay clean
- Fly access logs show no new `POST /oauth/register` from `client_name: "Claude"` (the disconnect signature)

If clean, promote to `0.6.0` stable + PyPI publish + LinkedIn announcement (mnemon onboarding handoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)