### PR TITLE
fix(downgrade): dump Fly vault to S3 before pulling — preserve current state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,25 @@
   prefix. Surfaced + fixed during the 0.6.0 Layer-3 attempt; 4
   regression tests cover the forwarding contract.
 
+- **`mnemon downgrade local` now dumps the current Fly vault to S3
+  before pulling.** Previously, downgrade did `S3 → local` only and
+  silently skipped the `Fly → S3` step, so any memory added via
+  remote between upgrade time and downgrade time was lost — the
+  local vault was seeded from a stale S3 snapshot. For ad-hoc
+  testing this manifested as "docs added post-upgrade missing
+  after downgrade." For prod operators it would have been a quiet,
+  severe data-loss bug: weeks of remote-added memories vanishing
+  on the first `mnemon downgrade local` call. Now SSHes into the
+  Fly machine and runs `mnemon sync push` before the local
+  `mnemon sync pull` — mirror of `upgrade._fly_seed_vault` in the
+  opposite direction. New `--skip-fly-push` flag as an operator
+  escape hatch (e.g., when the Fly machine is unreachable);
+  default behavior is to fail-loud if the dump SSH errors out,
+  rather than silently fall through to the stale-pull data loss.
+  5 regression tests cover the call order (`fly_dump → s3_pull`),
+  the override flag, the fail-loud on SSH error, the
+  custom-domain skip, and the SSH command shape.
+
   The rc cycle delivered:
   - The simplification arc — mnemon local (stdio + single-file vault)
     and mnemon web (Fly + S3 backup) as one codebase, symmetric

--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -291,6 +291,7 @@ def main() -> None:
                     yes=parsed["yes"],
                     skip_doctor=parsed["skip_doctor"],
                     app_name_override=parsed["app_name"],
+                    skip_fly_push=parsed["skip_fly_push"],
                 )
             )
         except DowngradeError as exc:
@@ -359,6 +360,7 @@ def _parse_downgrade_args(args: list[str]) -> dict:
         "yes": False,
         "skip_doctor": False,
         "app_name": None,
+        "skip_fly_push": False,
     }
     i = 0
     while i < len(args):
@@ -371,6 +373,9 @@ def _parse_downgrade_args(args: list[str]) -> dict:
             i += 1
         elif flag == "--skip-doctor":
             result["skip_doctor"] = True
+            i += 1
+        elif flag == "--skip-fly-push":
+            result["skip_fly_push"] = True
             i += 1
         elif flag == "--app-name" and i + 1 < len(args):
             result["app_name"] = args[i + 1]

--- a/src/mnemon/downgrade.py
+++ b/src/mnemon/downgrade.py
@@ -132,6 +132,33 @@ def _reconfigure_clients_local(detected: list[str]) -> list[str]:
     return reconfigured
 
 
