### PR TITLE
fix(scripts): layer3 pins mnemon upgrade web to a PyPI-available version

### DIFF
--- a/scripts/promote_stable.sh
+++ b/scripts/promote_stable.sh
@@ -21,6 +21,10 @@
 # Usage:
 #   scripts/promote_stable.sh preflight   # read-only, runs before everything else
 #   scripts/promote_stable.sh layer3      # E2E web test (creates+destroys test Fly app, ~15 min)
+#                                         # pins mnemon upgrade web --mnemon-version to TARGET_VERSION
+#                                         # if it's on PyPI, otherwise the latest published version
+#                                         # as proxy (LAYER3_VERSION_OVERRIDE=<ver> to override).
+#                                         # SOTA for true pre-publish validation: TestPyPI (ROADMAP).
 #   scripts/promote_stable.sh publish     # POST-MERGE: build → twine upload → tag → GH release → Fly redeploy
 #   scripts/promote_stable.sh verify      # post-publish sanity check
 #
@@ -65,6 +69,50 @@ MNEMON_VENV_BIN="$REPO_ROOT/.venv/bin"
 [ -x "$MNEMON_VENV_BIN/mnemon" ] || die "mnemon CLI not found at $MNEMON_VENV_BIN/mnemon — activate / install editable venv first"
 [ -x "$MNEMON_VENV_BIN/twine" ] || die "twine not found at $MNEMON_VENV_BIN/twine — pip install -e .[dev]"
 [ -x "$MNEMON_VENV_BIN/python" ] || die "venv python not found at $MNEMON_VENV_BIN/python"
+
+# ---- helpers ----
+
+# Resolve the latest version of mnemon-memory currently published to PyPI,
+# pre-releases included. Uses the PyPI JSON API + packaging.version (via
+# the venv python) so the answer is deterministic — `pip index versions`
+# proved unreliable in the wild (stale cache + info.version field returning
+# the latest STABLE only, hiding 0.6.0rcN entirely).
+latest_pypi_version() {
+    "$MNEMON_VENV_BIN/python" - <<'PY' 2>/dev/null
+import urllib.request, json, sys
+from packaging.version import Version, InvalidVersion
+try:
+    with urllib.request.urlopen("https://pypi.org/pypi/mnemon-memory/json", timeout=10) as r:
+        d = json.load(r)
+except Exception as e:
+    sys.exit(1)
+vs = []
+for s in d.get("releases", {}).keys():
+    try:
+        vs.append(Version(s))
+    except InvalidVersion:
+        pass
+if not vs:
+    sys.exit(1)
+vs.sort()
+print(vs[-1])
+PY
+}
+
+# Is a specific version published to PyPI?
+is_pypi_published() {
+    local v="$1"
+    "$MNEMON_VENV_BIN/python" - "$v" <<'PY' 2>/dev/null
+import urllib.request, json, sys
+target = sys.argv[1]
+try:
+    with urllib.request.urlopen("https://pypi.org/pypi/mnemon-memory/json", timeout=10) as r:
+        d = json.load(r)
+except Exception:
+    sys.exit(2)
+sys.exit(0 if target in d.get("releases", {}) else 1)
+PY
+}
 
 # ============================================================
 # preflight — read-only validation that the candidate is ready
