### PR TITLE
feat(server-remote): periodic confidence-decay sweep on Fly lifespan

### DIFF
--- a/src/mnemon/persistent_sessions.py
+++ b/src/mnemon/persistent_sessions.py
@@ -30,7 +30,7 @@ import contextlib
 import logging
 import sqlite3
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -58,6 +58,15 @@ DEFAULT_TTL_SECONDS = 7 * 24 * 3600
 # Set to 0 to disable (e.g. tests that don't want a background task
 # bleeding into other test files).
 DEFAULT_EXPIRE_INTERVAL_SECONDS = 6 * 3600
+
+# How often the in-process periodic decay task wakes up to run
+# contradiction.apply_confidence_decay() over the memory vault. Decay is
+# orthogonal to session pruning — it ages confidence on stored memories
+# so older facts sort lower in search — but it lives next to the prune
+# task because both are background hygiene that the lifespan task group
+# is the right place to schedule. Set to 0 (or pass decay_fn=None) to
+# disable.
+DEFAULT_DECAY_INTERVAL_SECONDS = 24 * 3600
 
 
 class SessionStore:
@@ -206,6 +215,8 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
         retry_interval: int | None = None,
         session_idle_timeout: float | None = None,
         expire_interval_seconds: int = DEFAULT_EXPIRE_INTERVAL_SECONDS,
