### PR TITLE
docs(claude): add Session State & Wind-down to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,28 @@
 
 Universal long-term memory layer for AI agents via MCP.
 
+## Session State & Wind-down
+
+**At the start of any mnemon session, read `private/SYSTEM_STATE.md`
+first** — the living buildout snapshot (version, deploy, architecture,
+security posture, in-flight/deferred, known gotchas). It supersedes the
+one-time `private/mnemon-system-audit-260412.md`. Honor its "Last
+verified" date: if older than ~1 week, re-verify the Current State /
+Deploy blocks before trusting specifics. `ROADMAP.md` (same dir) holds
+open work + the pre-deploy ritual.
+
+**When closing/wrapping a session,** run the wind-down before ending:
+
+1. **`private/ROADMAP.md`** — refresh every task state touched (mark
+   shipped/merged, annotate awaiting-merge, add new items surfaced).
+2. **`private/SYSTEM_STATE.md`** — overwrite the Current State snapshot
+   in place for any changed facts; append a dated Recent Changes line;
+   bump "Last verified". Confirmed milestones only, no speculation.
+3. **Memories** — save durable cross-session facts/decisions/feedback.
+
+`private/` is gitignored — these doc edits are local-only (no commit);
+the git history of code + `CHANGELOG.md` is the durable audit trail.
+
 ## Stack
 
 - **Runtime:** Python >= 3.10


### PR DESCRIPTION
## What

Makes the new `private/SYSTEM_STATE.md` load-bearing instead of an orphan doc by wiring it into `CLAUDE.md`:

- **Session start:** read `private/SYSTEM_STATE.md` first (living buildout snapshot; supersedes the one-time `mnemon-system-audit-260412.md`); honor its "Last verified" staleness note.
- **Session wind-down (on close/wrap):** 3-step checklist — (1) refresh `ROADMAP.md` task states, (2) overwrite `SYSTEM_STATE.md` Current State + append dated Recent Changes + bump Last verified (confirmed milestones only), (3) save memories.
- Notes `private/` is gitignored so these doc edits are local-only (no commit) — the code git history + `CHANGELOG.md` are the durable audit trail.

Mirrors the alpha-engine SYSTEM_STATE protocol, adapted for mnemon's gitignored-local docs.

## Scope note

Per Brian's "all apps" + hybrid placement decision: the generic app-agnostic form of this rule also went into `~/.claude/CLAUDE.md` (global, untracked — covers every project incl. future), and the explicit 3-step wind-down was added to the alpha-engine system doc (`~/Development/CLAUDE.md`, a loose untracked file). This PR is the only one of the three that lands in a git repo. Doc-only; no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)