### PR TITLE
fix(scripts): unique content per Step-2 seed save (mnemon content-hash dedup)

### DIFF
--- a/scripts/promote_stable.sh
+++ b/scripts/promote_stable.sh
@@ -323,12 +323,18 @@ cmd_layer3() {
     fi
 
     echo_step "Step 2 — seed local test vault"
-    "$M" save "Test memory for E2E upgrade cycle" "run-$TEST_RUN_ID" --type observation
-    "$M" save "Second test memory, should survive upgrade" "run-$TEST_RUN_ID" --type observation
-    "$M" save "Preference to keep after upgrade/downgrade" "run-$TEST_RUN_ID" --type preference
+    # mnemon's store.save() does content-hash dedup (rc15+) — saves with
+    # byte-identical *content* collapse into one doc, even with different
+    # titles. The original runbook (pre-rc15) passed the same `run-$ID`
+    # content across all three saves, which now silently dedups down to
+    # 2 docs (the third escapes because `--type preference` puts it in a
+    # different content_type bucket). Make the content unique per save.
+    "$M" save "Test memory for E2E upgrade cycle"             "seed-1 observation run-$TEST_RUN_ID" --type observation
+    "$M" save "Second test memory, should survive upgrade"    "seed-2 observation run-$TEST_RUN_ID" --type observation
+    "$M" save "Preference to keep after upgrade/downgrade"    "seed-3 preference run-$TEST_RUN_ID" --type preference
     local seeded_local_count
     seeded_local_count="$("$M" status 2>&1 | awk '/^Total memories:/{print $NF; exit}')"
-    [[ "$seeded_local_count" == "3" ]] || die "expected 3 docs in local test vault, got '$seeded_local_count' (saves likely routed somewhere unexpected)"
+    [[ "$seeded_local_count" == "3" ]] || die "expected 3 docs in local test vault, got '$seeded_local_count' (saves may have deduped — check store content-hash logic, or routed somewhere unexpected)"
     echo_ok "3 docs seeded in local test vault"
 
     echo_step "Step 3 — upgrade web to $TEST_APP_NAME (pinned to mnemon-memory==$LAYER3_VERSION)"

--- a/tests/test_promote_stable.sh
+++ b/tests/test_promote_stable.sh
@@ -248,6 +248,43 @@ test_sourcing_does_not_dispatch() {
     return 0
 }
 
+# ---- tests: Step-2 seed content uniqueness ----
+
+test_step2_seed_contents_are_unique() {
+    # mnemon's store.save() does content-hash dedup (rc15+). The original
+    # runbook passed the same content to all three Step-2 saves, which
+    # silently deduped down to 2 docs in the local test vault and caused
+    # a confusing "got '2', expected '3'" Step-2 assertion failure
+    # 2026-05-21. The fix makes content unique per save. Guard against
+    # the regression returning.
+    local script_path
+    script_path="$REPO_ROOT/scripts/promote_stable.sh"
+
+    # Extract the three Step-2 save lines.
+    local seed_lines
+    seed_lines="$(awk '/echo_step "Step 2 — seed local test vault"/,/seeded_local_count/' "$script_path" \
+        | grep -E '"\$M" save ')"
+
+    # Must be exactly 3 saves.
+    local n_saves
+    n_saves="$(echo "$seed_lines" | grep -c '"\$M" save ')"
+    [[ "$n_saves" == "3" ]] || { echo "    expected 3 'mnemon save' lines in Step 2, got $n_saves" >&2; return 1; }
+
+    # Extract the content (second quoted arg) from each save line.
+    # Pattern: `"$M" save "TITLE" "CONTENT" --type X`
+    local contents
+    contents="$(echo "$seed_lines" | sed -E 's/.*"\$M" save +"[^"]+" +"([^"]+)".*/\1/')"
+
+    # Count unique contents.
+    local n_unique
+    n_unique="$(echo "$contents" | sort -u | wc -l | tr -d ' ')"
+    [[ "$n_unique" == "3" ]] || {
+        echo "    expected 3 unique seed contents, got $n_unique unique across:" >&2
+        echo "$contents" | sed 's/^/      /' >&2
+        return 1
+    }
+}
+
 # ============================================================
 # runner
 # ============================================================
@@ -264,6 +301,7 @@ run_test test_awk_extracts_total_memories_count
 run_test test_awk_handles_zero_count
 run_test test_awk_returns_empty_when_field_missing
 run_test test_sourcing_does_not_dispatch
