### PR TITLE
fix(hooks): collapse handoff_generator per-Stop noise via 3 gates

### DIFF
--- a/src/mnemon/hooks/handoff_generator.py
+++ b/src/mnemon/hooks/handoff_generator.py
@@ -7,12 +7,69 @@ Saved as a "handoff" memory with 30-day half-life.
 Phase 3 unification: saves go to the Fly vault via _remote_client
 (``memory_save`` tool call). LLM summarization remains local.
 Falls back to regex heuristics if LLM is unavailable.
+
+Stop fires after every assistant turn, not once per session — so without
+gates this hook saves a fresh handoff per prompt. A 30-prompt
+conversation produces ~30 near-duplicate ``handoff`` rows whose
+``session_extractor`` cousin can't dedup cross-hook. The three gates
+below collapse that to roughly one save per ``HANDOFF_DEBOUNCE_SEC``
+window per session_id, plus skip the trivial / system-generated
+transcripts that aren't real sessions:
+
+1. **Trivial-prompt skip** — first user line matches a slash-command,
+   notification payload, or test-output paste. These aren't real
+   prompts and shouldn't seed a "Session: ..." memory.
+2. **Per-session debounce** — small JSON file at
+   ``~/.mnemon/handoff_session_state.json`` tracks last save time per
+   ``session_id``. Inside the cooldown, the hook returns before paying
+   the LLM cost.
+3. **Remote vector dedup** — final belt-and-suspenders check against
+   recent vault content, mirroring ``session_extractor``'s
+   ``is_duplicate_remote`` posture.
 """
 
 from __future__ import annotations
 
+import json
 import re
 import sys
+import time
+from pathlib import Path
+
+from ..config import HOOK_DEDUP_SIMILARITY_THRESHOLD, HOOK_DEDUP_TIMEOUT_SEC
+
+# ── Filters ────────────────────────────────────────────────────────────────
+
+# How long after a successful save to treat new Stop events on the same
+# session_id as no-ops. 600s ≈ 10 minutes — long enough to absorb a
+# normal back-and-forth working session, short enough that genuinely
+# distinct work later in the day still produces a new handoff.
+HANDOFF_DEBOUNCE_SEC = 600
+
+# Per-session debounce state. Schema: ``{session_id: last_save_ts}``.
+# Pruned on read; entries older than 24h are dropped to keep the file
+# from growing unbounded.
+_SESSION_STATE_PATH = Path.home() / ".mnemon" / "handoff_session_state.json"
+_SESSION_STATE_PRUNE_SEC = 86400
+
+# Patterns matched against the first ``[user]:`` line in the transcript.
+# These all indicate non-prompt content surfacing as the conversation's
+# nominal opening message — slash-command bodies (loop fires, etc.),
+# Claude Code system payloads, and pasted tool output.
+_TRIVIAL_FIRST_PROMPT_PATTERNS = (
+    re.compile(r"^#\s*/loop\b", re.I),
+    re.compile(r"^<[a-z-]+-(?:notification|caveat|output)\b", re.I),
+    re.compile(r"^<command-name>", re.I),
+    re.compile(r"^={5,}"),
+    re.compile(r"^short test summary info", re.I),
+)
+
+# Minimum length of the first user prompt after trimming. Catches one-
+# word replies like "yes", "done", "pr merged" that don't carry enough
+# signal to seed a handoff.
+_MIN_FIRST_PROMPT_CHARS = 15
+
+CLIENT_LABEL_DEDUP = "claude-code-handoff-generator-dedup"
 
 # ── LLM Summarization ──────────────────────────────────────────────────────
 
@@ -100,6 +157,105 @@ def generate_with_regex(transcript: str) -> dict | None:
     return {"title": first_topic[:60], "summary": "\n".join(bullets)}
 
 
+# ── Filters & dedup ────────────────────────────────────────────────────────
+
+def _first_user_line(transcript: str) -> str:
+    """Return the first ``[user]:`` line in the transcript, with the prefix
+    stripped and surrounding whitespace trimmed. Empty string if the
+    transcript carries no user lines (the regex fallback rejects that
+    shape elsewhere; this helper just normalizes the lookup)."""
+    for line in transcript.split("\n"):
+        if line.startswith("[user]: "):
+            return line[len("[user]: "):].strip()
+    return ""
+
+
+def is_trivial_first_prompt(first_user: str) -> bool:
+    """True if the first user line is a slash-command body, system
+    payload, pasted tool output, or too short to carry session signal.
+
+    Real prompts can be short, but anything under ``_MIN_FIRST_PROMPT_CHARS``
+    after trimming is in practice a follow-up like "yes" / "done" /
+    "pr merged" — not a session-opening message that should seed a
+    "Session: ..." memory title."""
+    if not first_user or len(first_user) < _MIN_FIRST_PROMPT_CHARS:
+        return True
+    return any(p.match(first_user) for p in _TRIVIAL_FIRST_PROMPT_PATTERNS)
+
+
+def _load_session_state() -> dict[str, float]:
+    """Read + prune the session debounce state file. Tolerant of missing
+    files, parse errors, and OSError on read — any failure mode returns
+    an empty dict so the hook saves rather than silently no-ops."""
+    if not _SESSION_STATE_PATH.exists():
+        return {}
+    try:
+        raw = json.loads(_SESSION_STATE_PATH.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    now = time.time()
+    return {
+        sid: ts
+        for sid, ts in raw.items()
+        if isinstance(sid, str)
+        and isinstance(ts, (int, float))
+        and now - ts < _SESSION_STATE_PRUNE_SEC
+    }
+
+
+def _record_session_save(session_id: str, state: dict[str, float]) -> None:
+    """Persist ``state`` with ``session_id`` stamped at now. Best-effort
+    — read-only home (sandbox, container) silently swallows the write
+    so the save itself isn't blocked."""
+    state[session_id] = time.time()
+    try:
+        _SESSION_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _SESSION_STATE_PATH.write_text(json.dumps(state))
+    except OSError:
+        pass
+
+
+def should_save_for_session(session_id: str) -> bool:
+    """True iff this session_id has not had a handoff saved within
+    ``HANDOFF_DEBOUNCE_SEC``. Empty / missing session_id → always True
+    (degrades to legacy per-Stop behavior so a malformed hook payload
+    doesn't drop a real save)."""
+    if not session_id:
+        return True
+    state = _load_session_state()
+    last = state.get(session_id, 0.0)
+    return time.time() - last >= HANDOFF_DEBOUNCE_SEC
+
+
+def is_duplicate_remote(title: str, content: str) -> bool:
+    """Vector-similarity dedup against the Fly vault — mirrors
+    ``session_extractor.is_duplicate_remote``. False on any error
+    (network, timeout, parse) so a transient remote failure never drops
+    a novel handoff. Threshold is shared with session_extractor via
+    ``HOOK_DEDUP_SIMILARITY_THRESHOLD`` for consistency."""
+    try:
+        from ._client import get_client
+
+        client = get_client()
+        query = f"{title}: {content}"
+        raw, _elapsed = client.call_tool(
+            "memory_search",
+            {"query": query, "limit": 3},
+            timeout=HOOK_DEDUP_TIMEOUT_SEC,
+            client_label=CLIENT_LABEL_DEDUP,
+        )
+        results = json.loads(raw)
+        for r in results:
+            sim = r.get("vector_similarity")
+            if sim is not None and sim > HOOK_DEDUP_SIMILARITY_THRESHOLD:
+                return True
+        return False
+    except Exception:
+        return False
+
+
 # ── Main ────────────────────────────────────────────────────────────────────
 
 def main() -> None:
