### PR TITLE
fix(scripts): Layer-3 remote verification uses MCP client, not local-only mnemon CLI

### DIFF
--- a/scripts/_layer3_remote_helper.py
+++ b/scripts/_layer3_remote_helper.py
@@ -1,0 +1,66 @@
+"""scripts/_layer3_remote_helper.py — remote MCP tool invocation for layer3.
+
+`mnemon` CLI save/status/search are LOCAL-ONLY — they instantiate
+`Store()` directly and never check `MNEMON_REMOTE_URL` or
+`~/.mnemon/remote_url`. Only `mnemon doctor` and the hook scripts
+actually go through the remote MCP client. The e2e test runbook
+was written assuming CLI commands honor remote mode; they don't, so
+`scripts/promote_stable.sh layer3`'s post-upgrade verification was
+silently reading a freshly-created empty local SQLite instead of the
+test app's remote state.
+
+This helper bypasses the broken CLI path by calling the same
+`call_tool_sync` that the hooks (and `mnemon doctor`) use. URL + token
+resolution comes from `MNEMON_REMOTE_URL` env or
+`~/.mnemon/remote_url` file (set by `mnemon upgrade web`).
+
+Tracked as ROADMAP follow-up: extend `mnemon` CLI to honor remote mode
+for save/status/search, then this helper can go away.
+
+Usage (from promote_stable.sh):
+    .venv/bin/python scripts/_layer3_remote_helper.py status
+    .venv/bin/python scripts/_layer3_remote_helper.py save TITLE CONTENT CONTENT_TYPE
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from mnemon.hooks._remote_client import call_tool_sync
+
+
+def _total_documents() -> int:
+    result, _elapsed = call_tool_sync("memory_status", {})
+    data = json.loads(result)
+    return int(data["total_documents"])
+
+
+def _save(title: str, content: str, content_type: str) -> str:
+    result, _elapsed = call_tool_sync(
+        "memory_save",
+        {"title": title, "content": content, "content_type": content_type},
+    )
+    return result
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("usage: _layer3_remote_helper.py <status|save> [args...]", file=sys.stderr)
+        sys.exit(2)
+
+    cmd = sys.argv[1]
+    if cmd == "status":
+        print(_total_documents())
+    elif cmd == "save":
+        if len(sys.argv) < 5:
+            print("usage: _layer3_remote_helper.py save TITLE CONTENT CONTENT_TYPE", file=sys.stderr)
+            sys.exit(2)
+        print(_save(sys.argv[2], sys.argv[3], sys.argv[4]))
+    else:
+        print(f"unknown command: {cmd}", file=sys.stderr)
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/promote_stable.sh
+++ b/scripts/promote_stable.sh
@@ -341,20 +341,25 @@ cmd_layer3() {
     "$M" upgrade web --app-name "$TEST_APP_NAME" --mnemon-version "$LAYER3_VERSION"
     ls "$MNEMON_VAULT_DIR/archive/" | grep -q "pre-web-" || die "expected pre-web-*.sqlite archive missing"
     ! [ -f "$MNEMON_VAULT_DIR/default.sqlite" ] || die "local vault should be archived; default.sqlite still present"
+
+    # `mnemon status` CLI is local-only (instantiates Store() directly, ignores
+    # MNEMON_REMOTE_URL). Use the remote helper that goes through the same
+    # call_tool_sync path mnemon doctor uses. Tracked as ROADMAP follow-up:
+    # extend mnemon CLI to honor remote mode so this workaround can go away.
+    local REMOTE_HELPER="$REPO_ROOT/scripts/_layer3_remote_helper.py"
     local seeded_count
-    seeded_count="$(MNEMON_REMOTE_URL="https://$TEST_APP_NAME.fly.dev/mcp" "$M" status 2>&1 | awk '/^Total memories:/{print $NF; exit}')"
+    seeded_count="$("$MNEMON_VENV_BIN/python" "$REMOTE_HELPER" status)"
     [[ "$seeded_count" == "3" ]] || die "expected 3 docs seeded to remote, got '$seeded_count'"
     echo_ok "upgrade complete; local vault archived; 3 docs seeded to remote via S3 → Fly"
 
     echo_step "Step 4 — exercise remote (add via HTTP)"
-    MNEMON_REMOTE_URL="https://$TEST_APP_NAME.fly.dev/mcp" \
-      "$M" save "Memory added after upgrade, should survive downgrade" "run-$TEST_RUN_ID" --type observation
+    # mnemon save CLI is also local-only — use the remote helper.
+    "$MNEMON_VENV_BIN/python" "$REMOTE_HELPER" save \
+        "Memory added after upgrade, should survive downgrade" \
+        "seed-4 observation run-$TEST_RUN_ID" \
+        "observation"
     local remote_count
-    # `mnemon status` emits "Total memories: N" — anchor on that exact line.
-    # The previous regex looked for "Documents:" which doesn't appear in the
-    # output; the awk match silently came back empty and the count check
-    # failed loudly with "got ''".
-    remote_count="$(MNEMON_REMOTE_URL="https://$TEST_APP_NAME.fly.dev/mcp" "$M" status 2>&1 | awk '/^Total memories:/{print $NF; exit}')"
+    remote_count="$("$MNEMON_VENV_BIN/python" "$REMOTE_HELPER" status)"
     [[ "$remote_count" == "4" ]] || die "expected 4 docs on remote, got '$remote_count'"
     echo_ok "4 docs on remote"
 

--- a/tests/test_promote_stable.sh
+++ b/tests/test_promote_stable.sh
@@ -250,6 +250,43 @@ test_sourcing_does_not_dispatch() {
 
 # ---- tests: Step-2 seed content uniqueness ----
 
+test_remote_helper_exists_and_is_invokable() {
+    # The Python helper that bypasses mnemon's local-only CLI for Layer-3
+    # remote verification (see _layer3_remote_helper.py docstring).
+    # Asserts the file exists, has the expected entry-points, and prints
+    # usage when called without args (basic smoke).
+    local helper="$REPO_ROOT/scripts/_layer3_remote_helper.py"
+    [ -f "$helper" ] || { echo "    helper not found at $helper" >&2; return 1; }
+
+    # The script needs python + the venv's mnemon installable.
+    local out
+    out="$("$REPO_ROOT/.venv/bin/python" "$helper" 2>&1)" && return 1   # bare invocation should fail with usage
+    echo "$out" | grep -q "usage:" || { echo "    helper didn't print usage on bare invocation: $out" >&2; return 1; }
+}
+
+test_layer3_uses_remote_helper_not_mnemon_status() {
+    # Regression for the 2026-05-21 verification bug: cmd_layer3 used
+    # `mnemon status` (local-only) to assert remote state, which always
+    # read an empty freshly-created local SQLite. The fix switched to
+    # the remote helper. Guard against a future edit reverting to
+    # `mnemon status` for remote verification.
+    local script="$REPO_ROOT/scripts/promote_stable.sh"
+
+    # Extract Step 3 + Step 4 bodies and check they use the helper.
+    local body
+    body="$(awk '/echo_step "Step 3/,/echo_step "Step 5/' "$script")"
+    echo "$body" | grep -q "_layer3_remote_helper.py" \
+        || { echo "    Step 3/4 doesn't reference _layer3_remote_helper.py" >&2; return 1; }
+
+    # And NEITHER step uses `mnemon status` against the test app remote
+    # (the broken pattern). Step 5 still uses mnemon status post-downgrade
+    # which is correct because local mode is appropriate then; so we
+    # constrain the negative check to Steps 3 + 4 only.
+    echo "$body" | grep -E '"\$M" status|"\$MNEMON_VENV_BIN/mnemon" status' \
+        && { echo "    Step 3/4 still uses local-only mnemon status for remote verification" >&2; return 1; }
+    return 0
+}
+
 test_step2_seed_contents_are_unique() {
     # mnemon's store.save() does content-hash dedup (rc15+). The original
     # runbook passed the same content to all three Step-2 saves, which
@@ -302,6 +339,8 @@ run_test test_awk_handles_zero_count
 run_test test_awk_returns_empty_when_field_missing
 run_test test_sourcing_does_not_dispatch
 run_test test_step2_seed_contents_are_unique
+run_test test_remote_helper_exists_and_is_invokable
+run_test test_layer3_uses_remote_helper_not_mnemon_status
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

**7th iteration on the 0.6.0 stable cut.** PRs #131-#137 each cleared one bug. With PR #137's `upgrade.py` fix in place, the Fly machine correctly received the 3 seeded docs (`doc_id=4` from doctor vs prior runs' `doc_id=35` is the smoking gun — the rowid counter being at 4 proves 3 prior rowids exist in the test app's vault). But the assertion still failed:

```
✗ expected 3 docs seeded to remote, got '0'
```

## Root cause

**`mnemon` CLI save / status / search are all local-only.** They instantiate `Store()` directly and never consult `MNEMON_REMOTE_URL` or `~/.mnemon/remote_url`. Only `mnemon doctor` and the hook scripts use the remote MCP client (`hooks._remote_client.call_tool_sync`).

My verification call:
```bash
MNEMON_REMOTE_URL="https://$TEST_APP_NAME.fly.dev/mcp" "$M" status
```

The `MNEMON_REMOTE_URL=...` prefix is silently ignored — `mnemon status` opens `$MNEMON_VAULT_DIR/default.sqlite`, which `upgrade web` archived in Step 3, so `Store()` creates a fresh empty SQLite at that path. **"Total memories: 0" was always about that just-created empty local file, never about Fly.**

The runbook (`e2e-test-runbook-260421.md`) was written assuming CLI commands honor remote mode. They don't. That assumption had never been exercised because Layer-3 had never been run end-to-end before today.

## Fix

**`scripts/_layer3_remote_helper.py`** — new Python helper that bypasses the broken CLI path by calling `hooks._remote_client.call_tool_sync` directly (same path `mnemon doctor` uses). Resolves URL+token from env/file the same way doctor does.

```python
from mnemon.hooks._remote_client import call_tool_sync
result, _ = call_tool_sync("memory_status", {})  # ← actually goes remote
print(json.loads(result)["total_documents"])
```

Verified against prod: helper returns `2410` (actual remote count), proving it routes correctly.

**`cmd_layer3` Step 3:** verification uses the helper for remote count.
**`cmd_layer3` Step 4:** both the save AND the verification use the helper. (Step 4's save was also going local-only — the runbook's "added via HTTP" step was actually adding to a fresh local file, not the test Fly app.)
**`cmd_layer3` Step 5:** still uses `mnemon status` because `mnemon downgrade local` flipped us back to local mode — local status is correct there.

## Harness regression tests

```
✓ test_remote_helper_exists_and_is_invokable
✓ test_layer3_uses_remote_helper_not_mnemon_status
```

The second test greps Step 3 + Step 4 bodies for the helper invocation; fails loud if a future edit reverts to `mnemon status` for remote verification.

Harness now at **12/12**.

## ROADMAP follow-up (gitignored, filed in private/ROADMAP.md)

**Extend `mnemon` CLI (cli.py) to honor remote mode for `save`/`status`/`search`**, mirroring `mnemon doctor`'s branching:
```python
if os.environ.get("MNEMON_REMOTE_URL") or remote_url_file_exists():
    return call_tool_sync(...)
else:
    return Store()...
```
When that ships, `scripts/_layer3_remote_helper.py` can be deleted.

This is the underlying product gap — operator setting `MNEMON_REMOTE_URL` ahead of `mnemon save` REASONABLY expects the save to go remote. Today it silently goes local. Same for `mnemon status`. The CLI's contract is misleading.

## Verified

- `bash -n` clean on both files
- 12/12 harness green
- Helper smoke-tested against prod (returns `2410`)
- Full pytest suite: still 790/790 (no test_*.py changes in this PR)

## Test plan

- [x] Harness 12/12
- [x] Helper standalone smoke against prod
- [ ] After merge: 7th `scripts/promote_stable.sh layer3` attempt — should clear Steps 1-6
- [ ] Once Layer-3 clears: `scripts/promote_stable.sh publish` ships 0.6.0 to PyPI + Fly

## Session note

8 PRs (#131 promote + #132/#133/#134/#136/#137/this) for the 0.6.0 stable cut. Of these:
- 5 in `scripts/promote_stable.sh` — script-level fixes for a never-run ritual
- 1 in `src/mnemon/upgrade.py` — real product bug (S3 prefix not forwarded to Fly)
- 1 harness PR (#135)
- 1 promote PR (#131)

The mnemon CLI's local-only contract for save/status/search is the next product-level gap surfaced. Filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)