+def _fly_dump_vault(app_name: str) -> None:
+    """SSH into the Fly machine and run ``mnemon sync push``.
+
+    Mirror of ``upgrade._fly_seed_vault`` in the opposite direction —
+    dumps the *current* Fly vault to S3 so the subsequent local
+    ``mnemon sync pull`` gets up-to-date state, not whatever stale
+    snapshot was last pushed at upgrade time.
+
+    Without this step, any memory added via remote after the upgrade
+    is lost on downgrade — only data that was on S3 at upgrade time
+    survives the round-trip. Surfaced 2026-05-21 during the 0.6.0
+    Layer-3 test as "expected 4 docs after downgrade, got '3'".
+    """
+    subprocess.run(
+        [
+            "flyctl",
+            "ssh",
+            "console",
+            "--app",
+            app_name,
+            "-C",
+            "mnemon sync push",
+        ],
+        check=True,
+    )
+
+
 def _fly_destroy_app(app_name: str) -> None:
     """Run ``flyctl apps destroy`` unattended (``-y``)."""
     subprocess.run(
@@ -160,6 +187,7 @@ def downgrade_local(
     yes: bool = False,
     skip_doctor: bool = False,
     app_name_override: str | None = None,
+    skip_fly_push: bool = False,
 ) -> str:
     """Downgrade a web install back to local-only.
 
@@ -169,9 +197,15 @@ def downgrade_local(
     """
     remote_url = _resolve_remote_url()
 
-    # Step 2: sync pull S3 → local
-    from .sync import pull as s3_pull
-
+    # Step 1: ensure S3 has the *current* Fly vault before pulling.
+    # `mnemon upgrade web` pushes local→S3→Fly at upgrade time, then
+    # the Fly vault evolves independently. Without a Fly→S3 dump here,
+    # the subsequent pull would seed the local vault from a stale
+    # snapshot (the one from upgrade time) and silently lose any
+    # memory the user added via remote post-upgrade. Skipping with
+    # --skip-fly-push is an operator escape hatch for the case where
+    # SSH isn't reachable (machine off, etc.) and the operator
+    # explicitly accepts the stale-pull data loss.
     bucket = os.environ.get("MNEMON_S3_BUCKET", "").strip()
     if not bucket:
         raise DowngradeError(
@@ -180,6 +214,24 @@ def downgrade_local(
             "downgraded local vault would be empty. Export "
             "MNEMON_S3_BUCKET and retry."
         )
+
+    app_name = app_name_override or _extract_app_name(remote_url)
+    if app_name and not skip_fly_push:
+        try:
+            _fly_dump_vault(app_name)
+        except subprocess.CalledProcessError as exc:
+            raise DowngradeError(
+                f"Fly→S3 dump failed ({exc}). Without this push the "
+                f"downgrade would seed local from a stale S3 snapshot "
+                f"and lose any post-upgrade remote-added memories. "
+                f"Investigate via `flyctl ssh console --app {app_name}` "
+                f"and retry. If you accept the data loss, rerun with "
+                f"--skip-fly-push."
+            ) from exc
+
+    # Step 2: sync pull S3 → local
+    from .sync import pull as s3_pull
+
     pull_result = s3_pull()
     if pull_result["errors"]:
         raise DowngradeError(
@@ -195,9 +247,9 @@ def downgrade_local(
     detected = detect_installed_clients()
     reconfigured = _reconfigure_clients_local(detected)
 
-    # Step 4 (optional): destroy the Fly app.
+    # Step 4 (optional): destroy the Fly app. `app_name` was resolved
+    # up at the Fly→S3 dump step (Step 1) so we don't re-extract here.
     destroyed: str | None = None
-    app_name = app_name_override or _extract_app_name(remote_url)
     if destroy_fly_app:
         if not app_name:
             raise DowngradeError(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -566,6 +566,7 @@ class TestDowngradeCli:
             yes=True,
             skip_doctor=True,
             app_name_override=None,
+            skip_fly_push=False,
         )
         assert "downgrade output" in capsys.readouterr().out
 

--- a/tests/test_downgrade.py
+++ b/tests/test_downgrade.py
@@ -90,7 +90,7 @@ class TestSyncPull:
         with patch(
             "mnemon.sync.pull",
             return_value={"pulled": [], "errors": ["access denied"]},
-        ):
+        ), patch("mnemon.downgrade._fly_dump_vault"):
             with pytest.raises(DowngradeError, match="S3 pull failed"):
                 downgrade_local(skip_doctor=True)
         # Remote config was NOT cleared — downgrade aborted.
@@ -128,6 +128,7 @@ class TestReconfigureLocal:
                 "mnemon.downgrade._reconfigure_clients_local",
                 return_value=["claude-code", "cursor"],
             ) as mock_reconfig, \
+            patch("mnemon.downgrade._fly_dump_vault"), \
             patch("mnemon.doctor.run_doctor", return_value=0):
             result = downgrade_local(skip_doctor=True)
 
@@ -227,8 +228,10 @@ class TestDestroyFlyApp:
             patch(
                 "mnemon.downgrade.subprocess.run"
             ) as mock_run:
+            # skip_fly_push=True because the Fly→S3 pre-pull push isn't
+            # what this test exercises; it tests destroy-decline behavior.
             result = downgrade_local(
-                destroy_fly_app=True, skip_doctor=True
+                destroy_fly_app=True, skip_doctor=True, skip_fly_push=True
             )
         # No flyctl destroy call
         mock_run.assert_not_called()
@@ -297,3 +300,89 @@ class TestDestroyFlyApp:
             "-y",
         ]
         assert "destroyed (my-custom-app)" in result
+
+
+class TestFlyDumpVaultBeforePull:
+    """Regression for the 2026-05-21 Layer-3 bug: downgrade only did
+    S3→local pull, never Fly→S3 push first. Any memory added on the
+    Fly side after upgrade time was silently lost on downgrade because
+    the local pull got the stale upgrade-time S3 snapshot. Surfaced
+    as "expected 4 docs after downgrade, got '3'" — the 4th doc was
+    added via remote after upgrade, only existed in Fly's SQLite, and
+    didn't make it back to local.
+
+    For prod operators this would have been a quiet, severe data-loss
+    bug: any work done via remote between upgrade and downgrade would
+    vanish. Fix: SSH into Fly and run `mnemon sync push` before the
+    local `mnemon sync pull`.
+    """
+
+    def _seed_remote_config(self, tmp_path, url="https://mnemon-test-999.fly.dev/mcp"):
+        mnemon_dir = tmp_path / ".mnemon"
+        mnemon_dir.mkdir()
+        (mnemon_dir / "remote_url").write_text(url)
+
+    def test_fly_dump_runs_before_s3_pull_by_default(self, tmp_path):
+        self._seed_remote_config(tmp_path)
+        call_order: list[str] = []
+
+        def _record_dump(app_name):
+            call_order.append("fly_dump")
+
+        def _record_pull():
+            call_order.append("s3_pull")
+            return {"pulled": ["sqlite"], "errors": []}
+
+        with patch("mnemon.downgrade._fly_dump_vault", side_effect=_record_dump), \
+            patch("mnemon.sync.pull", side_effect=_record_pull), \
+            patch("mnemon.setup.detect_installed_clients", return_value=[]), \
+            patch("mnemon.downgrade._reconfigure_clients_local", return_value=[]):
+            downgrade_local(skip_doctor=True)
+
+        assert call_order == ["fly_dump", "s3_pull"], (
+            f"expected fly_dump → s3_pull, got {call_order}"
+        )
+
+    def test_skip_fly_push_omits_dump(self, tmp_path):
+        self._seed_remote_config(tmp_path)
+        with patch("mnemon.downgrade._fly_dump_vault") as mock_dump, \
+            patch("mnemon.sync.pull", return_value={"pulled": ["sqlite"], "errors": []}), \
+            patch("mnemon.setup.detect_installed_clients", return_value=[]), \
+            patch("mnemon.downgrade._reconfigure_clients_local", return_value=[]):
+            downgrade_local(skip_doctor=True, skip_fly_push=True)
+        mock_dump.assert_not_called()
+
+    def test_fly_dump_failure_aborts_downgrade(self, tmp_path):
+        self._seed_remote_config(tmp_path)
+        from subprocess import CalledProcessError
+        with patch(
+            "mnemon.downgrade._fly_dump_vault",
+            side_effect=CalledProcessError(1, ["flyctl"]),
+        ), patch("mnemon.sync.pull") as mock_pull:
+            with pytest.raises(DowngradeError, match="Fly→S3 dump failed"):
+                downgrade_local(skip_doctor=True)
+        # Pull never ran — abort happened first, so no stale-snapshot
+        # restore of the local vault.
+        mock_pull.assert_not_called()
+
+    def test_fly_dump_skipped_when_app_name_not_extractable(self, tmp_path):
+        # Custom (non-fly.dev) domain → _extract_app_name returns None →
+        # we can't SSH so we skip the dump. Pull still runs.
+        self._seed_remote_config(tmp_path, url="https://mnemon.example.com/mcp")
+        with patch("mnemon.downgrade._fly_dump_vault") as mock_dump, \
+            patch("mnemon.sync.pull", return_value={"pulled": ["sqlite"], "errors": []}), \
+            patch("mnemon.setup.detect_installed_clients", return_value=[]), \
+            patch("mnemon.downgrade._reconfigure_clients_local", return_value=[]):
+            downgrade_local(skip_doctor=True)
+        mock_dump.assert_not_called()
+
+    def test_fly_dump_runs_ssh_console_with_sync_push(self, tmp_path):
+        # Direct test that _fly_dump_vault issues the expected flyctl
+        # command. Mirror of upgrade._fly_seed_vault but with `push`.
+        from mnemon import downgrade as dgmod
+        with patch("mnemon.downgrade.subprocess.run") as mock_run:
+            dgmod._fly_dump_vault("mnemon-test-abc")
+        mock_run.assert_called_once_with(
+            ["flyctl", "ssh", "console", "--app", "mnemon-test-abc", "-C", "mnemon sync push"],
+            check=True,
+        )


### PR DESCRIPTION
## Summary

**Real data-loss bug in `mnemon downgrade local`.** Surfaced during the 0.6.0 Layer-3 attempt as "expected 4 docs after downgrade, got '3'" — Step 4 added a doc via remote, Step 5's downgrade lost it. Investigation revealed the asymmetric sync flow:

| Op | What it does today | What it should do |
|---|---|---|
| `upgrade web` | local → S3 → Fly seed (`_fly_seed_vault`) | ✓ correct |
| `downgrade local` | S3 → local (`s3_pull`) | ✗ **misses Fly → S3 first** |

So `downgrade local` restores whatever was on S3 *at upgrade time*, not the current Fly state. Any memory added via remote between upgrade and downgrade is silently lost.

**This isn't just a Layer-3 issue — it's a prod data-loss bug.** Brian's S3 vault was last updated `2026-04-12` (per `aws s3 ls s3://mnemon-memory/mnemon/vaults/`). Current remote has 2410 docs (per `mnemon doctor`). Running `mnemon downgrade local` today would silently restore the April snapshot, vanishing weeks of work. Hasn't bitten yet because Brian's never had to downgrade.

## Fix

`src/mnemon/downgrade.py`:
- New `_fly_dump_vault(app_name)` — mirror of `upgrade._fly_seed_vault` in the opposite direction:
  ```python
  subprocess.run(
      ["flyctl", "ssh", "console", "--app", app_name, "-C", "mnemon sync push"],
      check=True,
  )
  ```
- `downgrade_local` resolves `app_name` early (was deferred to the --destroy branch) and calls `_fly_dump_vault` before `s3_pull`.
- **Fails loud** if SSH errors — raises `DowngradeError` naming the cause + suggesting `flyctl ssh console` to investigate. The alternative (silent fall-through to stale-pull data loss) violates the new "fail loud" rule.
- Operator escape hatch: `--skip-fly-push` flag for the case where Fly is unreachable and the operator explicitly accepts the stale-pull data loss.
- Skips dump if `app_name` can't be extracted (custom-domain remote URL).

`src/mnemon/cli.py`: new `--skip-fly-push` flag, threaded through to `downgrade_local(skip_fly_push=parsed["skip_fly_push"])`.

## Tests

- **Existing tests:** 3 patched to mock `_fly_dump_vault` (they were asserting `subprocess.run` not called; with the new pre-pull push that's no longer the contract for those tests).
- **5 new tests in `TestFlyDumpVaultBeforePull`:**
  - `test_fly_dump_runs_before_s3_pull_by_default` — call order regression (the load-bearing one)
  - `test_skip_fly_push_omits_dump` — the escape hatch works
  - `test_fly_dump_failure_aborts_downgrade` — fail-loud on SSH error, and crucially `s3_pull` is NOT called (no stale restore)
  - `test_fly_dump_skipped_when_app_name_not_extractable` — custom-domain path
  - `test_fly_dump_runs_ssh_console_with_sync_push` — SSH command shape mirrors `_fly_seed_vault`

- **`test_cli.py`:** downgrade-flag test updated to assert the new `skip_fly_push=False` parameter.

Full suite: **795 passed** (was 790 before the 5 new tests; net +5).

## CHANGELOG

`[0.6.0]` entry updated to list **two** fixes now (the prior MNEMON_S3_PREFIX forwarding from PR #137 + this downgrade fix). 0.6.0 still hasn't been published to PyPI so the diff is still amendable.

Both 0.6.0 fixes are quiet bugs that bite specific scenarios:
- PR #137: only fires when operator overrides `MNEMON_S3_PREFIX` (Layer-3 ritual). No prod impact.
- This PR: any `mnemon downgrade local` against a long-lived Fly. **Real prod data-loss risk.**

## Test plan

- [x] 18/18 downgrade tests pass (13 existing + 5 new)
- [x] Full 795/795 suite green
- [x] Harness 12/12 still green
- [ ] After merge: 8th `scripts/promote_stable.sh layer3` attempt — Step 5 should now report 4 docs after downgrade

## Session note

9 PRs (#131-#138 + this). Of mnemon-proper bugs surfaced:
1. #137 — `upgrade web` doesn't forward `MNEMON_S3_PREFIX` (Layer-3-only)
2. This PR — `downgrade local` doesn't push Fly → S3 first (**prod data-loss**)

Both were latent because the runbook had never been exercised end-to-end. The Layer-3 ritual is doing exactly what it was designed for: surfacing real prod-safety bugs in the upgrade/downgrade cycle before they cost someone their data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)