@@ -112,12 +268,35 @@ def main() -> None:
         if not transcript or len(transcript) < 200:
             return
 
+        # Trivial / system-payload skip. Cheaper than LLM extraction so
+        # it runs first.
+        first_user = _first_user_line(transcript)
+        if first_user and is_trivial_first_prompt(first_user):
+            return
+
+        # Per-session debounce. Empty session_id degrades to "always
+        # save" so a malformed hook payload can't silently drop work.
+        session_id = hook_input.get("session_id", "") or ""
+        if not should_save_for_session(session_id):
+            return
+
         # Try LLM generation first, fall back to regex
         handoff = generate_with_llm(transcript)
         if handoff is None:
             handoff = generate_with_regex(transcript)
 
         if not handoff or handoff.get("skip"):
+            return
+
+        # Final remote-side dedup (covers the case where session_id
+        # rotated but content is still near-identical to a recent save).
+        if is_duplicate_remote(
+            f"Session: {handoff['title']}", handoff["summary"]
+        ):
+            print(
+                f'mnemon: skipping duplicate handoff: "{handoff["title"]}"',
+                file=sys.stderr,
+            )
             return
 
         try:
@@ -132,6 +311,8 @@ def main() -> None:
                 },
                 client_label=CLIENT_LABEL,
             )
