### PR TITLE
fix(sync): checkpoint WAL before push so long-lived-server writes flush to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,26 @@
   the override flag, the fail-loud on SSH error, the
   custom-domain skip, and the SSH command shape.
 
+- **`mnemon sync push` now WAL-checkpoints before reading the sqlite
+  file.** SQLite WAL mode means new commits accumulate in
+  `default.sqlite-wal` until an auto-checkpoint fires (default: WAL
+  > 1000 pages). For short-lived CLI processes (`mnemon save`) this
+  doesn't matter — connection close auto-checkpoints. For long-lived
+  servers (`mnemon serve-remote` on Fly) the WAL accumulates
+  indefinitely; `aws s3 cp default.sqlite` then uploads a stale main
+  file missing all the recent writes. Composed with the downgrade
+  fix above, this manifested as: Step 4's `memory_save` against
+  Fly committed to WAL → downgrade's Fly→S3 dump uploaded only the
+  main file (still stale) → local pull restored 3 docs instead of 4.
+  Fix: `sync._checkpoint_wal` opens a transient connection and
+  runs `PRAGMA wal_checkpoint(TRUNCATE)` before the `aws s3 cp`.
+  Reproduced: 3-row insert via long-lived `Store()` left main at
+  4KB (no `documents` table at all in a main-only copy); after
+  checkpoint, main grew to 69KB and copy showed all 3 rows. 3
+  regression tests cover the helper's behavior, the error-string
+  contract for malformed files, and the call order in `push()`
+  (checkpoint then aws_cp).
+
   The rc cycle delivered:
   - The simplification arc — mnemon local (stdio + single-file vault)
     and mnemon web (Fly + S3 backup) as one codebase, symmetric

--- a/src/mnemon/sync.py
+++ b/src/mnemon/sync.py
@@ -59,6 +59,45 @@ def _run_cmd(cmd: str) -> tuple[bool, str]:
     return False, result.stderr.strip()
 
 