@@ -154,6 +202,40 @@ cmd_layer3() {
         die "dangling mnemon-test-* Fly apps exist — destroy them before running"
     fi
 
+    # ---- Resolve the mnemon-memory version Layer-3 will deploy to the test app ----
+    #
+    # `mnemon upgrade web` calls `flyctl deploy`, which builds a Docker image that
+    # runs `pip install mnemon-memory[server]==<ver>` against real PyPI. The
+    # candidate version (TARGET_VERSION) may not yet be published — that's the
+    # whole point of pre-publish validation. So Layer-3 must pin to a version
+    # that *is* on PyPI:
+    #
+    #   - If TARGET_VERSION is already on PyPI (e.g., re-running layer3 after
+    #     a publish), use it directly.
+    #   - Otherwise pin to the latest published version as a proxy. This is
+    #     valid for the byte-identical rc → stable promotion (0.6.0rc18 ↔
+    #     0.6.0 source-identical). For future rc bumps where the candidate has
+    #     code changes from the prior rc, the latest-published-as-proxy is
+    #     incomplete validation — see ROADMAP "TestPyPI integration for true
+    #     pre-publish validation" for the institutional fix.
+    #
+    # Override: set LAYER3_VERSION_OVERRIDE=<ver> to bypass auto-resolution.
+    local LAYER3_VERSION
+    if [ -n "${LAYER3_VERSION_OVERRIDE:-}" ]; then
+        LAYER3_VERSION="$LAYER3_VERSION_OVERRIDE"
+        echo_ok "Layer-3 pinning mnemon-memory==$LAYER3_VERSION (operator override)"
+    elif is_pypi_published "$TARGET_VERSION"; then
+        LAYER3_VERSION="$TARGET_VERSION"
+        echo_ok "Layer-3 pinning mnemon-memory==$LAYER3_VERSION (candidate already on PyPI)"
+    else
+        LAYER3_VERSION="$(latest_pypi_version)"
+        [ -n "$LAYER3_VERSION" ] || die "could not resolve mnemon-memory latest from PyPI JSON API"
+        echo_warn "candidate $TARGET_VERSION isn't on PyPI yet"
+        echo_warn "Layer-3 will deploy mnemon-memory==$LAYER3_VERSION (latest published) as a proxy"
+        echo_warn "for true pre-publish validation of $TARGET_VERSION's code: file TestPyPI integration as ROADMAP follow-up"
+    fi
+    confirm "proceed with Layer-3 deploying mnemon-memory==$LAYER3_VERSION?"
+
     # Isolate test environment per the runbook.
     local TEST_RUN_ID
     TEST_RUN_ID="$(date +%Y%m%d-%H%M%S)"
@@ -180,8 +262,8 @@ cmd_layer3() {
     "$M" status
     echo_ok "3 docs seeded in test vault"
 
-    echo_step "Step 3 — upgrade web to $TEST_APP_NAME"
-    "$M" upgrade web --app-name "$TEST_APP_NAME"
+    echo_step "Step 3 — upgrade web to $TEST_APP_NAME (pinned to mnemon-memory==$LAYER3_VERSION)"
+    "$M" upgrade web --app-name "$TEST_APP_NAME" --mnemon-version "$LAYER3_VERSION"
     ls "$MNEMON_VAULT_DIR/archive/" | grep -q "pre-web-" || die "expected pre-web-*.sqlite archive missing"
     ! [ -f "$MNEMON_VAULT_DIR/default.sqlite" ] || die "local vault should be archived; default.sqlite still present"
     echo_ok "upgrade complete; local vault archived"


### PR DESCRIPTION
## Summary

PR #131 shipped `scripts/promote_stable.sh` but its `layer3` subcommand had a latent chicken-and-egg bug that surfaced on first invocation against the 0.6.0 stable cut:

```
1.733 ERROR: No matching distribution found for mnemon-memory==0.6.0
Error: failed to fetch an image or build from source ...
subprocess.CalledProcessError: Command '['flyctl', 'deploy', ...]' returned non-zero exit status 1.
  ⚠ cleanup: destroying lingering test app mnemon-test-20260521-101238
```

**Root cause.** `mnemon upgrade web` defaults `--mnemon-version` to the local editable install's `__version__`. During a stable promotion that's ahead of PyPI: local says `0.6.0`, PyPI still has `0.6.0rc18`. The Docker build inside `flyctl deploy` runs `pip install mnemon-memory[server]==0.6.0` against real PyPI and fails.

The script's `set -euo pipefail` and the `_layer3_cleanup` EXIT trap worked exactly as designed — failure was loud, test Fly app destroyed, prod surfaces untouched.

## Fix

`cmd_layer3` now resolves the pin before invoking `flyctl deploy`:
- If `TARGET_VERSION` is on PyPI, pin to it (re-run after publish)
- Otherwise pin to the latest published version as a proxy + WARN about the proxy
- `LAYER3_VERSION_OVERRIDE=<ver>` for an explicit operator override

The proxy is valid for the 0.6.0 stable cut because 0.6.0 is byte-identical to rc18. For future rc bumps where the candidate has real code changes, the proxy is incomplete validation — flagged in the script comment and filed as a ROADMAP item ("TestPyPI integration for true pre-publish validation").

## Other changes

- `latest_pypi_version` and `is_pypi_published` helpers using the PyPI JSON API + `packaging.version` (already in the venv). Chose the JSON API over `pip index versions` because the latter proved unreliable in the wild: returned `info.version=0.4.0` and ignored the entire `0.6.0rcN` line, presumably because PyPI's `info.version` returns the latest *stable* and 0.6.0rcN are pre-releases.
- Confirmation prompt before flyctl deploy starts, showing the resolved version so the operator sees exactly what's being deployed before any Fly resources spin up.
- Script header doc updated; private `e2e-test-runbook-260421.md` updated locally (gitignored).

## Verified

- `bash -n` syntax-checks clean.
- Helpers in isolation: `latest_pypi_version` → `0.6.0rc18`; `is_pypi_published 0.6.0rc18` → yes; `is_pypi_published 0.6.0` → no.
- Cleanup from the failed run completed: no dangling Fly apps, S3 prefix empty, prod surfaces healthy (verified via `flyctl apps list`, `aws s3 ls`, `flyctl status --app mnemon-memory`).

## Test plan

- [ ] After merge: `scripts/promote_stable.sh layer3` on main pins to `0.6.0rc18`, prompts for confirmation, completes the upgrade/downgrade cycle against `mnemon-test-<ts>`
- [ ] Post-merge `scripts/promote_stable.sh publish` runs the full publish sequence
- [ ] Once 0.6.0 is published, re-running `scripts/promote_stable.sh layer3` would pin to `0.6.0` (the candidate-on-PyPI branch) — not testable until after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)