### PR TITLE
fix(server): narrow _session_creation_lock to dict mutation only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## [0.6.0rc13] - 2026-05-06
+
+### Fixed
+
+- **Fresh-init MCP requests wedged the server-wide session-creation lock.**
+  Diagnosed live during the rc12 soak: `mnemon doctor` and any
+  `streamablehttp_client` consumer that opens a new MCP session
+  ([no `Mcp-Session-Id` header) hung past 15s while warm-keeper
+  PingRequests and tool calls on existing sessions kept working. Direct
+  curl confirmed: `tools/list` with the persisted session ID returned
+  in <300ms; `initialize` with no session ID hung 20s with no
+  `Processing request of type` log on the server. Root cause: upstream
+  `StreamableHTTPSessionManager._handle_stateful_request` holds
+  `_session_creation_lock` for the **full** duration of the new-session
+  branch — including the `await transport.handle_request(...)` that
+  dispatches the JSON-RPC payload and waits for the response. If that
+  handler wedges for any reason (we never identified the underlying
+  trigger, but the wedge reproduced reliably across rc11 and rc12
+  fresh-deploys), every subsequent fresh-init queues behind the lock
+  and times out at the client side. PR #109 patched the SSE-mode
+  variant of this same lock-held-too-long pattern; the
+  `json_response=True` variant still had its own way to wedge.
+
+  Fix: `PersistentSessionManager` now bypasses upstream's locked path
+  for fresh-init via a new `_create_new_session` method that holds
+  `_session_creation_lock` only for the brief `_server_instances`
+  mutation, then releases before `task_group.start()` and
+  `transport.handle_request()`. `_resume_session` got the same
+  narrowing — the lock now covers only the race-guard read + dict
+  write, not the dispatch. One wedged handler can no longer take down
+  the server's ability to accept new sessions.
+
+### Tests
+
+- `TestSessionCreationLockNarrowing` (5 cases) in
+  `tests/test_persistent_sessions.py`: lock-released-before-dispatch
+  invariant for both `_create_new_session` and `_resume_session`,
+  wedged-handler-doesn't-block-concurrent-fresh-init reproduction
+  (this directly mirrors the live-prod symptom), 5-concurrent-fresh-
+  inits-get-distinct-ids sanity, and resume-race-lost-falls-through
+  coverage. 708 → 713 passing.
+
 ## [0.6.0rc12] - 2026-05-06
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.6.0rc12"
+version = "0.6.0rc13"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.6.0rc12"
+__version__ = "0.6.0rc13"

--- a/src/mnemon/persistent_sessions.py
+++ b/src/mnemon/persistent_sessions.py
@@ -33,6 +33,7 @@ import time
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 import anyio
 from anyio.abc import TaskStatus
@@ -314,21 +315,25 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
             await self._resume_session(session_id, scope, receive, send)
             return
 
-        # Either a brand-new session (no header) or an unknown session
-        # ID we never issued / has expired. Upstream handles both — new
-        # session creation will write through _PersistingInstanceDict.
+        # Fresh-init or stale. Branch BEFORE delegating: fresh-init
+        # takes our narrow-lock path (see _create_new_session); stale
+        # delegates to upstream's lock-free 404 path.
         if session_id is None:
             self._counters["fresh_inits"] += 1
-        else:
-            # Stale: client sent a session ID we never issued or that
-            # expired. Upstream returns 404 — this is the actual
-            # "Session not found" surface seen by clients.
-            self._counters["stale_session_misses"] += 1
-            logger.warning(
-                "Stale session_id %s — not in memory, not in SQLite. "
-                "Upstream will return 404 per MCP spec.",
-                session_id,
-            )
+            await self._create_new_session(scope, receive, send)
+            return
+
+        # Stale: client sent a session ID we never issued or that
+        # expired. Upstream returns 404 — this is the actual
+        # "Session not found" surface seen by clients. The 404 branch
+        # in upstream does NOT acquire _session_creation_lock, so
+        # delegating here is safe even when the lock is contended.
+        self._counters["stale_session_misses"] += 1
+        logger.warning(
+            "Stale session_id %s — not in memory, not in SQLite. "
+            "Upstream will return 404 per MCP spec.",
+            session_id,
+        )
         await super()._handle_stateful_request(scope, receive, send)
 
     async def _resume_session(
@@ -344,68 +349,163 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
         but reuses the supplied session_id instead of minting a fresh one
         and runs the MCP app stateless so the server-side ServerSession
         is born already-initialized.
+
+        Lock scope is deliberately narrow: ``_session_creation_lock`` is
+        held only for the race-guard read + ``_server_instances`` write,
+        then released before ``transport.handle_request`` is awaited.
+        See :meth:`_create_new_session` for the rationale; same wedge
+        risk applies here.
         """
+        transport = StreamableHTTPServerTransport(
+            mcp_session_id=session_id,
+            is_json_response_enabled=self.json_response,
+            event_store=self.event_store,
+            security_settings=self.security_settings,
+            retry_interval=self.retry_interval,
+        )
+
+        async def run_server(
+            *, task_status: TaskStatus[None] = anyio.TASK_STATUS_IGNORED
+        ) -> None:
+            async with transport.connect() as streams:
+                read_stream, write_stream = streams
+                task_status.started()
+                try:
+                    idle_scope = anyio.CancelScope()
+                    if self.session_idle_timeout is not None:
+                        idle_scope.deadline = (
+                            anyio.current_time() + self.session_idle_timeout
+                        )
+                        transport.idle_scope = idle_scope
+
+                    with idle_scope:
+                        # stateless=True is the resume trick: the
+                        # ServerSession is constructed with
+                        # InitializationState.Initialized so it does
+                        # not block waiting for an InitializeRequest
+                        # the client will never re-send.
+                        await self.app.run(
+                            read_stream,
+                            write_stream,
+                            self.app.create_initialization_options(),
+                            stateless=True,
+                        )
+
+                    if idle_scope.cancelled_caught:
+                        logger.info(
+                            "Resumed session %s idle timeout", session_id
+                        )
+                        self._server_instances.pop(session_id, None)
+                        await transport.terminate()
+                except Exception:
+                    logger.exception("Resumed session %s crashed", session_id)
+                finally:
+                    if (
+                        transport.mcp_session_id
+                        and transport.mcp_session_id in self._server_instances
+                        and not transport.is_terminated
+                    ):
+                        del self._server_instances[transport.mcp_session_id]
+
+        # Narrow lock: race-guard + dict mutation only.
         async with self._session_creation_lock:
-            # Race guard: another concurrent request may have already
-            # resumed this session while we were waiting for the lock.
             if session_id in self._server_instances:
+                # Race lost: another concurrent request resumed the
+                # session while we were minting our transport. Drop
+                # ours and fall through to the in-memory hit path.
                 self._session_store.touch(session_id)
-                await super()._handle_stateful_request(scope, receive, send)
-                return
+                race_lost = True
+            else:
+                self._server_instances[session_id] = transport
+                self._session_store.touch(session_id)
+                race_lost = False
 
-            transport = StreamableHTTPServerTransport(
-                mcp_session_id=session_id,
-                is_json_response_enabled=self.json_response,
-                event_store=self.event_store,
-                security_settings=self.security_settings,
-                retry_interval=self.retry_interval,
-            )
-            self._server_instances[session_id] = transport
-            self._session_store.touch(session_id)
+        if race_lost:
+            # Outside the lock — upstream's in-memory hit path is
+            # lock-free, so delegating here can't reintroduce the
+            # bottleneck.
+            await super()._handle_stateful_request(scope, receive, send)
+            return
 
-            async def run_server(
-                *, task_status: TaskStatus[None] = anyio.TASK_STATUS_IGNORED
-            ) -> None:
-                async with transport.connect() as streams:
-                    read_stream, write_stream = streams
-                    task_status.started()
-                    try:
-                        idle_scope = anyio.CancelScope()
-                        if self.session_idle_timeout is not None:
-                            idle_scope.deadline = (
-                                anyio.current_time() + self.session_idle_timeout
-                            )
-                            transport.idle_scope = idle_scope
+        assert self._task_group is not None
+        await self._task_group.start(run_server)
+        await transport.handle_request(scope, receive, send)
 
-                        with idle_scope:
-                            # stateless=True is the resume trick: the
-                            # ServerSession is constructed with
-                            # InitializationState.Initialized so it does
-                            # not block waiting for an InitializeRequest
-                            # the client will never re-send.
-                            await self.app.run(
-                                read_stream,
-                                write_stream,
-                                self.app.create_initialization_options(),
-                                stateless=True,
-                            )
+    async def _create_new_session(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        """Mint + register a fresh MCP session, then dispatch outside the lock.
 
-                        if idle_scope.cancelled_caught:
-                            logger.info(
-                                "Resumed session %s idle timeout", session_id
-                            )
-                            self._server_instances.pop(session_id, None)
-                            await transport.terminate()
-                    except Exception:
-                        logger.exception("Resumed session %s crashed", session_id)
-                    finally:
-                        if (
-                            transport.mcp_session_id
-                            and transport.mcp_session_id in self._server_instances
-                            and not transport.is_terminated
-                        ):
-                            del self._server_instances[transport.mcp_session_id]
+        Mirrors upstream's new-session creation logic but narrows
+        ``_session_creation_lock`` to cover only the brief
+        ``_server_instances`` mutation. Upstream holds the lock for the
+        full ``handle_request`` await, which made the lock a single
+        point of failure: on 2026-05-06 a wedged fresh-init handler
+        held the lock and every subsequent fresh-init request queued
+        behind it and timed out at the client side, while in-memory
+        hits and resumes (which don't need the lock) kept working.
+        Releasing earlier means one wedged handler can't take down the
+        server's ability to accept new sessions.
+        """
+        new_session_id = uuid4().hex
+        transport = StreamableHTTPServerTransport(
+            mcp_session_id=new_session_id,
+            is_json_response_enabled=self.json_response,
+            event_store=self.event_store,
+            security_settings=self.security_settings,
+            retry_interval=self.retry_interval,
+        )
 
-            assert self._task_group is not None
-            await self._task_group.start(run_server)
-            await transport.handle_request(scope, receive, send)
+        async def run_server(
+            *, task_status: TaskStatus[None] = anyio.TASK_STATUS_IGNORED
+        ) -> None:
+            async with transport.connect() as streams:
+                read_stream, write_stream = streams
+                task_status.started()
+                try:
+                    idle_scope = anyio.CancelScope()
+                    if self.session_idle_timeout is not None:
+                        idle_scope.deadline = (
+                            anyio.current_time() + self.session_idle_timeout
+                        )
+                        transport.idle_scope = idle_scope
+
+                    with idle_scope:
+                        await self.app.run(
+                            read_stream,
+                            write_stream,
+                            self.app.create_initialization_options(),
+                            stateless=False,
+                        )
+
+                    if idle_scope.cancelled_caught:
+                        logger.info(
+                            "Session %s idle timeout", new_session_id
+                        )
+                        self._server_instances.pop(new_session_id, None)
+                        await transport.terminate()
+                except Exception:
+                    logger.exception(
+                        "Session %s crashed", new_session_id
+                    )
+                finally:
+                    if (
+                        transport.mcp_session_id
+                        and transport.mcp_session_id in self._server_instances
+                        and not transport.is_terminated
+                    ):
+                        del self._server_instances[transport.mcp_session_id]
+
+        # Narrow lock: only the dict mutation needs to be serialized.
+        # transport.connect() / app.run() / transport.handle_request()
+        # are all per-session — no shared state between concurrent
+        # fresh-init requests.
+        async with self._session_creation_lock:
+            self._server_instances[new_session_id] = transport
+
+        assert self._task_group is not None
+        await self._task_group.start(run_server)
+        await transport.handle_request(scope, receive, send)

--- a/tests/test_persistent_sessions.py
+++ b/tests/test_persistent_sessions.py
@@ -314,16 +314,15 @@ class TestMetricsCounters:
         assert manager.metrics()["resume_hits"] == 1
 
     async def test_fresh_init_increments_counter(self, tmp_path, monkeypatch):
+        """Fresh-init now flows through ``_create_new_session`` rather
+        than upstream's locked path. Patch that directly so we don't
+        have to spin up a real task group."""
         manager = self._make_manager(tmp_path)
 
-        async def fake_super(self, scope, receive, send):  # noqa: ANN001
+        async def fake_create(scope, receive, send):
             pass
 
-        monkeypatch.setattr(
-            "mnemon.persistent_sessions.StreamableHTTPSessionManager."
-            "_handle_stateful_request",
-            fake_super,
-        )
+        monkeypatch.setattr(manager, "_create_new_session", fake_create)
         await manager._handle_stateful_request(
             self._scope(None), self._noop_receive, self._noop_send
         )
@@ -500,3 +499,257 @@ class TestPeriodicExpireTask:
             "Periodic session prune raised" in rec.message
             for rec in caplog.records
         )
+
+
+# ---------------------------------------------------------------------------
+# Narrow-lock contract — _session_creation_lock must be released BEFORE
+# transport.handle_request is awaited, so a wedged handler can't block
+# subsequent fresh-init / resume requests from acquiring the lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+class TestSessionCreationLockNarrowing:
+    """Regression coverage for the 2026-05-06 lock-held wedge.
+
+    Symptom: upstream's ``_handle_stateful_request`` held
+    ``_session_creation_lock`` for the full duration of a fresh-init
+    request including ``transport.handle_request``. When that handler
+    wedged for any reason (observed in prod), every subsequent fresh-
+    init queued behind the lock and timed out at the client side.
+
+    Fix: narrow the lock to only the ``_server_instances`` mutation in
+    both ``_create_new_session`` and ``_resume_session``. After the
+    lock releases, the dispatch (``transport.handle_request``) runs
+    outside it, so concurrent fresh-init / resume requests can proceed
+    even if one handler is stuck.
+    """
+
+    @pytest.fixture
+    def anyio_backend(self):
+        return "asyncio"
+
+    @staticmethod
+    def _make_manager(tmp_path):
+        store = SessionStore(tmp_path / "sessions.sqlite")
+        return PersistentSessionManager(
+            app=MagicMock(name="mcp_server"), session_store=store
+        )
+
+    @staticmethod
+    def _scope(session_id: bytes | None):
+        headers = []
+        if session_id is not None:
+            headers.append((b"mcp-session-id", session_id))
+        return {"type": "http", "method": "POST", "path": "/mcp", "headers": headers}
+
+    @staticmethod
+    async def _noop_receive():  # pragma: no cover
+        return {"type": "http.disconnect"}
+
+    @staticmethod
+    async def _noop_send(_):  # pragma: no cover
+        pass
+
+    async def test_create_new_session_releases_lock_before_handle_request(
+        self, tmp_path, monkeypatch
+    ):
+        """Probe the narrow-lock invariant: when ``transport.handle_request``
+        is awaited, ``_session_creation_lock`` must already be released.
+
+        We patch ``handle_request`` to assert the lock is non-locked at
+        call time. Pre-fix this would have failed (lock still held).
+        """
+        import anyio
+
+        manager = self._make_manager(tmp_path)
+
+        # Stub task_group so _create_new_session doesn't need a real run().
+        class _FakeTaskGroup:
+            async def start(self, _coro):
+                return None
+
+        manager._task_group = _FakeTaskGroup()  # type: ignore[assignment]
+
+        observed = {"locked_during_dispatch": None}
+
+        async def fake_handle_request(self_transport, scope, receive, send):
+            # If the lock is held here, the narrow-lock invariant is broken.
+            observed["locked_during_dispatch"] = (
+                manager._session_creation_lock.locked()
+            )
+
+        monkeypatch.setattr(
+            "mnemon.persistent_sessions.StreamableHTTPServerTransport."
+            "handle_request",
+            fake_handle_request,
+        )
+
+        await manager._create_new_session(
+            self._scope(None), self._noop_receive, self._noop_send
+        )
+
+        assert observed["locked_during_dispatch"] is False, (
+            "_session_creation_lock was still held when handle_request was "
+            "awaited — narrow-lock invariant broken"
+        )
+
+    async def test_resume_session_releases_lock_before_handle_request(
+        self, tmp_path, monkeypatch
+    ):
+        manager = self._make_manager(tmp_path)
+        manager._session_store.register("survivor")
+
+        class _FakeTaskGroup:
+            async def start(self, _coro):
+                return None
+
+        manager._task_group = _FakeTaskGroup()  # type: ignore[assignment]
+
+        observed = {"locked_during_dispatch": None}
+
+        async def fake_handle_request(self_transport, scope, receive, send):
+            observed["locked_during_dispatch"] = (
+                manager._session_creation_lock.locked()
+            )
+
+        monkeypatch.setattr(
+            "mnemon.persistent_sessions.StreamableHTTPServerTransport."
+            "handle_request",
+            fake_handle_request,
+        )
+
+        await manager._resume_session(
+            "survivor", self._scope(b"survivor"), self._noop_receive, self._noop_send
+        )
+
+        assert observed["locked_during_dispatch"] is False
+
+    async def test_wedged_handler_does_not_block_concurrent_fresh_init(
+        self, tmp_path, monkeypatch
+    ):
+        """The reproduction we lived through: one fresh-init handler
+        hangs forever (simulated). A second fresh-init request must
+        still be able to acquire the lock + register its session and
+        reach its own ``handle_request`` call. Pre-fix this hung
+        forever; post-fix it completes."""
+        import anyio
+
+        manager = self._make_manager(tmp_path)
+
+        class _FakeTaskGroup:
+            async def start(self, _coro):
+                return None
+
+        manager._task_group = _FakeTaskGroup()  # type: ignore[assignment]
+
+        wedge_event = anyio.Event()
+        second_dispatched = anyio.Event()
+
+        async def fake_handle_request(self_transport, scope, receive, send):
+            # First call hangs forever; second completes immediately.
+            if not wedge_event.is_set():
+                wedge_event.set()
+                await anyio.sleep_forever()
+            else:
+                second_dispatched.set()
+
+        monkeypatch.setattr(
+            "mnemon.persistent_sessions.StreamableHTTPServerTransport."
+            "handle_request",
+            fake_handle_request,
+        )
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(
+                manager._create_new_session,
+                self._scope(None),
+                self._noop_receive,
+                self._noop_send,
+            )
+            # Wait for the first request to be IN handle_request (lock
+            # released, hang in progress).
+            await wedge_event.wait()
+            # Second request should sail through.
+            tg.start_soon(
+                manager._create_new_session,
+                self._scope(None),
+                self._noop_receive,
+                self._noop_send,
+            )
+            with anyio.fail_after(2.0):
+                await second_dispatched.wait()
+            tg.cancel_scope.cancel()
+
+        assert second_dispatched.is_set()
+
+    async def test_concurrent_fresh_inits_get_distinct_session_ids(
+        self, tmp_path, monkeypatch
+    ):
+        """Sanity: each fresh-init mints its own session_id. The narrow
+        lock still serializes ``_server_instances`` writes so two
+        sessions can't end up with the same key."""
+        manager = self._make_manager(tmp_path)
+
+        class _FakeTaskGroup:
+            async def start(self, _coro):
+                return None
+
+        manager._task_group = _FakeTaskGroup()  # type: ignore[assignment]
+
+        async def fake_handle_request(self_transport, scope, receive, send):
+            return None
+
+        monkeypatch.setattr(
+            "mnemon.persistent_sessions.StreamableHTTPServerTransport."
+            "handle_request",
+            fake_handle_request,
+        )
+
+        import anyio
+
+        async with anyio.create_task_group() as tg:
+            for _ in range(5):
+                tg.start_soon(
+                    manager._create_new_session,
+                    self._scope(None),
+                    self._noop_receive,
+                    self._noop_send,
+                )
+
+        assert len(manager._server_instances) == 5
+        # All session_ids unique
+        assert len(set(manager._server_instances.keys())) == 5
+
+    async def test_resume_race_lost_falls_through_to_in_memory_path(
+        self, tmp_path, monkeypatch
+    ):
+        """Race-guard: if another coroutine resumed the session while
+        we were waiting for the lock, drop our minted transport and
+        delegate to upstream's lock-free in-memory hit branch."""
+        import anyio
+
+        manager = self._make_manager(tmp_path)
+        manager._session_store.register("survivor")
+        # Pre-populate _server_instances so the race-guard fires.
+        manager._server_instances["survivor"] = MagicMock(name="winning_transport")
+
+        super_called = {"yes": False}
+
+        async def fake_super(self, scope, receive, send):
+            super_called["yes"] = True
+
+        monkeypatch.setattr(
+            "mnemon.persistent_sessions.StreamableHTTPSessionManager."
+            "_handle_stateful_request",
+            fake_super,
+        )
+
+        await manager._resume_session(
+            "survivor",
+            self._scope(b"survivor"),
+            self._noop_receive,
+            self._noop_send,
+        )
+
+        assert super_called["yes"] is True


### PR DESCRIPTION
## Summary

Diagnosed live during the rc12 soak on 2026-05-06: every MCP client that opened a new session (mnemon doctor, claude-code-context-surfacing hook, claude.ai polling on first connect, direct curl initialize) hung past the client's 15s timeout. Warm-keeper PingRequests and existing-session tool calls kept working.

Direct curl confirmed the asymmetry:
- ✅ `tools/list` with persisted `Mcp-Session-Id` → <300ms, full response, server logs `Processing request of type ListToolsRequest`
- ❌ `initialize` with no session ID → 20s hang, no `Processing request of type` log ever

Root cause: upstream `StreamableHTTPSessionManager._handle_stateful_request` holds `_session_creation_lock` for the **full** duration of the new-session branch, including `await transport.handle_request(...)`. If that handler wedges for any reason, every subsequent fresh-init request queues behind the lock and times out at the client side. PR #109 patched the SSE-mode variant of this same lock-held-too-long pattern; the `json_response=True` variant still had its own way to wedge.

## Fix

`PersistentSessionManager` now bypasses upstream's locked path for fresh-init via a new `_create_new_session` method that holds `_session_creation_lock` only for the brief `_server_instances` mutation. `_resume_session` got the same narrowing.

Lock scope: race-guard read + dict write only. Released before `task_group.start()` and `transport.handle_request()`. One wedged handler can no longer take down the server's ability to accept new sessions.

## Test plan

- [x] `pytest -m "not integration"` → 708 passing (+5 new in `TestSessionCreationLockNarrowing`)
- [x] `pytest -m integration` → 4 passing (real `serve-remote` over HTTP, exercises fresh-init end-to-end)
- [ ] Post-merge: publish `mnemon-memory==0.6.0rc13` to PyPI
- [ ] Post-publish: `pip install -U mnemon-memory` then `mnemon upgrade web --app-name mnemon-memory --mnemon-version 0.6.0rc13`; confirm `mnemon doctor` passes 7/7 (this is the test that wedged repeatedly on rc11/rc12)
- [ ] Soak: `/health` shows `fresh_inits` incrementing as expected, no client-side timeout reports

## Note on the underlying upstream trigger

We never identified what specifically caused the first fresh-init `handle_request` to wedge. Reproduced reliably on rc11 (no override) and rc12 (with my override) — confirms it isn't introduced by my changes. This PR is defense-in-depth: even if the underlying handler hang isn't fixed, narrowing the lock means the wedge stays scoped to a single wedged session instead of the whole server's ability to accept new sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)