### PR TITLE
fix(scripts): layer3 parses 'Total memories:' from mnemon status output

### DIFF
--- a/scripts/promote_stable.sh
+++ b/scripts/promote_stable.sh
@@ -266,20 +266,27 @@ cmd_layer3() {
     "$M" upgrade web --app-name "$TEST_APP_NAME" --mnemon-version "$LAYER3_VERSION"
     ls "$MNEMON_VAULT_DIR/archive/" | grep -q "pre-web-" || die "expected pre-web-*.sqlite archive missing"
     ! [ -f "$MNEMON_VAULT_DIR/default.sqlite" ] || die "local vault should be archived; default.sqlite still present"
-    echo_ok "upgrade complete; local vault archived"
+    local seeded_count
+    seeded_count="$(MNEMON_REMOTE_URL="https://$TEST_APP_NAME.fly.dev/mcp" "$M" status 2>&1 | awk '/^Total memories:/{print $NF; exit}')"
+    [[ "$seeded_count" == "3" ]] || die "expected 3 docs seeded to remote, got '$seeded_count'"
+    echo_ok "upgrade complete; local vault archived; 3 docs seeded to remote via S3 → Fly"
 
     echo_step "Step 4 — exercise remote (add via HTTP)"
     MNEMON_REMOTE_URL="https://$TEST_APP_NAME.fly.dev/mcp" \
       "$M" save "Memory added after upgrade, should survive downgrade" "run-$TEST_RUN_ID" --type observation
     local remote_count
-    remote_count="$(MNEMON_REMOTE_URL="https://$TEST_APP_NAME.fly.dev/mcp" "$M" status 2>&1 | awk '/[Dd]ocuments?:/{print $NF; exit}')"
+    # `mnemon status` emits "Total memories: N" — anchor on that exact line.
+    # The previous regex looked for "Documents:" which doesn't appear in the
+    # output; the awk match silently came back empty and the count check
+    # failed loudly with "got ''".
+    remote_count="$(MNEMON_REMOTE_URL="https://$TEST_APP_NAME.fly.dev/mcp" "$M" status 2>&1 | awk '/^Total memories:/{print $NF; exit}')"
     [[ "$remote_count" == "4" ]] || die "expected 4 docs on remote, got '$remote_count'"
     echo_ok "4 docs on remote"
 
     echo_step "Step 5 — downgrade local + destroy fly app"
     "$M" downgrade local --destroy-fly-app
     local local_count
-    local_count="$("$M" status 2>&1 | awk '/[Dd]ocuments?:/{print $NF; exit}')"
+    local_count="$("$M" status 2>&1 | awk '/^Total memories:/{print $NF; exit}')"
     [[ "$local_count" == "4" ]] || die "expected 4 docs after downgrade, got '$local_count'"
     if flyctl apps list 2>/dev/null | grep -q "$TEST_APP_NAME"; then
         die "test app not destroyed: $TEST_APP_NAME"


### PR DESCRIPTION
## Summary

PR #132 fixed the version-pin chicken-and-egg. The test Fly app then deployed cleanly from `mnemon-memory==0.6.0rc18`, but Step 4 of Layer-3 failed:

```
==> Step 4 — exercise remote (add via HTTP)
Saved memory #1: "Memory added after upgrade, should survive downgrade"
  ✗ expected 4 docs on remote, got ''
  ⚠ cleanup: destroying lingering test app mnemon-test-20260521-103937
```

**Root cause.** `mnemon status` emits `Total memories: N`. My awk regex `/[Dd]ocuments?:/` looks for `Documents:` (or `Document:`), which doesn't appear in the output. The match silently came back empty, the `[[ "$remote_count" == "4" ]]` check failed loudly, the trap destroyed the test app, and the script exited non-zero. Fail-loud worked exactly as designed — the assumption baked into the regex was just wrong.

Verified locally with the real status output:
```
Vault: /Users/brianmcmahon/.mnemon/default.sqlite
Total memories: 0
Vectors: 2
Pinned: 0
Invalidated: 1
```

## Fix

- Step 4 + Step 5: anchor on `^Total memories:` to be exact about the field
- Step 3: **also** verify the remote shows 3 docs after the S3 → Fly seed. The runbook expects this and the previous script skipped it. With the awk pattern now matching, this assertion is cheap and catches seed regressions early.

## Unrelated noise (no fix needed)

The doctor output also showed:
```
⚠ OAuth AS metadata: AS not enabled (MNEMON_AS_ENABLED unset) — browser clients won't work
```

That's expected on the test Fly app — `mnemon upgrade web` doesn't propagate `MNEMON_AS_ENABLED` as a Fly secret to test-scoped apps, and Layer-3 doesn't exercise browser-client auth. `mnemon upgrade web` correctly continued past the warning (deployed the app, rewrote configs), so the script's flow wasn't affected. No change.

## Verified

- `bash -n` syntax-checks clean
- `awk '/^Total memories:/{print $NF}'` against real status output extracts the count correctly
- Cleanup from the failed Layer-3 run is verified clean: no Fly apps, no S3 prefix, no test vault dirs, prod surfaces healthy

## Test plan

- [ ] After merge: `scripts/promote_stable.sh layer3` runs to completion (Steps 1-6, ~15 min)
- [ ] Post-merge: `scripts/promote_stable.sh publish` ships 0.6.0 to PyPI + Fly

🤖 Generated with [Claude Code](https://claude.com/claude-code)