### PR TITLE
fix(scripts): publish step uses Python regex for CHANGELOG extraction (was empty awk)

### DIFF
--- a/scripts/promote_stable.sh
+++ b/scripts/promote_stable.sh
@@ -466,9 +466,26 @@ cmd_publish() {
 
     echo_step "Create GitHub Release"
     local release_notes
-    # Extract this version's CHANGELOG section: from the heading to the
-    # next heading exclusive (sed '$d' drops the next-heading line).
-    release_notes="$(awk "/^## \[$TARGET_VERSION\]/,/^## \[/" CHANGELOG.md | sed '$d')"
+    # Extract this version's CHANGELOG section: from the `## [VER]`
+    # heading to (but not including) the next `## [` heading.
+    #
+    # The naive awk range `/^## \[VER\]/,/^## \[/` doesn't work — both
+    # patterns match the same SINGLE line (the start heading itself
+    # matches the end pattern too), so awk emits just that one line
+    # and `sed '$d'` strips it → empty. Caught 2026-05-21 when the
+    # publish step died with "could not extract CHANGELOG section
+    # for 0.6.0" right after a successful twine upload + tag push.
+    #
+    # Use Python regex which is unambiguous about the range semantics.
+    release_notes="$("$MNEMON_VENV_BIN/python" - <<PY
+import re
+ver = re.escape("$TARGET_VERSION")
+content = open("CHANGELOG.md").read()
+m = re.search(rf"^## \[{ver}\].*?(?=^## \[)", content, re.DOTALL | re.MULTILINE)
+if m:
+    print(m.group(0).rstrip())
+PY
+)"
     [ -n "$release_notes" ] || die "could not extract CHANGELOG section for $TARGET_VERSION"
     gh release create "v$TARGET_VERSION" --title "v$TARGET_VERSION" --notes "$release_notes"
     echo_ok "GitHub Release v$TARGET_VERSION created"

--- a/tests/test_promote_stable.sh
+++ b/tests/test_promote_stable.sh
@@ -287,6 +287,70 @@ test_layer3_uses_remote_helper_not_mnemon_status() {
     return 0
 }
 