+            if session_id:
+                _record_session_save(session_id, _load_session_state())
             print(f'mnemon: saved handoff "{handoff["title"]}"', file=sys.stderr)
         except RemoteClientConfigError as e:
             log_hook_error("handoff-generator", "config error", e)

--- a/tests/test_hooks_extended.py
+++ b/tests/test_hooks_extended.py
@@ -1058,6 +1058,8 @@ class TestHandoffGeneratorMain:
              patch("mnemon.hooks.framework.read_transcript", return_value="A" * 300), \
              patch.object(handoff_generator, "generate_with_llm", return_value=None), \
              patch.object(handoff_generator, "generate_with_regex", return_value={"title": "Regex handoff", "summary": "- Did stuff"}) as mock_regex, \
+             patch.object(handoff_generator, "is_duplicate_remote", return_value=False), \
+             patch.object(handoff_generator, "_record_session_save"), \
              patch("mnemon.hooks._remote_client.call_tool_sync", return_value=("Saved doc-456", 0.4)) as mock_call:
             main()
         mock_regex.assert_called_once()
@@ -1087,6 +1089,8 @@ class TestHandoffGeneratorMain:
         with patch("mnemon.hooks.framework.read_stdin", return_value={"transcript_path": "/tmp/t.jsonl"}), \
              patch("mnemon.hooks.framework.read_transcript", return_value="A" * 300), \
              patch.object(handoff_generator, "generate_with_llm", return_value={"title": "LLM summary", "summary": "- Deployed feature X"}), \
+             patch.object(handoff_generator, "is_duplicate_remote", return_value=False), \
+             patch.object(handoff_generator, "_record_session_save"), \
              patch("mnemon.hooks._remote_client.call_tool_sync", return_value=("Saved doc-789", 0.5)) as mock_call:
             main()
         mock_call.assert_called_once()
@@ -1103,6 +1107,7 @@ class TestHandoffGeneratorMain:
         with patch("mnemon.hooks.framework.read_stdin", return_value={"transcript_path": "/tmp/t.jsonl"}), \
              patch("mnemon.hooks.framework.read_transcript", return_value="A" * 300), \
              patch.object(handoff_generator, "generate_with_llm", return_value={"title": "X", "summary": "Y"}), \
+             patch.object(handoff_generator, "is_duplicate_remote", return_value=False), \
              patch("mnemon.hooks._remote_client.call_tool_sync", side_effect=RemoteClientConfigError("no url")):
             main()
         captured = capsys.readouterr()
@@ -1115,8 +1120,255 @@ class TestHandoffGeneratorMain:
         with patch("mnemon.hooks.framework.read_stdin", return_value={"transcript_path": "/tmp/t.jsonl"}), \
              patch("mnemon.hooks.framework.read_transcript", return_value="A" * 300), \
              patch.object(handoff_generator, "generate_with_llm", return_value={"title": "X", "summary": "Y"}), \
+             patch.object(handoff_generator, "is_duplicate_remote", return_value=False), \
              patch("mnemon.hooks._remote_client.call_tool_sync", side_effect=ConnectionError("timeout")):
             main()
         captured = capsys.readouterr()
         assert "save error" in captured.err
         assert "ConnectionError" in captured.err