+run_test test_step2_seed_contents_are_unique
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

5th bug in the script during the 0.6.0 cut, **caught by PR #134's new Step-2 assertion + handled cleanly by PR #134's auth-restore** — so no prod damage this time, just a script-level fail-loud. Total session score: harness 10/10, scripted ritual still flaking.

### Output captured (4th real Layer-3 attempt)

```
==> Step 2 — seed local test vault
Saved memory #1: "Test memory for E2E upgrade cycle"
Saved memory #1: "Second test memory, should survive upgrade"   ← doc_id=1 again
Saved memory #2: "Preference to keep after upgrade/downgrade"
  ✗ expected 3 docs in local test vault, got '2'
  ✓ cleanup: restored 2 pre-Layer-3 auth file(s) under ~/.mnemon/
```

Two of the three "saves" deduped into doc_id=1. Third escaped because `--type preference` puts it in a different content_type bucket.

## Root cause

`mnemon save TITLE CONTENT --type T` — title is positional arg 1, content is positional arg 2. The pre-rc15 e2e-test-runbook passes `"run-$TEST_RUN_ID"` as **content** to all three saves. Titles differ; content is byte-identical.

mnemon's `store.save()` does content-hash dedup (shipped rc15+, per CHANGELOG). Same-content saves within the same (collection, content_type, invalidated_at IS NULL) scope collapse to one live doc. Two `--type observation` saves with identical content dedup; the `--type preference` escapes because it's a different bucket.

The runbook predates rc15 dedup. My script copied the broken pattern verbatim.

## Fix

**`scripts/promote_stable.sh`:**
```diff
-"$M" save "Test memory for E2E upgrade cycle"          "run-$TEST_RUN_ID" --type observation
-"$M" save "Second test memory, should survive upgrade" "run-$TEST_RUN_ID" --type observation
-"$M" save "Preference to keep after upgrade/downgrade" "run-$TEST_RUN_ID" --type preference
+"$M" save "Test memory for E2E upgrade cycle"             "seed-1 observation run-$TEST_RUN_ID" --type observation
+"$M" save "Second test memory, should survive upgrade"    "seed-2 observation run-$TEST_RUN_ID" --type observation
+"$M" save "Preference to keep after upgrade/downgrade"    "seed-3 preference run-$TEST_RUN_ID" --type preference
```

**`tests/test_promote_stable.sh`** — new test `test_step2_seed_contents_are_unique`:
- greps the three save lines from the script
- extracts the content (quoted arg 2)
- asserts 3 unique values via `sort -u`
- fails loud (with the actual contents printed) if a future edit reintroduces non-unique content

**`private/e2e-test-runbook-260421.md`** (gitignored) — call out the dedup behavior so by-hand operators don't repeat.

## Verified

```
promote_stable.sh sandbox harness
==================================
  ✓ test_latest_pypi_version_returns_pep440_semver
  ✓ test_is_pypi_published_truth_table
  ✓ test_snapshot_preserves_content_and_permissions
  ✓ test_layer3_cleanup_restores_auth_files
  ✓ test_layer3_cleanup_no_backup_dir_is_safe
  ✓ test_awk_extracts_total_memories_count
  ✓ test_awk_handles_zero_count
  ✓ test_awk_returns_empty_when_field_missing
  ✓ test_sourcing_does_not_dispatch
  ✓ test_step2_seed_contents_are_unique

Results: 10 passed, 0 failed
```

The new test was hand-validated against the broken state: changing one content line back to `"run-$TEST_RUN_ID"` (matching one of the others) makes `sort -u` return 2 unique → test fails with the diff printed. Catching the bug in ~50ms instead of after a real Fly deploy.

## Test plan

- [x] Harness 10/10 locally
- [ ] After merge: `scripts/promote_stable.sh layer3` should now run Step 2 → Step 6 without dedup tripping the local-count assertion
- [ ] If Layer-3 surfaces a 6th bug, the harness's stub-and-coverage gap is queued under the ROADMAP "expand sandbox" item

## Session-level note

5 PRs (#132/#133/#134/#135/this one) on a byte-identical version-string promotion. The script went from green-on-syntax-check to **green-on-real-prod-flow** through 5 fix-and-iterate cycles. The harness now covers the regression for each, so the next stable cut (eventually 0.7.0 → 0.7.0 stable) should not need this density.

🤖 Generated with [Claude Code](https://claude.com/claude-code)