+def _checkpoint_wal(sqlite_path: Path) -> str | None:
+    """Force a WAL checkpoint so the main sqlite file contains all
+    committed writes before ``aws s3 cp`` reads it.
+
+    Short-lived CLI processes (e.g. ``mnemon save``) auto-checkpoint
+    on connection close, so the WAL file disappears and the main file
+    contains all data. Long-lived processes (e.g. ``mnemon
+    serve-remote`` on Fly) hold an open SQLite connection — new
+    commits accumulate in the WAL and SQLite only auto-checkpoints
+    once the WAL grows past 1000 pages (default). Without an explicit
+    checkpoint here, ``mnemon sync push`` running against a
+    long-running server uploads a stale main file missing the latest
+    writes, and the downstream ``sync pull`` silently restores
+    the stale state.
+
+    Surfaced 2026-05-21 during the 0.6.0 Layer-3 test: Step 4 added a
+    doc via remote (committed to Fly serve-remote's WAL but never
+    flushed to main); downgrade's Fly→S3 dump (added in 0.6.0 too)
+    then uploaded the stale main and lost the doc on local restore.
+
+    TRUNCATE mode: most thorough, blocks briefly if other readers
+    hold locks. Acceptable for the (push, sync) flow — we don't
+    expect concurrent traffic during a deliberate sync push. Failures
+    are returned as a string so the caller can log without raising
+    (sync push remains best-effort per error).
+    """
+    import sqlite3
+    try:
+        conn = sqlite3.connect(str(sqlite_path), timeout=10.0)
+        try:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE);")
+            conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        return f"sqlite checkpoint failed: {exc}"
+    return None
+
+
 def push() -> dict[str, list[str]]:
     """Push local vault to S3.
 
@@ -75,6 +114,14 @@ def push() -> dict[str, list[str]]:
     for label, local_path in files.items():
         if not local_path.exists():
             continue
+
+        # Force WAL → main flush before reading the sqlite file as bytes.
+        # See _checkpoint_wal docstring for the rationale.
+        if label == "sqlite":
+            ckpt_err = _checkpoint_wal(local_path)
+            if ckpt_err is not None:
+                errors.append(ckpt_err)
+                continue
 
         ext = "sqlite" if label == "sqlite" else "vec.npz"
         s3_target = _s3_path(f"{_vault_name()}.{ext}")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -34,8 +34,9 @@ class TestPush:
             result = push()
             assert result["errors"] == ["MNEMON_S3_BUCKET not set"]
 
+    @patch("mnemon.sync._checkpoint_wal", return_value=None)
     @patch("mnemon.sync._run_cmd")
-    def test_push_uploads_existing_files(self, mock_run):
+    def test_push_uploads_existing_files(self, mock_run, _mock_ckpt):
         mock_run.return_value = (True, "")
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -54,8 +55,9 @@ class TestPush:
             assert "sqlite" in result["pushed"][0]
             assert result["errors"] == []
 
+    @patch("mnemon.sync._checkpoint_wal", return_value=None)
     @patch("mnemon.sync._run_cmd")
-    def test_push_reports_errors(self, mock_run):
+    def test_push_reports_errors(self, mock_run, _mock_ckpt):
         mock_run.return_value = (False, "access denied")
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -120,3 +122,115 @@ class TestPull:
             # Both files were listed, but only sqlite had content in the ls response
             # The vec ls also returns True in our mock, so both get attempted
             assert len(result["pulled"]) >= 1
+
+
+class TestPushCheckpointsWAL:
+    """Regression for the 2026-05-21 Layer-3 downgrade bug: sync.push
+    was uploading the main sqlite file without first flushing the WAL.
+    For long-lived server processes (mnemon serve-remote on Fly) that
+    hold an open SQLite connection, recent commits accumulate in WAL
+    without auto-checkpoint (which only fires at 1000 pages by default).
+    `aws s3 cp default.sqlite` then uploaded a stale main file missing
+    all the recent writes — silently lost on the downstream sync pull.
+
+    Short-lived CLI processes (`mnemon save`) auto-checkpointed WAL
+    on connection close, so this bug only manifested for the
+    serve-remote → upgrade-web-dump path (and would have manifested
+    similarly for any long-lived-process → sync-push flow).
+    """
+
+    def test_checkpoint_wal_flushes_data_from_wal_to_main(self, tmp_path):
+        # Reproduce a long-lived-connection scenario, then call the
+        # checkpoint helper and verify main file now contains the data.
+        import sqlite3
+        import shutil
+        from mnemon.sync import _checkpoint_wal
+
+        db = tmp_path / "test.sqlite"
+        # Open a persistent connection, set WAL, insert without closing.
+        conn = sqlite3.connect(str(db))
+        conn.execute("PRAGMA journal_mode = WAL;")
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);")
+        for i in range(3):
+            conn.execute("INSERT INTO t (v) VALUES (?)", (f"row-{i}",))
+        conn.commit()
+        # Don't close — simulates serve-remote holding the connection.
+
+        # Confirm the bug: copy of main file alone has no rows (or no table)
+        main_only = tmp_path / "main_only.sqlite"
+        shutil.copy(db, main_only)
+        try:
+            cnt_pre = sqlite3.connect(str(main_only)).execute(
+                "SELECT COUNT(*) FROM t"
+            ).fetchone()[0]
+        except sqlite3.OperationalError:
+            cnt_pre = -1  # no table at all — even worse symptom
+        assert cnt_pre != 3, (
+            f"WAL bug didn't reproduce — main file already has all 3 rows "
+            f"(got {cnt_pre}). Test setup is wrong; SQLite WAL semantics changed."
+        )
+
+        # Apply the fix.
+        err = _checkpoint_wal(db)
+        assert err is None, f"checkpoint failed: {err}"
+
+        # Verify: main file alone now has 3 rows.
+        main_only2 = tmp_path / "main_after.sqlite"
+        shutil.copy(db, main_only2)
+        cnt_post = sqlite3.connect(str(main_only2)).execute(
+            "SELECT COUNT(*) FROM t"
+        ).fetchone()[0]
+        assert cnt_post == 3, f"expected 3 rows in main file post-checkpoint, got {cnt_post}"
+
+        conn.close()
+
+    def test_checkpoint_wal_returns_error_string_on_locked_file(self, tmp_path):
+        # Failure mode: returns a string instead of raising, so push()
+        # can record it as an error and skip the cp without aborting
+        # the whole push call.
+        from mnemon.sync import _checkpoint_wal
+
+        # Non-existent path → sqlite will create + fail on missing table,
+        # but checkpoint of an empty DB is actually fine — so we test
+        # the contract by passing a path that's not a SQLite file.
+        bad = tmp_path / "not_a_db.bin"
+        bad.write_bytes(b"\x00\x01\x02not sqlite header at all")
+        err = _checkpoint_wal(bad)
+        assert err is not None, "expected error string for non-SQLite file"
+        assert "checkpoint" in err.lower() or "sqlite" in err.lower()
+
+    def test_push_calls_checkpoint_before_aws_cp(self, tmp_path):
+        # Integration: push() should call _checkpoint_wal for the
+        # sqlite file before invoking aws s3 cp. Verifies the call
+        # order via a side-effect-recording mock.
+        from unittest.mock import MagicMock
+        import shutil
+
+        sqlite_path = tmp_path / "default.sqlite"
+        sqlite_path.write_bytes(b"fake sqlite data")
+
+        call_order: list[str] = []
+
+        def _record_checkpoint(_path):
+            call_order.append("checkpoint")
+            return None
+
+        def _record_cp(cmd):
+            if "s3 cp" in cmd:
+                call_order.append("aws_cp")
+            return (True, "")
+
+        with patch.dict(os.environ, {"MNEMON_S3_BUCKET": "test-bucket"}), \
+             patch("mnemon.sync._vault_files", return_value={
+                 "sqlite": sqlite_path,
+                 "vec": tmp_path / "default.vec.npz",  # doesn't exist
+             }), \
+             patch("mnemon.sync._checkpoint_wal", side_effect=_record_checkpoint), \
+             patch("mnemon.sync._run_cmd", side_effect=_record_cp):
+            result = push()
+
+        # Checkpoint must come before the s3 cp call for the sqlite file.
+        assert call_order == ["checkpoint", "aws_cp"], (
+            f"expected checkpoint → aws_cp, got {call_order}"
+        )
+        assert not result["errors"], f"unexpected errors: {result['errors']}"


### PR DESCRIPTION
## Summary

Compounds with PR #139. With that downgrade fix in place, the next Layer-3 attempt **still** failed with "expected 4 docs after downgrade, got '3'". The SSH'd `mnemon sync push` on Fly was running, but uploading a stale main sqlite file.

## Root cause — SQLite WAL behavior in long-lived processes

`mnemon serve-remote` on Fly holds a persistent SQLite connection in WAL mode. New commits go to `default.sqlite-wal`. SQLite only auto-checkpoints when WAL grows past 1000 pages (default). For a Fly machine with 4 small saves, WAL stays far below that threshold — **all data lives in WAL, main file is essentially empty (just headers)**.

`mnemon sync push` does `aws s3 cp default.sqlite` — copying only the main file as bytes, not the WAL. The uploaded sqlite is missing all recent writes.

**Reproduced locally:**
```
BEFORE checkpoint: main=4096B, wal_exists=True, wal_size=222512
  main-only copy PRE-checkpoint: no such table: documents  ← BUG confirmed

AFTER checkpoint: main=69632B, wal_exists=True
  rows in main-only copy POST-checkpoint: 3  ← FIX verified
```

The main file is *literally* missing the `documents` table when the data is in WAL only. Long-lived process never flushed.

## Why short-lived CLI saves don't hit this

`mnemon save` opens → inserts → closes the connection. SQLite auto-checkpoints WAL on the last connection close, and the `-wal` file disappears entirely. So local-vault → S3 push during upgrade web works — each save closed its own connection and triggered an implicit checkpoint. Only the SSH'd push-from-Fly path is affected, because `mnemon serve-remote`'s connection NEVER closes.

## Fix

`sync._checkpoint_wal(path)` opens a transient SQLite connection and runs `PRAGMA wal_checkpoint(TRUNCATE)` before `aws s3 cp`:

```python
def _checkpoint_wal(sqlite_path: Path) -> str | None:
    import sqlite3
    try:
        conn = sqlite3.connect(str(sqlite_path), timeout=10.0)
        try:
            conn.execute("PRAGMA wal_checkpoint(TRUNCATE);")
            conn.commit()
        finally:
            conn.close()
    except sqlite3.Error as exc:
        return f"sqlite checkpoint failed: {exc}"
    return None
```

Called from `push()` for the sqlite file only (vec.npz isn't SQLite). Returns an error string instead of raising, so the existing `{pushed, errors}` contract is preserved and an aws-cp failure on one file doesn't take down the whole push.

TRUNCATE mode chosen over PASSIVE/FULL because we want the most-thorough flush + WAL reset, and the sync push flow doesn't expect concurrent writers (deliberate operator-driven sync).

## Tests

3 new in `TestPushCheckpointsWAL`:
- `test_checkpoint_wal_flushes_data_from_wal_to_main` — reproduces the bug (3-row insert via long-lived connection, main-only copy missing `documents` table), then asserts the helper fixes it
- `test_checkpoint_wal_returns_error_string_on_locked_file` — no-raise contract
- `test_push_calls_checkpoint_before_aws_cp` — integration call-order regression

Existing `test_push_uploads_existing_files` / `test_push_reports_errors` patched to mock `_checkpoint_wal` (they use fake bytes as sqlite content; real checkpoint correctly errors on non-SQLite files).

Full suite: **798 passed** (+3 net). Harness: 12/12.

## CHANGELOG

0.6.0 entry now lists **three** fixes:
1. PR #137 — `upgrade web` doesn't forward `MNEMON_S3_PREFIX`
2. PR #139 — `downgrade local` doesn't push Fly→S3 first
3. This PR — `sync push` doesn't checkpoint WAL

All three were latent because Layer-3 had never been run end-to-end. Compounding bugs: each individual fix exposed the next.

## Test plan

- [x] Local reproduction confirms bug + fix (`main=4KB → 69KB after checkpoint`)
- [x] 798/798 pytest, 12/12 harness
- [ ] After merge: 9th `scripts/promote_stable.sh layer3` attempt — Step 5 should now report 4 docs

## Session note (rolling)

10 PRs for the 0.6.0 stable cut. Of mnemon-proper bugs surfaced:
1. #137 — `upgrade web` MNEMON_S3_PREFIX not forwarded (Layer-3-only impact)
2. #139 — `downgrade local` doesn't push Fly→S3 first (**prod data-loss**)
3. This PR — `sync push` doesn't checkpoint WAL (**affects #139 in long-running-server case; would also have shown up the moment any operator ran sync push manually on a long-lived process**)

The 0.6.0 stable artifact is shaping up to be substantially safer than `rc18` for any operator who ever needs to touch the upgrade/downgrade flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)