+
+
+# ── handoff_generator.py: trivial-prompt skip ─────────────────────────────────
+
+
+class TestHandoffGeneratorTrivialPromptSkip:
+    """The first ``[user]:`` line is the de-facto session title. Slash-
+    command bodies, system payloads, pasted tool output, and one-word
+    replies should all bounce before the LLM runs."""
+
+    def test_is_trivial_loop_slash_command(self):
+        from mnemon.hooks.handoff_generator import is_trivial_first_prompt
+        assert is_trivial_first_prompt("# /loop — schedule a recurring or self-paced prompt")
+        assert is_trivial_first_prompt("#/loop foo")
+
+    def test_is_trivial_notification_payloads(self):
+        from mnemon.hooks.handoff_generator import is_trivial_first_prompt
+        assert is_trivial_first_prompt("<task-notification> something happened")
+        assert is_trivial_first_prompt("<local-command-caveat>caveat text")
+        assert is_trivial_first_prompt("<command-name>foo</command-name>")
+
+    def test_is_trivial_test_output_paste(self):
+        from mnemon.hooks.handoff_generator import is_trivial_first_prompt
+        assert is_trivial_first_prompt("=========================== short test summary info ====")
+        assert is_trivial_first_prompt("short test summary info: 1 failed")
+
+    def test_is_trivial_short_replies(self):
+        from mnemon.hooks.handoff_generator import is_trivial_first_prompt
+        assert is_trivial_first_prompt("yes")
+        assert is_trivial_first_prompt("done")
+        assert is_trivial_first_prompt("pr merged")
+        assert is_trivial_first_prompt("")
+
+    def test_is_not_trivial_real_prompts(self):
+        from mnemon.hooks.handoff_generator import is_trivial_first_prompt
+        assert not is_trivial_first_prompt(
+            "do we need to add linkedin/contact info to the about page"
+        )
+        assert not is_trivial_first_prompt(
+            "lets continue with counterfactual rule fit"
+        )
+
+    def test_first_user_line_extracted_from_transcript(self):
+        from mnemon.hooks.handoff_generator import _first_user_line
+        transcript = (
+            "[user]: real prompt that has enough chars\n\n"
+            "[assistant]: reply\n\n"
+            "[user]: yes\n"
+        )
+        assert _first_user_line(transcript) == "real prompt that has enough chars"
+
+    def test_main_skips_trivial_first_prompt(self):
+        from mnemon.hooks import handoff_generator
+        from mnemon.hooks.handoff_generator import main
+
+        transcript = "[user]: # /loop — schedule\n\n[assistant]: " + "x" * 250
+
+        with patch("mnemon.hooks.framework.read_stdin", return_value={"transcript_path": "/tmp/t.jsonl"}), \
+             patch("mnemon.hooks.framework.read_transcript", return_value=transcript), \
+             patch.object(handoff_generator, "generate_with_llm") as mock_llm, \
+             patch("mnemon.hooks._remote_client.call_tool_sync") as mock_call:
+            main()
+        mock_llm.assert_not_called()
+        mock_call.assert_not_called()
+
+    def test_main_proceeds_when_first_prompt_is_real(self):
+        from mnemon.hooks import handoff_generator
+        from mnemon.hooks.handoff_generator import main
+
+        transcript = (
+            "[user]: please refactor the dedup logic in handoff_generator\n\n"
+            "[assistant]: " + "x" * 250
+        )
+
+        with patch("mnemon.hooks.framework.read_stdin", return_value={"transcript_path": "/tmp/t.jsonl"}), \
+             patch("mnemon.hooks.framework.read_transcript", return_value=transcript), \
+             patch.object(handoff_generator, "generate_with_llm", return_value={"title": "Refactor", "summary": "- Did it"}), \
+             patch.object(handoff_generator, "is_duplicate_remote", return_value=False), \
+             patch.object(handoff_generator, "_record_session_save"), \
+             patch("mnemon.hooks._remote_client.call_tool_sync", return_value=("Saved doc-1", 0.1)) as mock_call:
+            main()
+        mock_call.assert_called_once()
+
+
+# ── handoff_generator.py: per-session debounce ────────────────────────────────
+
+
+class TestHandoffGeneratorSessionDebounce:
+    """Stop fires per turn; debounce keyed on session_id collapses
+    repeat fires within the cooldown window to a single save."""
+
+    def test_should_save_when_session_unseen(self, tmp_path, monkeypatch):
+        from mnemon.hooks import handoff_generator
+
+        monkeypatch.setattr(
+            handoff_generator,
+            "_SESSION_STATE_PATH",
+            tmp_path / "handoff_session_state.json",
+        )
+        assert handoff_generator.should_save_for_session("sess-new") is True
+
+    def test_should_not_save_inside_cooldown(self, tmp_path, monkeypatch):
+        from mnemon.hooks import handoff_generator
+
+        path = tmp_path / "handoff_session_state.json"
+        path.write_text(json.dumps({"sess-recent": time.time()}))
+        monkeypatch.setattr(handoff_generator, "_SESSION_STATE_PATH", path)
+        assert handoff_generator.should_save_for_session("sess-recent") is False
+
+    def test_should_save_after_cooldown_expires(self, tmp_path, monkeypatch):
+        from mnemon.hooks import handoff_generator
+
+        path = tmp_path / "handoff_session_state.json"
+        # 1 hour ago, well beyond the 600s cooldown
+        path.write_text(json.dumps({"sess-old": time.time() - 3600}))
+        monkeypatch.setattr(handoff_generator, "_SESSION_STATE_PATH", path)
+        assert handoff_generator.should_save_for_session("sess-old") is True
+
+    def test_should_save_when_session_id_empty(self, tmp_path, monkeypatch):
+        """Empty session_id degrades to legacy 'always save' so a malformed
+        hook payload doesn't silently drop work."""
+        from mnemon.hooks import handoff_generator
+
+        monkeypatch.setattr(
+            handoff_generator,
+            "_SESSION_STATE_PATH",
+            tmp_path / "handoff_session_state.json",
+        )
+        assert handoff_generator.should_save_for_session("") is True
+
+    def test_state_file_corrupt_treated_as_empty(self, tmp_path, monkeypatch):
+        from mnemon.hooks import handoff_generator
+
+        path = tmp_path / "handoff_session_state.json"
+        path.write_text("not json")
+        monkeypatch.setattr(handoff_generator, "_SESSION_STATE_PATH", path)
+        assert handoff_generator.should_save_for_session("sess-x") is True
+
+    def test_record_session_save_persists_timestamp(self, tmp_path, monkeypatch):
+        from mnemon.hooks import handoff_generator
+
+        path = tmp_path / "handoff_session_state.json"
+        monkeypatch.setattr(handoff_generator, "_SESSION_STATE_PATH", path)
+        handoff_generator._record_session_save("sess-1", {})
+        loaded = json.loads(path.read_text())
+        assert "sess-1" in loaded
+        assert isinstance(loaded["sess-1"], (int, float))
+
+    def test_main_skips_when_session_is_in_cooldown(self, tmp_path, monkeypatch):
+        from mnemon.hooks import handoff_generator
+        from mnemon.hooks.handoff_generator import main
+
+        path = tmp_path / "handoff_session_state.json"
+        path.write_text(json.dumps({"sess-cooldown": time.time()}))
+        monkeypatch.setattr(handoff_generator, "_SESSION_STATE_PATH", path)
+
+        transcript = (
+            "[user]: a real prompt that should normally save\n\n"
+            "[assistant]: " + "x" * 250
+        )
+
+        with patch("mnemon.hooks.framework.read_stdin", return_value={
+                  "transcript_path": "/tmp/t.jsonl",
+                  "session_id": "sess-cooldown",
+              }), \
+             patch("mnemon.hooks.framework.read_transcript", return_value=transcript), \
+             patch.object(handoff_generator, "generate_with_llm") as mock_llm, \
+             patch("mnemon.hooks._remote_client.call_tool_sync") as mock_call:
+            main()
+        # Cooldown skip happens BEFORE the LLM call.
+        mock_llm.assert_not_called()
+        mock_call.assert_not_called()
+
+    def test_main_records_session_after_successful_save(self, tmp_path, monkeypatch):
+        from mnemon.hooks import handoff_generator
+        from mnemon.hooks.handoff_generator import main
+
+        path = tmp_path / "handoff_session_state.json"
+        monkeypatch.setattr(handoff_generator, "_SESSION_STATE_PATH", path)
+
+        transcript = (
+            "[user]: please ship the dedup fix already\n\n"
+            "[assistant]: " + "x" * 250
+        )
+
+        with patch("mnemon.hooks.framework.read_stdin", return_value={
+                  "transcript_path": "/tmp/t.jsonl",
+                  "session_id": "sess-fresh",
+              }), \
+             patch("mnemon.hooks.framework.read_transcript", return_value=transcript), \
+             patch.object(handoff_generator, "generate_with_llm", return_value={"title": "Ship", "summary": "- shipped"}), \
+             patch.object(handoff_generator, "is_duplicate_remote", return_value=False), \
+             patch("mnemon.hooks._remote_client.call_tool_sync", return_value=("Saved doc-1", 0.1)):
+            main()
+
+        loaded = json.loads(path.read_text())
+        assert "sess-fresh" in loaded
+
+
+# ── handoff_generator.py: remote vector dedup ────────────────────────────────
+
+
+class TestHandoffGeneratorRemoteDedup:
+    """Belt-and-suspenders: catches near-duplicates that slip past the
+    session debounce (e.g. session_id rotated but content unchanged)."""
+
+    def test_returns_true_above_threshold(self):
+        from mnemon.hooks import handoff_generator
+
+        with patch("mnemon.hooks._remote_client.call_tool_sync",
+                   return_value=(json.dumps([{"vector_similarity": 0.95}]), 0.1)):
+            assert handoff_generator.is_duplicate_remote("t", "c") is True
+
+    def test_returns_false_below_threshold(self):
+        from mnemon.hooks import handoff_generator
+
+        with patch("mnemon.hooks._remote_client.call_tool_sync",
+                   return_value=(json.dumps([{"vector_similarity": 0.5}]), 0.1)):
+            assert handoff_generator.is_duplicate_remote("t", "c") is False
+
+    def test_returns_false_on_remote_error(self):
+        """A flaky remote should never block a novel handoff — fail open."""
+        from mnemon.hooks import handoff_generator
+
+        with patch("mnemon.hooks._remote_client.call_tool_sync",
+                   side_effect=ConnectionError("network down")):
+            assert handoff_generator.is_duplicate_remote("t", "c") is False
+
+    def test_main_skips_save_on_dedup_hit(self, capsys):
+        from mnemon.hooks import handoff_generator
+        from mnemon.hooks.handoff_generator import main
+
+        transcript = (
+            "[user]: a real prompt that almost matches a recent save\n\n"
+            "[assistant]: " + "x" * 250
+        )
+
+        with patch("mnemon.hooks.framework.read_stdin", return_value={"transcript_path": "/tmp/t.jsonl"}), \
+             patch("mnemon.hooks.framework.read_transcript", return_value=transcript), \
+             patch.object(handoff_generator, "generate_with_llm", return_value={"title": "Near dup", "summary": "- close"}), \
+             patch.object(handoff_generator, "is_duplicate_remote", return_value=True), \
+             patch("mnemon.hooks._remote_client.call_tool_sync") as mock_call:
+            main()
+        mock_call.assert_not_called()
+        captured = capsys.readouterr()
+        assert "skipping duplicate handoff" in captured.err