+        decay_fn: Callable[[], int] | None = None,
+        decay_interval_seconds: int = DEFAULT_DECAY_INTERVAL_SECONDS,
     ) -> None:
         super().__init__(
             app=app,
@@ -225,6 +236,12 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
         # sessions table otherwise grows monotonically until the next
         # restart.
         self._expire_interval_seconds = expire_interval_seconds
+        # Decay sweep is opt-in via an injected callable so this module
+        # doesn't import Store directly — keeps the session-management
+        # layer decoupled from the memory-vault layer. server_remote.py
+        # passes a closure that opens its own thread-local Store.
+        self._decay_fn = decay_fn
+        self._decay_interval_seconds = decay_interval_seconds
         # Process-lifetime counters scraped via /health for cold-stop diagnosis.
         # Single-event-loop server, so plain ints are race-free without a Lock.
         # NOTE: scripts/check_health.py reads these key names directly. If you
@@ -266,6 +283,9 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
             if self._expire_interval_seconds > 0:
                 assert self._task_group is not None
                 await self._task_group.start(self._run_periodic_expire)
+            if self._decay_fn is not None and self._decay_interval_seconds > 0:
+                assert self._task_group is not None
+                await self._task_group.start(self._run_periodic_decay)
             yield
 
     async def _run_periodic_expire(
@@ -289,6 +309,35 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
                 logger.info(
                     "Periodic prune: removed %d expired MCP session(s)",
                     expired,
+                )
+
+    async def _run_periodic_decay(
+        self, *, task_status: TaskStatus[None] = anyio.TASK_STATUS_IGNORED
+    ) -> None:
+        """Wake every ``decay_interval_seconds`` and apply confidence decay.
+
+        Mirrors ``_run_periodic_expire``: failures logged + swallowed so a
+        transient SQLite hiccup in the decay sweep cannot crash the
+        manager and take every active MCP session with it.
+
+        ``decay_fn`` is run in a worker thread via ``anyio.to_thread``
+        because ``apply_confidence_decay`` walks the full vault and does
+        blocking SQL — keeping it off the event loop avoids stalling
+        request handling during the sweep.
+        """
+        task_status.started()
+        assert self._decay_fn is not None
+        while True:
+            await anyio.sleep(self._decay_interval_seconds)
+            try:
+                updated = await anyio.to_thread.run_sync(self._decay_fn)
+            except Exception:  # noqa: BLE001
+                logger.exception("Periodic memory decay raised; retrying next tick")
+                continue
+            if updated:
+                logger.info(
+                    "Periodic decay: aged %d memory document(s)",
+                    updated,
                 )
 
     async def _handle_stateful_request(

--- a/src/mnemon/server_remote.py
+++ b/src/mnemon/server_remote.py
@@ -159,6 +159,22 @@ def run_remote() -> None:
     # Symptom this fixes: `mnemon doctor` and any `streamablehttp_client`
     # consumer timing out at session.initialize() while concurrent
     # requests sit in the lock queue.
+    # Periodic confidence-decay sweep over the memory vault. Opens a
+    # thread-local Store each tick because the sweep is dispatched via
+    # anyio.to_thread.run_sync (sqlite3 connections default to
+    # check_same_thread=True, so reusing the foreground singleton from
+    # server.py would raise across the thread boundary). Decay is non-
+    # destructive — it only adjusts the confidence column on aged
+    # documents — so a transient failure here is safe to swallow.
+    def _decay_sweep() -> int:
+        from .contradiction import apply_confidence_decay
+        from .store import Store
+        store = Store()
+        try:
+            return apply_confidence_decay(store)
+        finally:
+            store.close()
+
     mcp._session_manager = PersistentSessionManager(
         app=mcp._mcp_server,
         session_store=session_store,
@@ -167,11 +183,13 @@ def run_remote() -> None:
         json_response=True,
         stateless=mcp.settings.stateless_http,
         security_settings=mcp.settings.transport_security,
+        decay_fn=_decay_sweep,
     )
     print(
         f"MCP sessions persisted to {sessions_db} "
         f"(survives cold-stops, TTL {session_store.ttl_seconds}s, "
-        f"periodic prune every {mcp._session_manager._expire_interval_seconds}s)",
+        f"periodic prune every {mcp._session_manager._expire_interval_seconds}s, "
+        f"periodic memory decay every {mcp._session_manager._decay_interval_seconds}s)",
         file=sys.stderr,
     )
 

--- a/tests/test_persistent_sessions.py
+++ b/tests/test_persistent_sessions.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from mnemon.persistent_sessions import (
+    DEFAULT_DECAY_INTERVAL_SECONDS,
     DEFAULT_EXPIRE_INTERVAL_SECONDS,
     DEFAULT_TTL_SECONDS,
     PersistentSessionManager,
@@ -497,6 +498,156 @@ class TestPeriodicExpireTask:
         assert store.expire_old.call_count == 2
         assert any(
             "Periodic session prune raised" in rec.message
+            for rec in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# Periodic memory-decay sweep — wired alongside the prune task in run().
+# Runs apply_confidence_decay() on the vault every decay_interval_seconds
+# in a worker thread. Failures swallowed; counts logged when nonzero.
+# ---------------------------------------------------------------------------
+
+
+class TestPeriodicDecayConfig:
+    def test_default_interval_is_twenty_four_hours(self):
+        assert DEFAULT_DECAY_INTERVAL_SECONDS == 24 * 3600
+
+    def test_default_interval_applied_when_unspecified(self, tmp_path):
+        store = SessionStore(tmp_path / "sessions.sqlite")
+        manager = PersistentSessionManager(
+            app=MagicMock(name="mcp_server"), session_store=store
+        )
+        assert manager._decay_interval_seconds == DEFAULT_DECAY_INTERVAL_SECONDS
+
+    def test_decay_fn_defaults_to_none(self, tmp_path):
+        """Without an injected decay_fn the periodic decay task is a no-op."""
+        store = SessionStore(tmp_path / "sessions.sqlite")
+        manager = PersistentSessionManager(
+            app=MagicMock(name="mcp_server"), session_store=store
+        )
+        assert manager._decay_fn is None
+
+
+@pytest.mark.anyio
+class TestPeriodicDecayTask:
+    @pytest.fixture
+    def anyio_backend(self):
+        return "asyncio"
+
+    async def test_periodic_task_calls_decay_fn_on_each_tick(
+        self, tmp_path, monkeypatch
+    ):
+        """Drive the periodic loop directly: replace anyio.sleep with a
+        cancel-after-N-ticks shim and assert decay_fn fires N times."""
+        import anyio
+        import mnemon.persistent_sessions as mod
+
+        calls: list[None] = []
+
+        def _decay_fn() -> int:
+            calls.append(None)
+            return 0
+
+        store = SessionStore(tmp_path / "sessions.sqlite")
+        manager = PersistentSessionManager(
+            app=MagicMock(name="mcp_server"),
+            session_store=store,
+            decay_fn=_decay_fn,
+            decay_interval_seconds=1,
+        )
+
+        sleep_count = {"n": 0}
+
+        async def fake_sleep(_seconds):
+            sleep_count["n"] += 1
+            if sleep_count["n"] >= 3:
+                raise anyio.get_cancelled_exc_class()()
+
+        monkeypatch.setattr(mod.anyio, "sleep", fake_sleep)
+
+        with pytest.raises(BaseException):
+            await manager._run_periodic_decay()
+        assert len(calls) == 2  # ran on tick 1, tick 2; tick 3 cancelled before decay
+
+    async def test_periodic_task_logs_decayed_count_when_nonzero(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        import anyio
+        import mnemon.persistent_sessions as mod
+
+        store = SessionStore(tmp_path / "sessions.sqlite")
+        manager = PersistentSessionManager(
+            app=MagicMock(name="mcp_server"),
+            session_store=store,
+            decay_fn=lambda: 7,
+            decay_interval_seconds=1,
+        )
+
+        first_call = {"done": False}
+
+        async def fake_sleep(_seconds):
+            if not first_call["done"]:
+                first_call["done"] = True
+                return
+            raise anyio.get_cancelled_exc_class()()
+
+        monkeypatch.setattr(mod.anyio, "sleep", fake_sleep)
+
+        with caplog.at_level("INFO", logger="mnemon.persistent_sessions"), \
+            pytest.raises(BaseException):
+            await manager._run_periodic_decay()
+
+        assert any(
+            "Periodic decay" in rec.message and "7 memory" in rec.message
+            for rec in caplog.records
+        )
+
+    async def test_periodic_task_swallows_decay_failures(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Same contract as the prune task: a transient failure in the
+        decay sweep must not crash the manager and take active sessions
+        with it. The next tick must retry."""
+        import anyio
+        import mnemon.persistent_sessions as mod
+
+        side_effects: list[Exception | int] = [
+            RuntimeError("disk on fire"),  # tick 1: bang
+            0,  # tick 2: recovers
+        ]
+
+        def _decay_fn() -> int:
+            value = side_effects.pop(0)
+            if isinstance(value, Exception):
+                raise value
+            return value
+
+        store = SessionStore(tmp_path / "sessions.sqlite")
+        manager = PersistentSessionManager(
+            app=MagicMock(name="mcp_server"),
+            session_store=store,
+            decay_fn=_decay_fn,
+            decay_interval_seconds=1,
+        )
+
+        ticks = {"n": 0}
+
+        async def fake_sleep(_seconds):
+            ticks["n"] += 1
+            if ticks["n"] >= 3:
+                raise anyio.get_cancelled_exc_class()()
+
+        monkeypatch.setattr(mod.anyio, "sleep", fake_sleep)
+
+        with caplog.at_level("ERROR", logger="mnemon.persistent_sessions"), \
+            pytest.raises(BaseException):
+            await manager._run_periodic_decay()
+
+        # Both ticks happened — second one wasn't blocked by the first failure
+        assert side_effects == []
+        assert any(
+            "Periodic memory decay raised" in rec.message
             for rec in caplog.records
         )
 


### PR DESCRIPTION
## Summary

`apply_confidence_decay()` in `contradiction.py` has been an orphan helper — exists, no caller. Stored memories never aged after save, so search ranking treated a 6-month-old memory the same as a fresh one and confidence drift stayed permanently fictional.

This PR wires a daily decay sweep into `PersistentSessionManager.run()` next to the existing periodic prune task. Same pattern, same failure-isolation contract.

### Why on the Fly server lifespan
The remote server is where memories accumulate from many MCP clients. The existing prune task already has the lifespan task group running there; piggybacking adds one coroutine, no new infra.

### Why decay-only (not retroactive vector dedup) on this PR
Decay is non-destructive (only adjusts the `confidence` column on aged docs) and cheap. A retroactive contradiction sweep that classifies vector-near-duplicate pairs via the local LLM is a sensible follow-up but has a different cost/risk profile (LLM calls per pair, bounded work per tick). Out of scope here.

## Design notes

- `DEFAULT_DECAY_INTERVAL_SECONDS = 24 * 3600`. Set to 0 (or pass `decay_fn=None`) to disable.
- `decay_fn` is **injected as a callable** so `persistent_sessions.py` stays decoupled from `Store` — keeps the session-management layer from importing the memory-vault layer.
- `server_remote.py` supplies a closure that **opens its own thread-local Store** because:
  - `sqlite3.connect()` defaults to `check_same_thread=True`, so reusing the foreground `_get_store()` singleton across the worker thread would raise.
  - The sweep is dispatched via `anyio.to_thread.run_sync` so blocking SQL during the full-vault walk doesn't stall the event loop.
- Failures **logged and swallowed** (same contract as `_run_periodic_expire`): a transient SQLite hiccup must not crash the manager and take every active MCP session with it. Next tick retries.

## Tests

Mirror the existing prune-task suite (`TestPeriodicExpireConfig` / `TestPeriodicExpireTask`):

- `test_default_interval_is_twenty_four_hours`
- `test_default_interval_applied_when_unspecified`
- `test_decay_fn_defaults_to_none` — without an injected callable the sweep is a no-op
- `test_periodic_task_calls_decay_fn_on_each_tick`
- `test_periodic_task_logs_decayed_count_when_nonzero`
- `test_periodic_task_swallows_decay_failures` — transient failure on tick N doesn't block tick N+1

## Test plan

- [x] New decay tests pass (6/6)
- [x] Full `test_persistent_sessions.py` passes (38/38)
- [x] Full repo suite passes (732 passed)
- [ ] On next Fly redeploy, confirm startup banner shows `periodic memory decay every 86400s`
- [ ] Confirm `Periodic decay: aged N memory document(s)` log line appears at the 24h mark