### PR TITLE
fix(health-monitor): bump check_health.py read timeout 10s -> 30s

### DIFF
--- a/scripts/check_health.py
+++ b/scripts/check_health.py
@@ -31,7 +31,11 @@ DEFAULT_URL = "https://mnemon-memory.fly.dev/health"
 PERSISTED_SESSIONS_WARN_THRESHOLD = 5_000
 
 
-def fetch_health(url: str, timeout: float = 10.0) -> dict:
+def fetch_health(url: str, timeout: float = 30.0) -> dict:
+    # 30s tolerates a Fly cold-start (machine wake + Python boot + bge-small
+    # ONNX load + SQLite/FastMCP startup). With min_machines_running=0 the
+    # overnight idle window auto-stops the machine; a 10s read timeout raced
+    # the wake-up on 2026-05-07 (issue #117). /health responds in <200ms once warm.
     req = urllib.request.Request(url, headers={"User-Agent": "mnemon-health-monitor/1"})
     with urllib.request.urlopen(req, timeout=timeout) as resp:
         if resp.status != 200:


### PR DESCRIPTION
## Summary
- The hourly Health Monitor workflow false-alarmed 4x overnight (03:54 / 06:45 / 09:42 / 11:56 UTC on 2026-05-07) with `TimeoutError: The read operation timed out` against `https://mnemon-memory.fly.dev/health`.
- Root cause: Fly app runs with `auto_stop_machines: true` + `min_machines_running: 0`, so the SJC machine auto-stops during the overnight idle window. The hourly probe pays the cold-start tax (machine wake + Python boot + bge-small ONNX load + SQLite/FastMCP startup) and races `urllib`'s 10s read timeout in `fetch_health`.
- Bumping the default to 30s gives the cold path ample headroom. `/health` responds in <200ms once warm (verified live just now: `HTTP=200 time_total=0.124s`).
- Tracker issue #117 was getting one false-alarm comment per hour. This PR stops the bleeding without infra changes.

## Alternatives considered
- `min_machines_running=1` would eliminate cold starts everywhere (also benefits real users) at the cost of a always-on shared-cpu-1x. Worth doing later if cold-start latency hits real users; not needed to fix the false alarms.
- Two-shot probe (wake-up GET, then real check) — more code, same outcome as bumping the timeout.

## Test plan
- [x] Smoke-tested the patched script locally against live `/health`: returns `OK: status=ok, ...` exit 0
- [ ] Verify next scheduled run (`5 * * * *`) goes green
- [ ] Confirm tracker issue #117 auto-closes on the green run via the workflow's `Auto-close tracker issue if check passed` step