### PR TITLE
fix(mirror): upsert by stable slug + bump 0.6.0rc16 (P0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## [0.6.0rc16] - 2026-05-15
+
+### Fixed
+
+- **Auto-mirror re-inserted a new memory on every local-file edit
+  instead of upserting by stable slug (P0).** A Claude Code
+  auto-memory file's normal lifecycle is draft → refine →
+  finalize-on-merge — often several edits within one session. The
+  `mnemon-mirror` save path wrote a brand-new mnemon document on each
+  edit rather than updating the one keyed by the file's slug, so a
+  single intentional memory edited 3× became 3 near-identical docs
+  (concrete: `reference-morning-signal-iam-decoupled` mirrored 3× on
+  2026-05-15 — ids 2253/2256/2259). The at-save vector-overlap dedup
+  did not catch it: successive edits diverge enough to clear the
+  threshold while still being the same memory by identity.
+
+  Fix — `source_key` (stable caller-owned identity):
+
+  - **`store.save()` upsert-by-key** (`store.py`): a new optional
+    `source_key` argument. At most one *live* (non-invalidated)
+    document exists per `(collection, source_client, source_key)`. An
+    unchanged re-save is idempotent; a changed re-save invalidates the
+    prior live row(s) and inserts a fresh one, recording an auditable
+    supersession chain via `invalidated_by`. The generic content-hash
+    dedup branch is now scoped to `invalidated_at IS NULL` so a
+    revert (A → B → A) surfaces a fresh visible memory instead of
+    resurrecting a dead row's `access_count`. Additive
+    `documents.source_key` column + lookup index migrate in place on
+    existing vaults; rows that predate it stay `NULL` (insert-only,
+    exactly the old behaviour).
+  - **`memory_save` tool** (`server.py` / shared by `server_remote`):
+    threads the optional `source_key` through.
+  - **Auto-mirror** (`mirror.py`): keys `source_key` to the memory
+    file's frontmatter `name` (slug), so a memory edited several
+    times in one session stays a single document.
+
+  Also hardens the auto-generated `documents.path` with a uuid salt —
+  the upsert path can re-insert identical content within the same
+  millisecond (an in-session A → B → A revert), which collided with
+  the `UNIQUE(collection, path)` invariant under the old
+  `time-ms + hash-prefix` scheme.
+
+  Operator follow-up (not in this change): one-shot `memory_forget`
+  sweep of pre-fix same-slug pile-ups in the live default vault
+  (`source_client='mnemon-mirror'` grouped by title, keep
+  `max(created_at)`).
+
 ## [0.6.0rc15] - 2026-05-10
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.6.0rc15"
+version = "0.6.0rc16"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.6.0rc15"
+__version__ = "0.6.0rc16"

--- a/src/mnemon/mirror.py
+++ b/src/mnemon/mirror.py
@@ -294,11 +294,18 @@ def mirror_path(
 
         client = get_client()
 
+    # Stable upsert identity = the memory file's slug (frontmatter
+    # `name`). A memory file's normal lifecycle is draft → refine →
+    # finalize-on-merge, often several edits within one session; without
+    # this key each edit mirrored a brand-new document. The server
+    # upserts on (collection, source_client, source_key) so the slug
+    # stays a single live doc across edits.
     arguments: dict[str, Any] = {
         "title": title,
         "content": content,
         "content_type": content_type,
         "source_client": "mnemon-mirror",
+        "source_key": title,
     }
 
     result_text, elapsed = client.call_tool(

--- a/src/mnemon/server.py
+++ b/src/mnemon/server.py
@@ -149,11 +149,18 @@ def memory_save(
     content_type: str = "note",
     collection: str = "default",
     source_client: str | None = None,
+    source_key: str | None = None,
 ) -> str:
     """Save a new memory.
 
     Use this to explicitly store important information — decisions,
     preferences, observations, project context, or session handoffs.
+
+    ``source_key`` is an optional stable caller-owned identity. When
+    set, re-saving the same key updates in place (invalidate-prior +
+    insert) instead of accumulating near-duplicates — used by the
+    auto-mirror path, keyed to the local memory file's slug, so a
+    memory edited several times in one session stays a single document.
     """
     store = _get_store()
     doc_id = store.save(
@@ -162,6 +169,7 @@ def memory_save(
         content_type=content_type,
         collection=collection,
         source_client=source_client,
+        source_key=source_key,
     )
 
     # Embed asynchronously (non-blocking, failures are non-fatal — the

--- a/src/mnemon/store.py
+++ b/src/mnemon/store.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import sqlite3
 import time
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -181,6 +182,34 @@ class Store:
             );
         """)
         self.db.commit()
+        self._migrate_source_key()
+
+    def _migrate_source_key(self) -> None:
+        """Additive migration: ``documents.source_key`` is a stable
+        caller-supplied identity for upsert-by-slug (the auto-mirror
+        path keys it to the local file's frontmatter ``name``). Vaults
+        created before this column existed get it added in place;
+        ``ADD COLUMN`` with no default is metadata-only and safe on a
+        live WAL vault. Pre-existing rows keep ``source_key = NULL`` and
+        are treated as un-keyed (insert-only) — exactly the old
+        behaviour, so the migration is a no-op for everything that
+        predates it."""
+        cols = {
+            r["name"]
+            for r in self.db.execute("PRAGMA table_info(documents)").fetchall()
+        }
+        if "source_key" not in cols:
+            self.db.execute("ALTER TABLE documents ADD COLUMN source_key TEXT")
+        # Lookup index for the upsert probe. Non-unique on purpose:
+        # uniqueness is enforced at save() time scoped to
+        # ``invalidated_at IS NULL`` (a partial UNIQUE index can't
+        # express "one *live* row per key" cleanly across the
+        # invalidate-prior + insert supersession we do here).
+        self.db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_documents_source_key "
+            "ON documents (collection, source_client, source_key)"
+        )
+        self.db.commit()
 
     def save(
         self,
@@ -190,8 +219,20 @@ class Store:
         collection: str = "default",
         source_client: str | None = None,
         confidence: float | None = None,
+        source_key: str | None = None,
     ) -> int:
-        """Save a memory. Returns the document ID."""
+        """Save a memory. Returns the document ID.
+
+        ``source_key`` — when supplied — is a stable caller-owned
+        identity (e.g. the auto-mirror path passes the local memory
+        file's frontmatter ``name``). At most one *live*
+        (non-invalidated) document exists per
+        ``(collection, source_client, source_key)``: an unchanged
+        re-save is idempotent; a changed re-save invalidates the prior
+        live row(s) and inserts a fresh one (supersession recorded via
+        ``invalidated_by``). Without ``source_key`` the historical
+        insert-only behaviour is preserved exactly.
+        """
         content_hash = _sha256(content)
         ct = ContentType(content_type)
         mt = MEMORY_TYPE_MAP.get(ct, MemoryType.SEMANTIC)
@@ -205,9 +246,55 @@ class Store:
             (content_hash, content),
         )
 
-        # Check for existing document with same hash
+        superseded_ids: list[int] = []
+
+        # Upsert-by-slug: when the caller owns a stable identity key,
+        # there is at most one *live* document per
+        # (collection, source_client, source_key). Resolve that before
+        # the generic hash dedup so a divergent edit supersedes its
+        # prior instead of piling up a near-duplicate (the auto-mirror
+        # multi-edit-per-session case).
+        if source_key is not None:
+            priors = self.db.execute(
+                """SELECT id, hash FROM documents
+                   WHERE collection = ?
+                     AND source_client IS ?
+                     AND source_key = ?
+                     AND invalidated_at IS NULL""",
+                (collection, source_client, source_key),
+            ).fetchall()
+            if len(priors) == 1 and priors[0]["hash"] == content_hash:
+                # Unchanged re-save of the same slug — idempotent.
+                self.db.execute(
+                    "UPDATE documents SET access_count = access_count + 1, "
+                    "updated_at = datetime('now') WHERE id = ?",
+                    (priors[0]["id"],),
+                )
+                self.db.commit()
+                return priors[0]["id"]
+            if priors:
+                # Changed (or legacy pile-up) — invalidate every live
+                # row for this key; invalidated_by is stamped to the
+                # new doc below once we have its id.
+                superseded_ids = [p["id"] for p in priors]
+                qmarks = ",".join("?" * len(superseded_ids))
+                self.db.execute(
+                    f"UPDATE documents SET invalidated_at = datetime('now') "
+                    f"WHERE id IN ({qmarks})",
+                    superseded_ids,
+                )
+                self.db.executemany(
+                    "DELETE FROM documents_fts WHERE rowid = ?",
+                    [(i,) for i in superseded_ids],
+                )
+
+        # Check for an existing *live* document with the same content.
+        # Scoped to invalidated_at IS NULL so a re-save of content that
+        # was previously forgotten / superseded creates a fresh visible
+        # memory rather than resurrecting a dead row's access_count.
         row = self.db.execute(
-            "SELECT id FROM documents WHERE hash = ?", (content_hash,)
+            "SELECT id FROM documents WHERE hash = ? AND invalidated_at IS NULL",
+            (content_hash,),
         ).fetchone()
 
         if row:
@@ -218,17 +305,32 @@ class Store:
             self.db.commit()
             return row["id"]
 
-        # Auto-generate a stable path key — content-addressed, sortable by
-        # creation time. Callers have never needed to override this so the
-        # parameter was removed in 0.4.2.
-        path = f"{content_type}/{int(time.time() * 1000)}-{content_hash[:8]}"
+        # Auto-generate a stable path key — sortable by creation time.
+        # Callers have never needed to override this so the parameter was
+        # removed in 0.4.2. The uuid salt guarantees the
+        # UNIQUE(collection, path) invariant even when the upsert-by-slug
+        # path re-inserts identical content within the same millisecond
+        # (e.g. an A -> B -> A revert in one session).
+        path = (
+            f"{content_type}/{int(time.time() * 1000)}"
+            f"-{content_hash[:8]}-{uuid.uuid4().hex[:8]}"
+        )
 
         cur = self.db.execute(
-            """INSERT INTO documents (collection, path, title, hash, content_type, memory_type, confidence, source_client)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-            (collection, path, title, content_hash, ct.value, mt.value, conf, source_client),
+            """INSERT INTO documents (collection, path, title, hash, content_type, memory_type, confidence, source_client, source_key)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (collection, path, title, content_hash, ct.value, mt.value, conf, source_client, source_key),
         )
         doc_id = cur.lastrowid
+
+        # Record supersession: the prior live rows we just invalidated
+        # point at the doc that replaces them so the chain is auditable.
+        if superseded_ids:
+            qmarks = ",".join("?" * len(superseded_ids))
+            self.db.execute(
+                f"UPDATE documents SET invalidated_by = ? WHERE id IN ({qmarks})",
+                (doc_id, *superseded_ids),
+            )
 
         # Index in FTS5
         self.db.execute(

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -132,6 +132,9 @@ class TestMirrorPathSaved:
         assert payload["title"] == "Test handoff"
         assert payload["content_type"] == "handoff"
         assert payload["source_client"] == "mnemon-mirror"
+        # Stable upsert identity = the slug (frontmatter `name`), so a
+        # multi-edit session updates one doc instead of piling up dups.
+        assert payload["source_key"] == "Test handoff"
         # Body must be present; description should also be merged in.
         assert "Body content goes here." in payload["content"]
         assert "_A test memory file_" in payload["content"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -249,6 +249,7 @@ class TestMemorySave:
             content_type="note",
             collection="default",
             source_client=None,
+            source_key=None,
         )
 
     @patch("mnemon.server.Store")
@@ -279,6 +280,7 @@ class TestMemorySave:
             content_type="decision",
             collection="work",
             source_client="claude",
+            source_key=None,
         )
 
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -274,6 +274,106 @@ class TestStatus:
         assert stats["pinned"] == 1
 
 
+class TestUpsertBySourceKey:
+    """Regression coverage for the P0 fix: auto-mirror re-inserting a
+    new memory on every local-file edit instead of upserting by the
+    stable slug (frontmatter `name`)."""
+
+    def _live(self, store, source_key, source_client="mnemon-mirror"):
+        return store.db.execute(
+            """SELECT id, hash FROM documents
+               WHERE source_client IS ? AND source_key = ?
+                 AND invalidated_at IS NULL
+               ORDER BY id""",
+            (source_client, source_key),
+        ).fetchall()
+
+    def test_changed_reedit_supersedes_prior(self, store):
+        # Simulate one memory file's session lifecycle: draft -> refine
+        # -> finalize. Three edits, divergent content, same slug.
+        id1 = store.save(
+            title="my-slug", content="draft v1",
+            content_type="project", source_client="mnemon-mirror",
+            source_key="my-slug",
+        )
+        id2 = store.save(
+            title="my-slug", content="refined v2",
+            content_type="project", source_client="mnemon-mirror",
+            source_key="my-slug",
+        )
+        id3 = store.save(
+            title="my-slug", content="final v3 merged",
+            content_type="project", source_client="mnemon-mirror",
+            source_key="my-slug",
+        )
+        assert id1 != id2 != id3
+        # Exactly one live document for the slug — the latest.
+        live = self._live(store, "my-slug")
+        assert len(live) == 1
+        assert live[0]["id"] == id3
+        doc = store.get(id3)
+        assert doc.content == "final v3 merged"
+        # Priors form an auditable supersession chain id1 -> id2 -> id3
+        # (each edit invalidates only the then-live row).
+        for prior, successor in ((id1, id2), (id2, id3)):
+            row = store.db.execute(
+                "SELECT invalidated_at, invalidated_by FROM documents WHERE id = ?",
+                (prior,),
+            ).fetchone()
+            assert row["invalidated_at"] is not None
+            assert row["invalidated_by"] == successor
+
+    def test_unchanged_resave_is_idempotent(self, store):
+        id1 = store.save(
+            title="slug-x", content="stable body",
+            source_client="mnemon-mirror", source_key="slug-x",
+        )
+        id2 = store.save(
+            title="slug-x", content="stable body",
+            source_client="mnemon-mirror", source_key="slug-x",
+        )
+        assert id1 == id2
+        assert len(self._live(store, "slug-x")) == 1
+
+    def test_distinct_slugs_do_not_collide(self, store):
+        a = store.save(
+            title="slug-a", content="body a",
+            source_client="mnemon-mirror", source_key="slug-a",
+        )
+        b = store.save(
+            title="slug-b", content="body b",
+            source_client="mnemon-mirror", source_key="slug-b",
+        )
+        assert a != b
+        assert len(self._live(store, "slug-a")) == 1
+        assert len(self._live(store, "slug-b")) == 1
+
+    def test_revert_to_earlier_content_stays_single_live(self, store):
+        # A -> B -> A again. The final A must be a fresh visible doc,
+        # not a resurrected invalidated row (the old hash-dedup branch
+        # would have bumped a dead row's access_count and surfaced
+        # nothing).
+        store.save(title="s", content="A", source_client="mnemon-mirror", source_key="s")
+        store.save(title="s", content="B", source_client="mnemon-mirror", source_key="s")
+        id3 = store.save(title="s", content="A", source_client="mnemon-mirror", source_key="s")
+        live = self._live(store, "s")
+        assert len(live) == 1
+        assert live[0]["id"] == id3
+        assert store.get(id3).content == "A"
+
+    def test_no_source_key_preserves_insert_only_behaviour(self, store):
+        # Without a source_key the historical behaviour is unchanged:
+        # different content -> different ids, no supersession.
+        id1 = store.save(title="t1", content="alpha")
+        id2 = store.save(title="t2", content="beta")
+        assert id1 != id2
+        for i in (id1, id2):
+            row = store.db.execute(
+                "SELECT invalidated_at FROM documents WHERE id = ?", (i,)
+            ).fetchone()
+            assert row["invalidated_at"] is None
+
+
 class TestSweep:
     def test_sweep_dry_run_does_not_delete(self, store):
         store.save(title="Old note", content="old stuff", content_type="note")


### PR DESCRIPTION
## P0 — auto-mirror re-inserts on every edit (surfaced 2026-05-15)

A Claude Code auto-memory file's normal lifecycle is draft → refine → finalize-on-merge — often several edits within one session. The `mnemon-mirror` save path wrote a **brand-new** mnemon document on each edit instead of upserting by the file's slug, so a single intentional memory edited 3× became 3 near-identical docs (concrete: `reference-morning-signal-iam-decoupled` mirrored 3× on 2026-05-15 — ids 2253/2256/2259). The at-save vector-overlap dedup can't catch it: successive edits diverge enough to clear the threshold while still being the same memory by identity.

## Fix — `source_key` (stable caller-owned identity)

- **`store.save()` upsert-by-key** — optional `source_key`. At most one *live* (non-invalidated) doc per `(collection, source_client, source_key)`: unchanged re-save is idempotent; changed re-save invalidates the prior live row(s) and inserts a fresh one with an auditable `invalidated_by` supersession chain. Generic content-hash dedup now scoped to `invalidated_at IS NULL` so an A→B→A revert surfaces a fresh visible memory rather than resurrecting a dead row's `access_count`.
- **Migration** — additive `documents.source_key` column + lookup index, applied in place on existing vaults. Pre-existing rows stay `NULL` = old insert-only behaviour (no-op for everything predating this).
- **`memory_save` tool** (shared by `server_remote`) threads `source_key`.
- **`mirror.py`** keys `source_key` to the file's frontmatter `name` (slug).
- **`path` uuid salt** — the upsert path can re-insert identical content within the same millisecond (in-session A→B→A revert), which collided with `UNIQUE(collection, path)` under the old `time-ms + hash-prefix` scheme.

## Tests

+5 `store` regression tests (changed-reedit supersession, idempotent unchanged re-save, distinct-slug isolation, A→B→A revert, no-source_key insert-only preservation) + mirror payload assertion. Full suite **750 passed**.

## Release

Version bumped `0.6.0rc15` → `0.6.0rc16` for soak. CHANGELOG updated.

## Operator follow-up (not in this PR)

One-shot `memory_forget` sweep of pre-fix same-slug pile-ups in the live default vault (`source_client='mnemon-mirror'` grouped by title, keep `max(created_at)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)