### PR TITLE
chore(ci): ignore disputed PYSEC-2025-183 in pip-audit

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -35,4 +35,16 @@ jobs:
         # in a runtime/dev dep fails the workflow. If a transitive dep
         # has no fix available, file an upstream issue + add
         # `--ignore-vuln <ID>` here with a comment explaining why.
-        run: pip-audit --strict .
+        #
+        # Ignored advisories:
+        #
+        # PYSEC-2025-183 (pyjwt, 0.1.1–2.12.1, no fix release): flags
+        # that pyjwt does not enforce a minimum HMAC key length.
+        # Disputed by upstream ("the key length is chosen by the
+        # application that uses the library") — there is no patched
+        # version to upgrade to. mnemon's only pyjwt use is in
+        # `src/mnemon/oauth_as.py`, which signs/verifies with RS256
+        # against a 2048-bit RSA keypair (algorithm hard-locked, no
+        # HS-allowance). The advisory describes no condition that
+        # applies to this usage.
+        run: pip-audit --strict --ignore-vuln PYSEC-2025-183 .


### PR DESCRIPTION
## Summary
- Daily scheduled `pip-audit` workflow began failing on `main` (`4915af3`) on 2026-05-20 when a new advisory, **PYSEC-2025-183**, landed in the OSV database against PyJWT 0.1.1–2.12.1 with **no fix version**.
- The advisory flags that pyjwt doesn't enforce a minimum HMAC key length. Upstream **disputes** it: "the key length is chosen by the application that uses the library." 2.12.1 is the current latest release (2026-03-13); there is nothing to upgrade to.
- mnemon's only pyjwt use is in `src/mnemon/oauth_as.py`, which signs and verifies with **RS256 against a 2048-bit RSA keypair**, algorithm hard-locked, no HS-allowance. The advisory describes no condition that applies to this usage.
- Adds `--ignore-vuln PYSEC-2025-183` to the workflow with the rationale inline, exactly as the existing workflow comment prescribes for no-fix advisories. Any *new* advisory on any dep still fails the workflow.

## Test plan
- [ ] CI pip-audit job goes green on this PR.
- [ ] No other CI checks regress.
- [ ] After merge, the daily scheduled run at 14:00 UTC stays green until the next genuinely actionable advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)