+test_publish_extracts_changelog_section_correctly() {
+    # Regression for the 2026-05-21 publish-step bug: the naive awk
+    # range `/^## \[VER\]/,/^## \[/` extracted ZERO bytes because
+    # both patterns matched the same heading line on BWK awk
+    # (macOS default), and `sed '$d'` then dropped that single line.
+    # The fix uses Python regex with `(?=^## \[)` lookahead.
+    #
+    # This test simulates the publish-step extraction against a
+    # synthetic CHANGELOG and asserts the result contains the
+    # version's content (Release + Fixes sections) without bleeding
+    # into the next version's section.
+
+    local tmp_changelog
+    tmp_changelog="$(mktemp)"
+    cat > "$tmp_changelog" <<'CL'
+# Changelog
+
+## [9.9.9] - 2026-01-01
+
+### Release
+
+- v9.9.9 release notes — this should be extracted.
+
+### Fixes
+
+- v9.9.9 fix bullet — also extracted.
+
+## [9.9.8] - 2025-12-31
+
+### Release
+
+- v9.9.8 release notes — should NOT be in the v9.9.9 extract.
+CL
+
+    # Reproduce the publish-step extraction with the new logic.
+    local result
+    result="$("$REPO_ROOT/.venv/bin/python" - <<PY
+import re
+ver = re.escape("9.9.9")
+content = open("$tmp_changelog").read()
+m = re.search(rf"^## \[{ver}\].*?(?=^## \[)", content, re.DOTALL | re.MULTILINE)
+if m:
+    print(m.group(0).rstrip())
+PY
+)"
+
+    rm -f "$tmp_changelog"
+
+    # Positive: must contain v9.9.9 content.
+    echo "$result" | grep -q "v9.9.9 release notes" \
+        || { echo "    missing v9.9.9 release notes in extract" >&2; return 1; }
+    echo "$result" | grep -q "v9.9.9 fix bullet" \
+        || { echo "    missing v9.9.9 fix bullet in extract" >&2; return 1; }
+
+    # Negative: must NOT contain v9.9.8 content (no bleed across heading).
+    if echo "$result" | grep -q "v9.9.8"; then
+        echo "    v9.9.8 content leaked into v9.9.9 extract" >&2
+        return 1
+    fi
+
+    # Negative: must NOT be empty (the original bug).
+    [ -n "$result" ] || { echo "    extraction returned empty" >&2; return 1; }
+}
+
 test_step2_seed_contents_are_unique() {
     # mnemon's store.save() does content-hash dedup (rc15+). The original
     # runbook passed the same content to all three Step-2 saves, which
@@ -341,6 +405,7 @@ run_test test_sourcing_does_not_dispatch
 run_test test_step2_seed_contents_are_unique
 run_test test_remote_helper_exists_and_is_invokable
 run_test test_layer3_uses_remote_helper_not_mnemon_status
+run_test test_publish_extracts_changelog_section_correctly
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

Caught mid-publish for 0.6.0. After successful `twine upload` (0.6.0 LIVE on PyPI), tag push, and post-publish smoke (7/7), `gh release create` failed:

```
==> Create GitHub Release
  ✗ could not extract CHANGELOG section for 0.6.0
```

## Root cause

The naive awk range:

```bash
release_notes="$(awk "/^## \[$TARGET_VERSION\]/,/^## \[/" CHANGELOG.md | sed '$d')"
```

…returns only the SINGLE start heading line because both patterns match it (BWK awk's range semantics — the start heading itself matches the end pattern too). `sed '$d'` then drops that one line → 0 bytes. `[ -n "..." ]` fails loud with "could not extract."

Reproduced:
```
$ awk "/^## \[0.6.0\]/,/^## \[/" CHANGELOG.md
## [0.6.0] - 2026-05-21      ← just the heading; no body
$ awk "..." | sed '$d'
                              ← empty
```

## Fix

Replace awk with Python regex using `(?=^## \[)` lookahead — unambiguous about range semantics, no off-by-one. Tested against the real CHANGELOG: extracts 5938 bytes cleanly (the full 0.6.0 section, stopping before `[0.6.0rc18]`).

```python
ver = re.escape("$TARGET_VERSION")
m = re.search(rf"^## \[{ver}\].*?(?=^## \[)", content, re.DOTALL | re.MULTILINE)
```

## Operator completion path for the in-flight 0.6.0 publish

The script died at the GitHub Release step after these had already completed:
- ✅ Build sdist + wheel
- ✅ Twine check + sdist hygiene
- ✅ `twine upload` (0.6.0 LIVE on PyPI: https://pypi.org/project/mnemon-memory/0.6.0/)
- ✅ PyPI settle poll
- ✅ Post-publish fresh-venv smoke (7/7)
- ✅ Tag v0.6.0 pushed
- ❌ GitHub Release (awk bug)
- ⏸️ Fly redeploy
- ⏸️ Final live doctor

Manual completion:

```bash
# 1. GitHub Release (using corrected extraction)
.venv/bin/python -c "import re; c=open('CHANGELOG.md').read(); \
  m=re.search(r'^## \\[0\\.6\\.0\\].*?(?=^## \\[)', c, re.DOTALL|re.MULTILINE); \
  open('/tmp/r.md','w').write(m.group(0).rstrip())"
gh release create v0.6.0 --title "v0.6.0" --notes-file /tmp/r.md

# 2. Fly redeploy
.venv/bin/mnemon upgrade web --app-name mnemon-memory --mnemon-version 0.6.0

# 3. Final doctor
.venv/bin/mnemon doctor
```

## Tests

New `test_publish_extracts_changelog_section_correctly` in the harness:
- Builds a synthetic CHANGELOG with two versions
- Runs the new Python-regex extraction
- Asserts positive (target content present) + negative (next version's content not bleeding in) + non-empty contract

**Harness: 13/13.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)