### PR TITLE
chore: bump version to 0.6.0rc14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## [0.6.0rc14] - 2026-05-07
+
+### Added
+
+- **Periodic confidence-decay sweep on the Fly server lifespan** (#119).
+  `apply_confidence_decay()` in `contradiction.py` was an orphan helper
+  with no caller — stored memories never aged after save, so search
+  ranking treated a 6-month-old memory the same as one written
+  yesterday. `PersistentSessionManager.run()` now schedules a daily
+  decay sweep next to the existing prune task; both share the same
+  failure-isolation contract (logged + swallowed). Default interval
+  `DEFAULT_DECAY_INTERVAL_SECONDS = 24h`. Sweep runs in a worker thread
+  via `anyio.to_thread.run_sync` so the full-vault SQL walk doesn't
+  stall the event loop. `decay_fn` is injected as a callable so
+  `persistent_sessions.py` stays decoupled from `Store`;
+  `server_remote.py` supplies a closure that opens its own thread-local
+  `Store` (sqlite3 default `check_same_thread=True` forbids reusing the
+  foreground singleton across the worker thread).
+
+### Fixed
+
+- **Health-monitor false alarms during Fly cold-start window** (#118).
+  `scripts/check_health.py` had a 10s `urllib` read timeout that raced
+  the Fly cold-start (machine wake + Python boot + bge-small ONNX load
+  + SQLite/FastMCP startup) when the SJC machine auto-stopped during
+  the overnight idle window. Four false-alarm comments landed on issue
+  #117 between 03:54–11:56 UTC on 2026-05-07 before the timeout was
+  bumped to 30s. App was healthy throughout (`/health` <200ms warm).
+
+- **Stale comment + WARN message in `scripts/check_health.py`.** The
+  `PERSISTED_SESSIONS_WARN_THRESHOLD` block claimed `expire_old()` runs
+  only at startup; that fact has been false since rc12 added the
+  periodic prune (#115). Updated the comment + the WARN body to point
+  operators at TTL or prune-interval tuning instead of "pruning is
+  broken."
+
+### Tests
+
+- 6 new cases in `TestPeriodicDecayConfig` / `TestPeriodicDecayTask`
+  shipped in #119 mirror the existing prune-task suite: default
+  interval, opt-in via `decay_fn`, fires-on-each-tick,
+  logs-decayed-count-when-nonzero, swallows-decay-failures. Full repo
+  suite: 732 passing on the rc14 cut.
+
 ## [0.6.0rc13] - 2026-05-06
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.6.0rc13"
+version = "0.6.0rc14"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_health.py
+++ b/scripts/check_health.py
@@ -25,9 +25,13 @@ import urllib.request
 
 DEFAULT_URL = "https://mnemon-memory.fly.dev/health"
 
-# Soft cap. SessionStore.expire_old() runs only at startup, so this drifts
-# up during long uptime between Fly cold-stops; an unbounded climb means
-# either pruning is broken or the TTL is too long for the request rate.
+# Soft cap. Since 0.6.0rc12, PersistentSessionManager runs a periodic
+# expire_old() task on a 6h tick (DEFAULT_EXPIRE_INTERVAL_SECONDS in
+# persistent_sessions.py), so unbounded growth is no longer the failure
+# mode this guarded against. The remaining drift is steady-state count
+# under the 7-day TTL; the threshold trips when actual session volume
+# outpaces the prune cadence — investigate by lowering TTL or tightening
+# the prune interval rather than assuming pruning is broken.
 PERSISTED_SESSIONS_WARN_THRESHOLD = 5_000
 
 
@@ -86,9 +90,10 @@ def main() -> int:
     elif persisted >= PERSISTED_SESSIONS_WARN_THRESHOLD:
         warnings.append(
             f"metrics.persisted_sessions_total = {persisted} "
-            f"(>= {PERSISTED_SESSIONS_WARN_THRESHOLD}); SessionStore.expire_old() "
-            f"runs only at startup — long uptime drifts this up. Consider "
-            f"adding a periodic prune."
+            f"(>= {PERSISTED_SESSIONS_WARN_THRESHOLD}). Periodic prune runs "
+            f"every 6h since rc12, so this is steady-state count under the "
+            f"7-day TTL — investigate by lowering TTL or tightening the prune "
+            f"interval if the warning fires repeatedly."
         )
 
     print(f"OK: status={payload['status']}, metrics={json.dumps(metrics)}")

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.6.0rc13"
+__version__ = "0.6.0rc14"


### PR DESCRIPTION
## Summary

rc13 → rc14 cut for the soak window covering both PRs that landed today:

- **#118** — `scripts/check_health.py` 10s → 30s read timeout. Fly cold-start (machine wake + bge-small ONNX load + FastMCP startup) was racing the previous 10s `urllib` read timeout when the SJC machine auto-stopped overnight. Issue #117 was collecting one false-alarm comment per hour.
- **#119** — Periodic confidence-decay sweep on the Fly server lifespan. `apply_confidence_decay()` was an orphan helper with no caller; now ticks every 24h next to the existing prune task in `PersistentSessionManager`.

Bundled cleanup since the original surfaced from the same #117 thread:
- The `PERSISTED_SESSIONS_WARN_THRESHOLD` comment + WARN body in `check_health.py` still claimed `expire_old()` runs only at startup. That fact has been false since rc12 added the periodic prune (#115). Updated to point operators at TTL or prune-interval tuning when the warning fires, instead of "pruning is broken."

## Open items now in `private/ROADMAP.md`

Added so they don't get lost during the soak:

- **`persisted_sessions_total` warn threshold tuning** (alpha-test soft-signal section). Threshold (5,000) tripped 2026-05-07 at 4,944. Decide between raising the cap, shortening 7-day TTL, or tightening the 6h prune interval after one full cycle of soak data.
- **Periodic memory decay sweep behavior** (alpha-test soft-signal section). Watch list for the new `_run_periodic_decay`: log presence at 24h mark, sweep elapsed time, swallowed-error count.
- **Retroactive vector-near-duplicate sweep** (future product direction). Complement to the decay sweep: walk the vault, find pairs above the contradiction-overlap threshold, run the same `same/update/contradiction/unrelated` LLM classifier, apply the same decays + relations. Mirrors the `_run_periodic_decay` pattern.

## Test plan

- [x] `mnemon --version` → `0.6.0rc14`
- [x] `pytest` → 732 passing (same as rc13 cut; 6 new in #119 already in baseline)
- [x] `python scripts/check_health.py` against live `/health` → `OK: status=ok`
- [ ] Post-merge: `python -m build && twine upload dist/mnemon_memory-0.6.0rc14*`
- [ ] Post-publish: `mnemon upgrade web --mnemon-version 0.6.0rc14`
- [ ] Confirm startup banner shows `periodic memory decay every 86400s`
- [ ] Soak: watch for `Periodic decay: aged N memory document(s)` at the 24h mark; absence of `Periodic memory decay raised` ERROR

## Soak signals

Promotion to next rc / `0.6.0` stable when all signals stay clean for ~7 days:

- Health-monitor workflow goes green and **stays** green (issue #117 auto-closes on first green run via the workflow's auto-close step)
- `Periodic decay` log line appears at the 24h mark; sweep elapsed time stays bounded
- `persisted_sessions_total` either stays under the threshold or trips for legit reasons (i.e., real session volume) — informs the threshold-tuning roadmap entry
- Zero `Periodic memory decay raised` errors in fly logs