### PR TITLE
fix(server): use json_response=True so fresh sessions don't deadlock

### DIFF
--- a/src/mnemon/server_remote.py
+++ b/src/mnemon/server_remote.py
@@ -147,12 +147,24 @@ def run_remote() -> None:
             f"Pruned {expired} expired MCP session(s) from {sessions_db}",
             file=sys.stderr,
         )
+    # json_response=True flips StreamableHTTP into discrete request/
+    # response mode (one POST → one JSON body, no long-lived SSE stream
+    # per session). Required for mnemon: upstream's session-creation
+    # lock is held for the full duration of `handle_request`, and in
+    # SSE mode `handle_request` keeps the stream open until the client
+    # disconnects — so once one session is open, every fresh-session
+    # POST queues behind it indefinitely. mnemon's tools are all
+    # single-shot RPCs (no streaming, no server-initiated messages),
+    # so the SSE channel buys nothing and only exposes this hang.
+    # Symptom this fixes: `mnemon doctor` and any `streamablehttp_client`
+    # consumer timing out at session.initialize() while concurrent
+    # requests sit in the lock queue.
     mcp._session_manager = PersistentSessionManager(
         app=mcp._mcp_server,
         session_store=session_store,
         event_store=mcp._event_store,
         retry_interval=mcp._retry_interval,
-        json_response=mcp.settings.json_response,
+        json_response=True,
         stateless=mcp.settings.stateless_http,
         security_settings=mcp.settings.transport_security,
     )

--- a/tests/test_server_remote.py
+++ b/tests/test_server_remote.py
@@ -49,6 +49,54 @@ class TestRemoteConfig:
             assert not config.enabled
 
 
+class TestSessionManagerConfig:
+    """Regression tests for the StreamableHTTP session manager wiring.
+
+    These pin ``json_response=True`` because flipping it back to False
+    re-introduces a hang: upstream's ``_session_creation_lock`` is held
+    for the full duration of ``handle_request``, and in SSE response
+    mode ``handle_request`` keeps the per-session SSE stream open until
+    the client disconnects — so once one session is alive, every
+    fresh-session POST queues behind the lock indefinitely. mnemon's
+    tools are all single-shot RPCs, so json_response=True is the
+    correct mode and must stay pinned True.
+    """
+
+    def test_session_manager_uses_json_response(self, monkeypatch, tmp_path):
+        """Capture the kwargs passed to PersistentSessionManager when
+        ``server_remote.main`` runs and assert ``json_response=True``.
+        Bails out via SystemExit after the manager is instantiated so
+        we don't actually start uvicorn."""
+        import sys
+
+        captured: dict = {}
+
+        def fake_manager(*args, **kwargs):
+            captured.update(kwargs)
+            raise SystemExit("captured — abort before uvicorn.run")
+
+        monkeypatch.setattr(
+            "mnemon.persistent_sessions.PersistentSessionManager", fake_manager
+        )
+        monkeypatch.setenv("MNEMON_LOCAL_TOKEN", "x" * 32)
+        monkeypatch.setenv("MNEMON_VAULT_DIR", str(tmp_path))
+        monkeypatch.setenv("MNEMON_PUBLIC_URL", "http://127.0.0.1:8502")
+        monkeypatch.setenv("MNEMON_ALLOWED_HOSTS", "127.0.0.1,127.0.0.1:8502")
+        monkeypatch.delenv("MNEMON_AS_ENABLED", raising=False)
+
+        for mod_name in ("mnemon.server_remote",):
+            sys.modules.pop(mod_name, None)
+        from mnemon.server_remote import run_remote
+
+        with pytest.raises(SystemExit):
+            run_remote()
+
+        assert captured.get("json_response") is True, (
+            f"PersistentSessionManager must be wired with json_response=True; "
+            f"got {captured.get('json_response')!r}. See class docstring for why."
+        )
+
+
 class TestMcpServer:
     def test_mcp_has_tools(self):
         from mnemon.server import mcp


### PR DESCRIPTION
## Summary

`mnemon doctor`, any `streamablehttp_client` consumer, and even direct curl POSTs to `/mcp` were hanging past 60s on `session.initialize()` against a freshly-deployed rc9 server. Reproduces immediately on a fresh `fly machine restart` — not stale state.

**Fix:** wire `PersistentSessionManager` with `json_response=True` so each MCP request is a discrete request/response pair instead of keeping a per-session SSE stream open.

## Why

Upstream's `StreamableHTTPSessionManager._handle_stateful_request` (python-sdk `streamable_http_manager.py` L213-L306) holds `_session_creation_lock` for the full duration of `handle_request`. In SSE response mode (`json_response=False`, the previous mnemon default), `handle_request` keeps the per-session SSE stream open until the client disconnects. Result: once one session is alive, every fresh-session POST queues behind the lock indefinitely. mnemon's `PersistentSessionManager._resume_session` has the same shape and amplifies it after Fly cold-stops.

mnemon's tools are all single-shot RPCs — no streaming, no server-initiated messages, no resumable long-polls — so the SSE channel buys nothing and only exposes this hang.

## Verification

Local server with the patch:
- 3 sequential `streamablehttp_client` round-trips: **0.22s / 0.02s / 0.02s** (was 60s+ timeout against rc9 prod)
- `mnemon doctor` 6/7 pass + 1 expected warning, total runtime **0.385s** (was 30s+ timeout)

## Test plan

- [x] 689/689 pytest passes (was 688 — adds 1 new regression test)
- [x] New `TestSessionManagerConfig::test_session_manager_uses_json_response` captures `PersistentSessionManager` kwargs during `run_remote()` and asserts `json_response=True` — pins the config so it can't silently flip back
- [ ] After merge → rc10 bump → PyPI publish → Fly redeploy: rerun `mnemon doctor` against `mnemon-memory.fly.dev` and confirm all 7 checks pass with no timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)