### PR TITLE
chore: bump version to 0.6.0rc10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [0.6.0rc10] - 2026-05-02
+
+### Fixed
+
+- **MCP fresh-session deadlock — `json_response=True` for the
+  StreamableHTTP session manager.** `mnemon doctor`, any
+  `streamablehttp_client` consumer, and direct curl POSTs to `/mcp`
+  were hanging past 60s on `session.initialize()` against a freshly-
+  deployed rc9 server. Reproduces immediately on a fresh
+  `fly machine restart` — not stale state. Root cause: upstream's
+  `StreamableHTTPSessionManager._handle_stateful_request` holds
+  `_session_creation_lock` for the full duration of `handle_request`,
+  and in SSE response mode (`json_response=False`, the previous
+  default) `handle_request` keeps the per-session SSE stream open
+  until the client disconnects — so once one session is alive,
+  every fresh-session POST queues behind the lock indefinitely.
+  mnemon's tools are all single-shot RPCs, so the SSE channel buys
+  nothing and only exposes this hang. Fix: pin `json_response=True`
+  in `server_remote.run_remote` so each POST is a discrete request/
+  response pair. Symptom user-side was Claude Desktop `memory_save`
+  calls stalling indefinitely. PR #109.
+
+### Tests
+
+- New `TestSessionManagerConfig::test_session_manager_uses_json_response`
+  in `tests/test_server_remote.py` captures
+  `PersistentSessionManager` kwargs during `run_remote()` and asserts
+  `json_response=True` so this can't silently flip back. 688 → 689
+  passing.
+
 ## [0.6.0rc9] - 2026-05-02
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.6.0rc9"
+version = "0.6.0rc10"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.6.0rc9"
+__version__ = "0.6.0rc10"


### PR DESCRIPTION
## Summary

- rc9 → rc10 for the MCP fresh-session deadlock fix shipped in #109.
- Files: `pyproject.toml`, `src/mnemon/__init__.py`, `CHANGELOG.md`.

## Soak plan

Once merged → PyPI publish → Fly redeploy via `mnemon upgrade web`. Soak window restarts now with both fixes baked in:
- OAuth refresh-token rotation grace window (#107)
- `json_response=True` session-manager config (#109)

Promotion to `0.6.0` stable when both signals stay clean for ~7 days:
- Zero new `POST /oauth/register` from `client_name: "Claude"` in Fly access logs
- Zero new `mnemon doctor` timeouts or Claude Desktop save-stall reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)