### PR TITLE
chore: bump version to 0.6.0rc11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [0.6.0rc11] - 2026-05-06
+
+### Fixed
+
+- **Per-Stop handoff noise — `handoff_generator` now gates on three
+  conditions before saving.** Stop fires after every assistant turn,
+  not once per session, and `handoff_generator` previously had no dedup
+  — every turn produced a fresh `handoff` memory. Observed in the
+  production vault as 710/1376 documents (51.6%) being `handoff`-typed,
+  dominated by `claude-code-hook`-sourced rows whose first-user-line
+  was a `/loop` body, `<task-notification>`, pasted test output, or a
+  one-word reply ("yes", "done", "pr merged"). Three gates now run in
+  `main()` cheapest-first: trivial-prompt skip (regex match against
+  slash-command / notification / test-output patterns plus a 15-char
+  floor), per-session debounce (`~/.mnemon/handoff_session_state.json`
+  keyed by hook-payload `session_id` with 600s cooldown, degrades to
+  legacy "always save" on empty session_id), and a final remote vector
+  dedup mirroring `session_extractor.is_duplicate_remote` posture. PR
+  #112.
+
+### Tests
+
+- 20 new tests across `TestHandoffGeneratorTrivialPromptSkip`,
+  `TestHandoffGeneratorSessionDebounce`, and
+  `TestHandoffGeneratorRemoteDedup` in `tests/test_hooks_extended.py`.
+  4 existing `TestHandoffGeneratorMain` tests updated to patch
+  `is_duplicate_remote` so they keep exercising the save path. 689 →
+  709 passing.
+
 ## [0.6.0rc10] - 2026-05-02
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.6.0rc10"
+version = "0.6.0rc11"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.6.0rc10"
+__version__ = "0.6.0rc11"


### PR DESCRIPTION
## Summary

- rc10 → rc11 for the `handoff_generator` per-Stop dedup fix shipped in #112.
- Files: `pyproject.toml`, `src/mnemon/__init__.py`, `CHANGELOG.md`.

## Soak plan

Once merged → PyPI publish → Fly redeploy via `mnemon upgrade web`. Soak window restarts now with the handoff dedup baked in alongside the still-soaking rc10 fixes:

- OAuth refresh-token rotation grace window (#107, rc9)
- `json_response=True` session-manager config (#109, rc10)
- `handoff_generator` 3-gate dedup (#112, rc11)

Promotion to `0.6.0` stable when all signals stay clean for ~7 days:

- Zero new `POST /oauth/register` from `client_name: "Claude"` in Fly access logs
- Zero new `mnemon doctor` timeouts or Claude Desktop save-stall reports
- New `handoff` row rate from `claude-code-hook` source drops sharply (sample via `memory_timeline content_type=handoff` — pre-fix saw ~10 rows/hour during active use)

🤖 Generated with [Claude Code](https://claude.com/claude-code)