### PR DESCRIPTION
## Summary

`handoff_generator` fires on every Claude Code `Stop` event — every assistant turn, not once per session — and had **no dedup** before saving. Result: a 30-prompt conversation produced ~30 near-duplicate `handoff` memories.

Empirical impact in the production vault before the fix:

- **1,376 total documents**, **710 of them `handoff`** (51.6% of the vault)
- `memory_sweep` candidates: 0 (half-life decay isn't catching them)
- Dominant patterns observed in the last few hours of activity:
  - Same conversation re-saved at exchanges=3 and exchanges=5 minutes apart
  - `Session: # /loop — schedule a recurring or self-paced prompt` saved 6+ times in 3 hours
  - Trivial replies saved as full memory rows: `Session: done`, `Session: pr merged`, `Session: yes`
  - System payloads as titles: `Session: <task-notification>`, `Session: <local-command-caveat>...`, `Session: =========================== short test summary info ====`

## What changed

Three gates added to `handoff_generator.main()`, cheapest-first:

1. **Trivial-prompt skip** (`is_trivial_first_prompt`) — first `[user]:` line matched against slash-command / notification / test-output regexes plus a 15-char floor. Runs before LLM extraction so loop fires don't pay inference cost.

2. **Per-session debounce** (`should_save_for_session` + `_record_session_save`) — JSON state file at `~/.mnemon/handoff_session_state.json` keyed by `session_id` from the hook payload. 600s cooldown. Empty/missing session_id degrades to legacy "always save" so a malformed payload doesn't silently drop work. Pruned to 24h on every read.

3. **Remote vector dedup** (`is_duplicate_remote`) — final check via `memory_search`, mirroring `session_extractor.is_duplicate_remote` posture. Same threshold (`HOOK_DEDUP_SIMILARITY_THRESHOLD = 0.92`), same fail-open-on-error policy.

## Test plan

- [x] 6 existing `TestHandoffGeneratorMain` tests still pass (4 updated to patch `is_duplicate_remote` so they keep testing the save path, not the new short-circuit)
- [x] 20 new tests across `TestHandoffGeneratorTrivialPromptSkip`, `TestHandoffGeneratorSessionDebounce`, `TestHandoffGeneratorRemoteDedup`
- [x] Full suite: **709 passed** (was 689; +20 new)
- [ ] Soak: monitor `handoff` row growth rate over the next ~3 days; expect a sharp drop in `claude-code-hook`-sourced rows

## What this leaves on the table

- **The 710 already-stored handoffs.** This PR prevents future accumulation only. A separate one-shot cleanup script could `memory_forget` rows where `source_client="claude-code-hook"` AND title matches the trivial patterns; happy to write that as a follow-up.
- **Half-life tuning.** `handoff` is currently 30 days. After this lands, that's probably fine for `mnemon-mirror`-sourced curated handoffs but still long for `claude-code-hook` ones. Worth revisiting in a config-only PR once the reduction is observed.
- **`session_extractor` vs `handoff_generator` overlap.** Both fire on Stop, both extract from the transcript, but produce different content_types. Worth a separate design discussion on whether we actually want both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)