### PR TITLE
fix(downgrade): inline WAL checkpoint in _fly_dump_vault for version-skew bootstrap

### DIFF
--- a/src/mnemon/downgrade.py
+++ b/src/mnemon/downgrade.py
@@ -133,18 +133,43 @@ def _reconfigure_clients_local(detected: list[str]) -> list[str]:
 
 
 def _fly_dump_vault(app_name: str) -> None:
-    """SSH into the Fly machine and run ``mnemon sync push``.
+    """SSH into the Fly machine, force a WAL checkpoint, then run
+    ``mnemon sync push``.
 
     Mirror of ``upgrade._fly_seed_vault`` in the opposite direction —
     dumps the *current* Fly vault to S3 so the subsequent local
     ``mnemon sync pull`` gets up-to-date state, not whatever stale
     snapshot was last pushed at upgrade time.
 
+    The inline WAL checkpoint via Python (instead of relying on the
+    installed mnemon's `sync.push` to checkpoint) handles the
+    version-skew bootstrap: the Fly container may be running an older
+    mnemon that predates the in-push checkpoint (0.6.0+, via
+    `sync._checkpoint_wal`). Inline-checkpointing via stdlib `sqlite3`
+    guarantees correctness regardless of the installed mnemon
+    version. Once Fly is running 0.6.0+, this is belt-and-suspenders
+    (the second checkpoint inside `mnemon sync push` is a no-op).
+
     Without this step, any memory added via remote after the upgrade
     is lost on downgrade — only data that was on S3 at upgrade time
     survives the round-trip. Surfaced 2026-05-21 during the 0.6.0
     Layer-3 test as "expected 4 docs after downgrade, got '3'".
     """
+    # Inline Python checkpoint:
+    #   - Uses stdlib `sqlite3` — no mnemon-version dependency.
+    #   - Single quotes inside Python string don't conflict with the
+    #     outer shell-double-quoted `python -c "..."` argument.
+    #   - `PRAGMA wal_checkpoint(TRUNCATE)` flushes WAL → main and
+    #     truncates the WAL file. Idempotent.
+    checkpoint_py = (
+        "python -c \""
+        "import sqlite3; "
+        "c=sqlite3.connect('/data/default.sqlite', timeout=10); "
+        "c.execute('PRAGMA wal_checkpoint(TRUNCATE);'); "
+        "c.commit(); c.close()"
+        "\""
+    )
+    remote_cmd = f"{checkpoint_py} && mnemon sync push"
     subprocess.run(
         [
             "flyctl",
@@ -153,7 +178,7 @@ def _fly_dump_vault(app_name: str) -> None:
             "--app",
             app_name,
             "-C",
-            "mnemon sync push",
+            remote_cmd,
         ],
         check=True,
     )

--- a/tests/test_downgrade.py
+++ b/tests/test_downgrade.py
@@ -376,13 +376,40 @@ class TestFlyDumpVaultBeforePull:
             downgrade_local(skip_doctor=True)
         mock_dump.assert_not_called()
 
-    def test_fly_dump_runs_ssh_console_with_sync_push(self, tmp_path):
+    def test_fly_dump_runs_ssh_console_with_checkpoint_then_sync_push(self, tmp_path):
         # Direct test that _fly_dump_vault issues the expected flyctl
-        # command. Mirror of upgrade._fly_seed_vault but with `push`.
+        # command. Must include an inline WAL checkpoint BEFORE the
+        # sync push, so the push works correctly even when the Fly
+        # container is running a pre-0.6.0 mnemon that lacks the
+        # in-push checkpoint. Regression for the 2026-05-21 Layer-3
+        # version-skew bug.
         from mnemon import downgrade as dgmod
         with patch("mnemon.downgrade.subprocess.run") as mock_run:
             dgmod._fly_dump_vault("mnemon-test-abc")
-        mock_run.assert_called_once_with(
-            ["flyctl", "ssh", "console", "--app", "mnemon-test-abc", "-C", "mnemon sync push"],
-            check=True,
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args.args[0]
+        # Outer shape: flyctl ssh console --app NAME -C <remote_cmd>
+        assert call_args[0] == "flyctl"
+        assert call_args[1:5] == ["ssh", "console", "--app", "mnemon-test-abc"]
+        assert call_args[5] == "-C"
+        remote_cmd = call_args[6]
+        # Must contain BOTH the inline checkpoint and the sync push,
+        # with checkpoint first and chained via `&&` so a checkpoint
+        # failure prevents the push.
+        assert "PRAGMA wal_checkpoint" in remote_cmd, (
+            f"missing inline checkpoint in: {remote_cmd}"
         )
+        assert "sqlite3" in remote_cmd, (
+            f"missing stdlib sqlite3 invocation in: {remote_cmd}"
+        )
+        assert "mnemon sync push" in remote_cmd, (
+            f"missing mnemon sync push in: {remote_cmd}"
+        )
+        # Order: checkpoint must precede sync push.
+        ck_idx = remote_cmd.index("PRAGMA wal_checkpoint")
+        push_idx = remote_cmd.index("mnemon sync push")
+        assert ck_idx < push_idx, (
+            f"checkpoint must precede sync push in: {remote_cmd}"
+        )
+        # Chained with && so push only runs on checkpoint success.
+        assert "&&" in remote_cmd, f"missing && short-circuit in: {remote_cmd}"


### PR DESCRIPTION
## Summary

**11th iteration on 0.6.0.** PR #140 added a WAL checkpoint to `sync.push` — the correct long-term fix. But the Fly container during Layer-3 is running `mnemon-memory==0.6.0rc18` (pinned per PR #132's design, since we're testing *pre-publish*). rc18 doesn't have PR #140's checkpoint. So when `_fly_dump_vault` SSHes `flyctl ssh -C "mnemon sync push"`, the invoked `sync.push` is the **OLD rc18** version without the checkpoint. Same stale-main-file bug.

## Version-skew picture

| Layer | mnemon version | Has WAL checkpoint? |
|---|---|---|
| Operator's local install | 0.6.0 (editable, post-PR-#140) | ✓ |
| Fly container (Layer-3, pinned proxy) | 0.6.0rc18 | ✗ |
| Fly container (post-publish redeploy) | 0.6.0 (future) | ✓ |

PR #140 ships the right fix but won't apply to the Fly side until 0.6.0 is published and Fly is redeployed. This PR closes the bootstrap gap.

## Fix

Inline WAL checkpoint via stdlib `sqlite3`, chained before `mnemon sync push`:

```python
checkpoint_py = (
    "python -c \""
    "import sqlite3; "
    "c=sqlite3.connect('/data/default.sqlite', timeout=10); "
    "c.execute('PRAGMA wal_checkpoint(TRUNCATE);'); "
    "c.commit(); c.close()"
    "\""
)
remote_cmd = f"{checkpoint_py} && mnemon sync push"
subprocess.run([
    "flyctl", "ssh", "console", "--app", app_name, "-C", remote_cmd,
], check=True)
```

The inline checkpoint:
- Uses only stdlib `sqlite3` — no mnemon-version dependency
- Single quotes inside Python don't conflict with the outer shell-double-quoted `python -c "..."` argument
- `PRAGMA wal_checkpoint(TRUNCATE)` is idempotent — running it on an already-checkpointed DB is a no-op

Once Fly is running 0.6.0+, the second checkpoint inside `sync.push` (from PR #140) is redundant but harmless. Belt-and-suspenders.

## Defense-in-depth picture

- **PR #140** — library-level fix in `sync.push`. Correct long-term.
- **This PR** — operator-level fix in `_fly_dump_vault`. Bootstrap workaround for pre-0.6.0-on-Fly.
- Both together: Layer-3 works regardless of installed mnemon version on the Fly side. Future stable-cut rituals don't have to think about this.

## Test

Updated `test_fly_dump_runs_ssh_console_with_checkpoint_then_sync_push` (renamed from `..._with_sync_push`) to assert:
- SSH command contains `PRAGMA wal_checkpoint`
- Uses stdlib `sqlite3` (not mnemon's CLI — version-independent)
- Contains `mnemon sync push`
- Checkpoint precedes push in command order
- Chained with `&&` so checkpoint failure prevents push

Full suite: **798 passed** (no net change — modified 1 existing test, didn't add new).

## Test plan

- [x] 18/18 downgrade tests
- [x] 798/798 full suite
- [x] Harness 12/12
- [ ] After merge: 10th `scripts/promote_stable.sh layer3` — Step 5 should finally report 4 docs

## Session note

11 PRs. Of the four mnemon-proper bugs surfaced (PR #137, #139, #140, this):
- #137: `upgrade web` MNEMON_S3_PREFIX not forwarded
- #139: `downgrade local` missing Fly→S3 push
- #140: `sync.push` missing WAL checkpoint
- This PR: `_fly_dump_vault` missing version-skew bootstrap for the WAL checkpoint

Each fix exposed the next. #137 → Fly got the right prefix → #139 surfaced. #139 → push call ran → #140 surfaced (WAL not flushed in long-lived server). #140 → fix shipped to main → this PR surfaced (Fly still on rc18, doesn't see the fix yet).

This SHOULD be the last in the chain — the inline checkpoint is version-independent, so there's no further "but Fly is running an older version" surface to discover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)