### PR TITLE
fix(upgrade): forward MNEMON_S3_PREFIX + MNEMON_VAULT_NAME to Fly secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,26 @@
 
 ### Release
 
-- **Promotion from `0.6.0rc18` to `0.6.0` stable.** No code changes
-  from `rc18` — this release closes the rc cycle that ran from
-  `0.6.0rc1` (2026-04-21, the simplification arc → two-product split)
-  through `0.6.0rc18` (2026-05-18, the layered stored-injection
-  defense). `0.6.0` is `rc18` at stable maturity; the source under
-  this tag is byte-identical to the `rc18` source under the prior
-  tag, modulo this CHANGELOG entry and the version-string bump.
+- **Promotion from `0.6.0rc18` to `0.6.0` stable.** Closes the rc cycle
+  that ran from `0.6.0rc1` (2026-04-21, the simplification arc →
+  two-product split) through `0.6.0rc18` (2026-05-18, the layered
+  stored-injection defense). `0.6.0` is `rc18` plus the single bug
+  fix below — surfaced 2026-05-21 while exercising the pre-promote
+  Layer-3 web test for the first time.
+
+### Fixes
+
+- **`mnemon upgrade web` now forwards `MNEMON_S3_PREFIX` and
+  `MNEMON_VAULT_NAME` to the Fly container** as secrets, so a
+  non-default operator override propagates to the container's
+  `mnemon sync pull` seed step. Previously the Fly side fell back
+  to `sync.S3_PREFIX_DEFAULT` (`mnemon/vaults`) regardless of what
+  the operator set locally — which broke the runbook's
+  "test against an isolated S3 prefix" ritual. Not user-affecting
+  for normal prod redeploys (both sides default identically); only
+  affects ad-hoc test deploys where the operator overrides the
+  prefix. Surfaced + fixed during the 0.6.0 Layer-3 attempt; 4
+  regression tests cover the forwarding contract.
 
   The rc cycle delivered:
   - The simplification arc — mnemon local (stdio + single-file vault)

--- a/src/mnemon/upgrade.py
+++ b/src/mnemon/upgrade.py
@@ -386,6 +386,13 @@ def _fly_set_secrets(
     AWS creds are read from the user's environment (populated by aws
     configure or AWS_* env vars) and passed through as Fly secrets so
     the container's `aws s3 cp` works. Never logs the values.
+
+    Also forwards ``MNEMON_S3_PREFIX`` and ``MNEMON_VAULT_NAME`` so the
+    Fly container's ``mnemon sync pull`` reads from the same S3 location
+    the local ``mnemon sync push`` wrote to. Without this, the Fly side
+    falls back to ``sync.S3_PREFIX_DEFAULT`` / ``VAULT_NAME_DEFAULT`` and
+    seeds from the operator's prod prefix instead of any test-scoped
+    override (caught 2026-05-21 during the 0.6.0 Layer-3 test).
     """
     env = os.environ.copy()
     aws_access = env.get("AWS_ACCESS_KEY_ID") or _resolve_aws_key(
@@ -405,12 +412,21 @@ def _fly_set_secrets(
 
     aws_region = env.get("AWS_REGION") or env.get("AWS_DEFAULT_REGION") or "us-east-1"
 
+    # Read the same defaults sync.py uses so an unset env var on the
+    # operator side resolves to the same path on both sides — preserves
+    # prod-redeploy behavior (no override => default both sides).
+    from .sync import S3_PREFIX_DEFAULT, VAULT_NAME_DEFAULT
+    s3_prefix = env.get("MNEMON_S3_PREFIX", S3_PREFIX_DEFAULT)
+    vault_name = env.get("MNEMON_VAULT_NAME", VAULT_NAME_DEFAULT)
+
     secrets_kv = [
         f"MNEMON_LOCAL_TOKEN={local_token}",
         f"AWS_ACCESS_KEY_ID={aws_access}",
         f"AWS_SECRET_ACCESS_KEY={aws_secret}",
         f"AWS_DEFAULT_REGION={aws_region}",
         f"MNEMON_S3_BUCKET={s3_bucket}",
+        f"MNEMON_S3_PREFIX={s3_prefix}",
+        f"MNEMON_VAULT_NAME={vault_name}",
     ]
     # --stage: don't restart machines immediately (they don't exist yet).
     subprocess.run(

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -337,6 +337,64 @@ class TestRequireAwsSecrets:
                 )
 
 
+class TestFlySecretsForwardS3PrefixAndVaultName:
+    """Regression for the 2026-05-21 Layer-3 bug: `_fly_set_secrets`
+    forwarded `MNEMON_S3_BUCKET` but not `MNEMON_S3_PREFIX` / `MNEMON_VAULT_NAME`,
+    so the Fly container's `mnemon sync pull` fell back to defaults
+    and seeded from the wrong S3 prefix (operator's prod prefix instead
+    of the test-scoped override the operator set locally).
+    """
+
+    def _capture_secrets_args(self, monkeypatch, env_overrides=None):
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIA-test")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret-test")
+        for k, v in (env_overrides or {}).items():
+            monkeypatch.setenv(k, v)
+
+        with patch("mnemon.upgrade.subprocess.run") as mock_run:
+            mock_run.return_value = _ok_completed()
+            upgrade._fly_set_secrets(
+                "mnemon-test", "some-token", "mnemon-memory"
+            )
+        # The subprocess.run call carries the secrets-set CLI args.
+        call_args = mock_run.call_args.args[0]
+        # Pull just the KEY=VALUE pairs from the CLI args.
+        return [a for a in call_args if "=" in a]
+
+    def test_forwards_s3_prefix_override_to_fly_secrets(self, monkeypatch):
+        kvs = self._capture_secrets_args(
+            monkeypatch,
+            {"MNEMON_S3_PREFIX": "test-upgrade/abc123"},
+        )
+        assert "MNEMON_S3_PREFIX=test-upgrade/abc123" in kvs
+
+    def test_forwards_vault_name_override_to_fly_secrets(self, monkeypatch):
+        kvs = self._capture_secrets_args(
+            monkeypatch,
+            {"MNEMON_VAULT_NAME": "custom-vault"},
+        )
+        assert "MNEMON_VAULT_NAME=custom-vault" in kvs
+
+    def test_defaults_match_sync_module_constants_when_env_unset(self, monkeypatch):
+        # Unset both env vars + verify Fly gets the same defaults sync.py uses.
+        # Preserves prod-redeploy behavior (no override → default both sides).
+        monkeypatch.delenv("MNEMON_S3_PREFIX", raising=False)
+        monkeypatch.delenv("MNEMON_VAULT_NAME", raising=False)
+        from mnemon.sync import S3_PREFIX_DEFAULT, VAULT_NAME_DEFAULT
+        kvs = self._capture_secrets_args(monkeypatch)
+        assert f"MNEMON_S3_PREFIX={S3_PREFIX_DEFAULT}" in kvs
+        assert f"MNEMON_VAULT_NAME={VAULT_NAME_DEFAULT}" in kvs
+
+    def test_still_forwards_token_and_bucket(self, monkeypatch):
+        # Belt + suspenders: this fix didn't regress the existing
+        # forwarded secrets.
+        kvs = self._capture_secrets_args(monkeypatch)
+        assert "MNEMON_LOCAL_TOKEN=some-token" in kvs
+        assert "MNEMON_S3_BUCKET=mnemon-memory" in kvs
+        assert any(kv.startswith("AWS_ACCESS_KEY_ID=") for kv in kvs)
+        assert any(kv.startswith("AWS_SECRET_ACCESS_KEY=") for kv in kvs)
+
+
 # ── _fly_app_exists detection ────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

**This is the first real `mnemon`-proper bug surfaced during the 0.6.0 stable cut.** The previous 5 PRs (#131-#136) fixed bugs in `scripts/promote_stable.sh`. This one is in `src/mnemon/upgrade.py` — exposed for the first time because Layer-3 had never actually been exercised end-to-end before today (the runbook is dated 2026-04-21 but the pre-promote ritual was always marked `[ ]` Not started in ROADMAP).

## Bug

`_fly_set_secrets` (`src/mnemon/upgrade.py:381`) forwards `MNEMON_LOCAL_TOKEN`, `AWS_*`, and `MNEMON_S3_BUCKET` to the deployed Fly container — but **not** `MNEMON_S3_PREFIX` or `MNEMON_VAULT_NAME`. The Fly container then runs `mnemon sync pull` to seed `/data` from S3, and falls back to `sync.S3_PREFIX_DEFAULT = "mnemon/vaults"` / `VAULT_NAME_DEFAULT = "default"` — regardless of what the operator set locally for the *upload* side.

**Symptom captured today:**

```
==> Step 3 — upgrade web to mnemon-test-20260521-121142 ...
mnemon doctor — remote mode (https://mnemon-test-20260521-121142.fly.dev/mcp)
  ✓ Round-trip (save + search + forget): doc_id=35 saved, found, and forgotten

✗ expected 3 docs seeded to remote, got '0'
  ⚠ cleanup: destroying lingering test app
  ✓ cleanup: restored 2 pre-Layer-3 auth file(s) under ~/.mnemon/
```

`doc_id=35` is the smoking gun — fresh test app shouldn't have 34 prior rowids. The Fly machine seeded from the prod prefix (where Brian's stale local sqlite was last sync'd on Apr 12 — 34 historical rowids, 0 live docs) instead of the test prefix (3 fresh docs).

S3 confirms:
```
$ aws s3 ls s3://mnemon-memory/mnemon/vaults/        # prod default prefix
2026-04-12 07:43:35  196608 default.sqlite           ← stale prod snapshot
```

## Fix

```python
# Inside _fly_set_secrets:
from .sync import S3_PREFIX_DEFAULT, VAULT_NAME_DEFAULT
s3_prefix = env.get("MNEMON_S3_PREFIX", S3_PREFIX_DEFAULT)
vault_name = env.get("MNEMON_VAULT_NAME", VAULT_NAME_DEFAULT)

secrets_kv = [
    ...existing...
    f"MNEMON_S3_PREFIX={s3_prefix}",
    f"MNEMON_VAULT_NAME={vault_name}",
]
```

Reads from the same defaults `sync.py` uses, so:
- **Override case:** operator sets `MNEMON_S3_PREFIX=test-upgrade/<id>` → Fly seeds from the test prefix → test docs land
- **Default case (normal prod redeploy):** env unset → both sides resolve to `mnemon/vaults` → behavior unchanged

The default-case test asserts the two modules' defaults stay in sync, so a future drift can't silently break this again.

## Why this slipped past every prior rc

Every prior `mnemon upgrade web` run was either (a) operator's prod redeploy (which uses the default prefix on both sides, so converged by happenstance) or (b) a redeploy of an *existing* Fly app (which skips `_fly_set_secrets` entirely — only first-time deploys hit this path). Layer-3 is the first scenario that exercises a first-time deploy WITH a non-default prefix.

## CHANGELOG

0.6.0 entry updated from "byte-identical to rc18" → "rc18 + this fix". 0.6.0 hasn't been published to PyPI yet, so the diff is still amendable. Honest is better than tidy.

## Tests

4 new tests in `TestFlySecretsForwardS3PrefixAndVaultName`:
- `test_forwards_s3_prefix_override_to_fly_secrets`
- `test_forwards_vault_name_override_to_fly_secrets`
- `test_defaults_match_sync_module_constants_when_env_unset` — regression against any future drift between `sync.py` defaults and what upgrade.py forwards
- `test_still_forwards_token_and_bucket` — belt-and-suspenders against an over-aggressive edit removing already-forwarded secrets

Full suite: **790 passed** (was 786 before this PR).

## Test plan

- [x] 4 new tests green
- [x] Full pytest suite 790/790 green
- [x] `tests/test_promote_stable.sh` harness still 10/10 green
- [ ] After merge: `scripts/promote_stable.sh layer3` — Step 3 should now report 3 docs on remote instead of 0
- [ ] Once Layer-3 passes: `scripts/promote_stable.sh publish` to ship 0.6.0 to PyPI + Fly

🤖 Generated with [Claude Code](https://claude.com/claude-code)