### PR TITLE
feat(salience): Phase 0 — standing-tier diagnostic (feature-flagged, no schema)

### DIFF
--- a/scripts/build_standing_set.py
+++ b/scripts/build_standing_set.py
@@ -1,0 +1,258 @@
+"""scripts/build_standing_set.py — Phase 0 of the salience-tier plan.
+
+Score every live memory on cheap signals available today and print the
+top-N candidates for *manual* standing-tier curation. The operator
+inspects the candidates and hand-writes the selected IDs to
+`~/.mnemon/standing.json` (no auto-selection — the cap is the contract,
+and Phase 0 is hypothesis validation, not automation).
+
+Phase 0 plan: private/mnemon-salience-tier-plan-260521.md
+ROADMAP: "Salience tier — standing-context recall (added 2026-05-21)"
+
+Scoring:
+  correction_score   — 1.0 if content_type='feedback' AND confidence ≥ 0.85
+                       AND title or content matches a correction pattern.
+                       Operator-tunable patterns below.
+  contradiction_score — count of relations where the memory is the
+                       'winning' (source) side of a 'contradicts' or
+                       'supersedes' relation. Mnemon's contradiction
+                       classifier (contradiction.py) emits these when a
+                       new save resolves vs a prior conflicting memory.
+  breadth_score      — distinct content_types among the memory's top-50
+                       FTS neighbors. Crude proxy for "this fact
+                       conditions reasoning across many query types."
+
+  combined = 2.0·correction + 1.0·contradiction + 0.5·breadth
+  (weights provisional per the plan — tune by inspection)
+
+Usage:
+    .venv/bin/python scripts/build_standing_set.py
+    .venv/bin/python scripts/build_standing_set.py --top 30  # default
+    .venv/bin/python scripts/build_standing_set.py --top 50 --vault /alt/path
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+# Patterns that mark a memory as a correction. Operator-tunable —
+# the plan flags these as "small set" and asks for tuning by inspection.
+CORRECTION_PATTERNS = [
+    re.compile(r"^\s*(stop|don'?t|never|always)\b", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"\b(correction|corrected|wrong about|i was wrong)\b", re.IGNORECASE),
+]
+
+
+def _resolve_db(vault_override: str | None, db_override: str | None) -> Path:
+    """Resolve the sqlite path to score.
+
+    Precedence:
+      --db <path>           direct file path (highest)
+      --vault <dir>         vault-dir → <dir>/default.sqlite
+      MNEMON_VAULT_DIR env  env-dir   → <env>/default.sqlite
+      ~/.mnemon             default   → ~/.mnemon/default.sqlite
+    """
+    if db_override:
+        return Path(db_override)
+    if vault_override:
+        return Path(vault_override) / "default.sqlite"
+    env = os.environ.get("MNEMON_VAULT_DIR")
+    if env:
+        return Path(env) / "default.sqlite"
+    return Path.home() / ".mnemon" / "default.sqlite"
+
+
+def _correction_score(title: str, content: str, content_type: str, confidence: float) -> float:
+    """Return 1.0 if the memory shape matches a correction, else 0.0."""
+    if content_type != "feedback":
+        return 0.0
+    if confidence < 0.85:
+        return 0.0
+    text = f"{title or ''}\n{content or ''}"
+    for pat in CORRECTION_PATTERNS:
+        if pat.search(text):
+            return 1.0
+    return 0.0
+
+
+def _contradiction_scores(conn: sqlite3.Connection) -> dict[int, int]:
+    """For each memory, count incoming relations where it's the 'winning'
+    side of a 'contradicts' or 'supersedes' relation.
+
+    Mnemon's contradiction classifier emits:
+      - source_id 'contradicts' target_id  → source won
+      - source_id 'supersedes' target_id   → source is the newer/correct version
+    (See src/mnemon/contradiction.py)
+    """
+    out: dict[int, int] = {}
+    rows = conn.execute(
+        """
+        SELECT source_id, COUNT(*) AS n
+        FROM relations
+        WHERE relation_type IN ('contradicts', 'supersedes')
+        GROUP BY source_id
+        """
+    ).fetchall()
+    for source_id, n in rows:
+        out[source_id] = n
+    return out
+
+
+def _breadth_scores(conn: sqlite3.Connection, doc_ids: Iterable[int]) -> dict[int, int]:
+    """For each memory, count distinct content_types among its top-50
+    FTS neighbors (using the memory's title as the query).
+
+    Cheap proxy for cross-domain applicability — facts that touch many
+    types are more "constraint-like" than narrow single-context facts.
+    FTS (BM25 over the FTS5 index) rather than vector similarity to
+    avoid an O(N²) cosine pass on the full vault.
+    """
+    out: dict[int, int] = {}
+    for doc_id in doc_ids:
+        title_row = conn.execute(
+            "SELECT title FROM documents WHERE id = ?", (doc_id,)
+        ).fetchone()
+        if not title_row or not title_row[0]:
+            out[doc_id] = 0
+            continue
+        title = title_row[0]
+        # Strip FTS-special characters that would error the MATCH.
+        # Single quotes need doubling for SQL parameter substitution
+        # but we use parametric, so that's safe; we DO need to strip
+        # FTS operators (* " + - etc) and column qualifiers.
+        cleaned = re.sub(r"[\"'*\-+:^]", " ", title)
+        cleaned = re.sub(r"\s+", " ", cleaned).strip()
+        if not cleaned:
+            out[doc_id] = 0
+            continue
+        try:
+            rows = conn.execute(
+                """
+                SELECT DISTINCT d.content_type
+                FROM documents_fts f
+                JOIN documents d ON d.id = f.rowid
+                WHERE documents_fts MATCH ?
+                  AND d.invalidated_at IS NULL
+                LIMIT 50
+                """,
+                (cleaned,),
+            ).fetchall()
+            out[doc_id] = len(rows)
+        except sqlite3.OperationalError:
+            # FTS MATCH error (e.g. malformed query) — skip this doc's breadth.
+            out[doc_id] = 0
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    ap.add_argument(
+        "--top",
+        type=int,
+        default=30,
+        help="how many top-scored candidates to print (default: 30)",
+    )
+    ap.add_argument(
+        "--vault",
+        default=None,
+        help="vault dir (overrides MNEMON_VAULT_DIR / ~/.mnemon)",
+    )
+    ap.add_argument(
+        "--db",
+        default=None,
+        help="direct sqlite path (overrides --vault and env). Use for "
+             "scoring a snapshot of the prod Fly vault.",
+    )
+    args = ap.parse_args()
+
+    db_path = _resolve_db(args.vault, args.db)
+    if not db_path.exists():
+        print(f"ERROR: sqlite not found: {db_path}", file=sys.stderr)
+        return 2
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+
+    # Pull live memories with content.
+    docs = conn.execute(
+        """
+        SELECT d.id, d.title, d.content_type, d.confidence, c.doc AS content
+        FROM documents d
+        JOIN content c ON d.hash = c.hash
+        WHERE d.invalidated_at IS NULL
+        """
+    ).fetchall()
+
+    if not docs:
+        print(f"vault {db_path} has no live memories", file=sys.stderr)
+        return 1
+
+    print(f"# Standing-tier candidate scoring", file=sys.stderr)
+    print(f"# Vault: {db_path}", file=sys.stderr)
+    print(f"# Live memories: {len(docs)}", file=sys.stderr)
+
+    correction = {
+        d["id"]: _correction_score(d["title"], d["content"], d["content_type"], d["confidence"])
+        for d in docs
+    }
+    contradiction = _contradiction_scores(conn)
+    breadth = _breadth_scores(conn, [d["id"] for d in docs])
+
+    n_correction = sum(1 for v in correction.values() if v > 0)
+    n_contradiction = sum(1 for v in contradiction.values() if v > 0)
+    print(f"# Correction-flagged: {n_correction}", file=sys.stderr)
+    print(f"# Contradiction-winning: {n_contradiction}", file=sys.stderr)
+    print(f"# Mean breadth: {sum(breadth.values()) / max(1, len(breadth)):.1f}", file=sys.stderr)
+    print(file=sys.stderr)
+
+    combined: dict[int, tuple[float, float, float, float]] = {}
+    for d in docs:
+        doc_id = d["id"]
+        c = correction.get(doc_id, 0.0)
+        x = float(contradiction.get(doc_id, 0))
+        b = float(breadth.get(doc_id, 0))
+        score = 2.0 * c + 1.0 * x + 0.5 * b
+        combined[doc_id] = (score, c, x, b)
+
+    by_id = {d["id"]: d for d in docs}
+    top = sorted(combined.items(), key=lambda kv: kv[1][0], reverse=True)[: args.top]
+
+    print(f"# Top-{args.top} candidates (rank by combined score)")
+    print(f"# Format: [id] score=X.XX (corr=C, contra=X, breadth=B) type confidence")
+    print(f"#         title")
+    print(f"#         content snippet")
+    print(f"#")
+    print(f"# Operator: pick N≤20 IDs by hand, write to ~/.mnemon/standing.json as:")
+    print(f"#     {{\"ids\": [<id1>, <id2>, ...]}}")
+    print(f"# Then set MNEMON_STANDING_TIER_FILE=~/.mnemon/standing.json in your shell")
+    print(f"# (or per claude-code session config).")
+    print()
+
+    for rank, (doc_id, (score, c, x, b)) in enumerate(top, 1):
+        d = by_id[doc_id]
+        title = d["title"] or "(no title)"
+        ct = d["content_type"]
+        conf = d["confidence"]
+        snippet = (d["content"] or "")[:240].replace("\n", " ")
+        print(
+            f"[{doc_id:>5}] score={score:5.2f} "
+            f"(corr={c:.1f}, contra={int(x)}, breadth={int(b)}) "
+            f"{ct} conf={conf:.2f}"
+        )
+        print(f"        {title}")
+        print(f"        {snippet}{'...' if len(d['content'] or '') > 240 else ''}")
+        print()
+
+    conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mnemon/hooks/context_surfacing.py
+++ b/src/mnemon/hooks/context_surfacing.py
@@ -23,6 +23,7 @@ All memory reads flow to the Fly vault via :mod:`mnemon.hooks._remote_client`.
 from __future__ import annotations
 
 import json
+import os
 import secrets
 import sys
 
@@ -65,6 +66,76 @@ _SPOTLIGHT_INSTRUCTION = (
 )
 
 
+# ── Phase 0 of the salience-tier plan ─────────────────────────────
+# (private/mnemon-salience-tier-plan-260521.md)
+#
+# Standing context — feature-flagged, opt-in via MNEMON_STANDING_TIER_FILE.
+# When the env var points at a JSON file shaped {"ids": [<id>, <id>, ...]},
+# build_context fetches each ID via the remote MCP client and prepends a
+# labeled "Standing context" sub-section inside the existing
+# <mnemon-context> envelope, ahead of the query-driven block.
+#
+# Per-prompt cost: ~500ms × N (sequential memory_get HTTP calls). For N=10
+# that's ~5s added latency. Phase 0 accepts this cost — the diagnostic is
+# about hypothesis validation, not perf. Phase 1 will optimize via local
+# cache or batch fetch.
+#
+# Defaults to unset = original behavior unchanged.
+
+def _load_standing_ids() -> list[int]:
+    """Read standing-tier IDs from MNEMON_STANDING_TIER_FILE, if set."""
+    path = os.environ.get("MNEMON_STANDING_TIER_FILE")
+    if not path:
+        return []
+    try:
+        with open(os.path.expanduser(path)) as f:
+            data = json.load(f)
+        return [int(x) for x in data.get("ids", [])]
+    except (OSError, json.JSONDecodeError, ValueError, TypeError):
+        # Best-effort. Malformed standing file shouldn't break recall —
+        # log to stderr so the operator sees it without breaking Claude Code.
+        print(
+            f"mnemon: failed to load standing-tier IDs from {path}",
+            file=sys.stderr,
+        )
+        return []
+
+
+def _fetch_standing_block(ids: list[int]) -> str:
+    """Fetch standing-tier memories via memory_get and render as a block.
+
+    Sequential HTTP calls — fine for Phase 0 (N≤20). Empty string on any
+    failure / all-skipped (keeps the calling code branch-free).
+    """
+    if not ids:
+        return ""
+    try:
+        from ._remote_client import call_tool_sync
+    except ImportError:
+        return ""
+
+    from ..safety import defang_control_markup
+
+    lines: list[str] = []
+    for doc_id in ids:
+        try:
+            raw, _elapsed = call_tool_sync("memory_get", {"id": doc_id}, timeout=5.0)
+            data = json.loads(raw)
+        except Exception:
+            # Best-effort — skip failed IDs, don't pollute context with errors.
+            continue
+        title = defang_control_markup(str(data.get("title", "")))
+        content = str(data.get("content", ""))
+        content_type = str(data.get("content_type", "note"))
+        snippet = defang_control_markup(content[:_SNIPPET_CHARS])
+        ellipsis = "..." if len(content) > _SNIPPET_CHARS else ""
+        lines.append(
+            f"- [{content_type}] **{title}** (id={doc_id})\n"
+            f"  {snippet}{ellipsis}"
+        )
+    return "\n\n".join(lines)
+
+
 def _format_results(results: list[dict]) -> str:
     """Render a memory_search JSON response as a markdown list for prompt
     injection. Mirrors the pre-0.5.0 server-side prose format so the
@@ -99,34 +170,63 @@ def build_context(raw_text: str, *, prefix: str = "") -> str:
     ``prefix`` is prepended inside the block before the memories header —
     used to surface latency warnings on slow-but-successful calls.
 
-    Returns an empty string when there's nothing worth injecting — empty
-    input, an empty result list, or unparseable JSON.
+    **Phase 0 standing-tier (opt-in):** if ``MNEMON_STANDING_TIER_FILE``
+    is set, fetch the listed memory IDs via ``memory_get`` and prepend
+    a labeled "Standing context" sub-section inside the envelope, ahead
+    of the query-driven block. Conditions reasoning regardless of
+    query similarity — the hypothesis being validated in Phase 0 of
+    the salience-tier plan.
+
+    Returns an empty string when there's nothing worth injecting — no
+    standing IDs AND no situational results (or unparseable JSON).
     """
-    if not raw_text:
+    # Standing context — Phase 0 opt-in. Computed first so the function
+    # can inject standing-only when no situational results exist.
+    standing_ids = _load_standing_ids()
+    standing_block = _fetch_standing_block(standing_ids) if standing_ids else ""
+
+    # Parse the situational search results.
+    situational_rendered = ""
+    if raw_text:
+        trimmed = raw_text.strip()
+        if trimmed:
+            try:
+                results = json.loads(trimmed)
+                if isinstance(results, list) and results:
+                    situational_rendered = _format_results(results)
+                    if len(situational_rendered) > CHAR_BUDGET:
+                        situational_rendered = (
+                            situational_rendered[:CHAR_BUDGET].rstrip()
+                            + "\n...[truncated]"
+                        )
+            except json.JSONDecodeError:
+                # Server contract violation — don't inject garbage. Standing
+                # block still ships if present.
+                pass
+
+    if not standing_block and not situational_rendered:
         return ""
-    trimmed = raw_text.strip()
-    if not trimmed:
-        return ""
-    try:
-        results = json.loads(trimmed)
-    except json.JSONDecodeError:
-        # Server contract violation — don't inject garbage into the prompt.
-        return ""
-    if not isinstance(results, list) or not results:
-        return ""
-    rendered = _format_results(results)
-    if len(rendered) > CHAR_BUDGET:
-        rendered = rendered[:CHAR_BUDGET].rstrip() + "\n...[truncated]"
+
     # Per-call nonce: unguessable, so recalled content cannot forge a
     # matching close fence to break out of the untrusted-data region.
     nonce = secrets.token_hex(8)
-    lines = []
+    lines: list[str] = []
     if prefix:
         lines.append(prefix)
     lines.append(_SPOTLIGHT_INSTRUCTION)
     lines.append(f"[mnemon:data:{nonce}]")
-    lines.append("Relevant memories from previous sessions:")
-    lines.append(rendered)
+    if standing_block:
+        lines.append(
+            "## Standing context (always-on; conditions reasoning regardless of query)"
+        )
+        lines.append(standing_block)
+        lines.append("")
+    if situational_rendered:
+        if standing_block:
+            lines.append("## Situational recall (relevance ranked)")
+        else:
+            lines.append("Relevant memories from previous sessions:")
+        lines.append(situational_rendered)
     lines.append(f"[/mnemon:data:{nonce}]")
     inner = "\n".join(lines)
     return f"<mnemon-context>\n{inner}\n</mnemon-context>"


### PR DESCRIPTION
## Summary

Phase 0 of the salience-tier plan (`private/mnemon-salience-tier-plan-260521.md`). Strictly opt-in via env var; no schema, no new MCP tools, default behavior unchanged. Validates the two-tier hypothesis BEFORE investing in Phase 1's schema migration + tooling.

## Hypothesis being validated

The 2026-05-21 runway-weighting failure surfaced a class of bug current mnemon can't address: the relevant memory was retrieved into context and STILL under-weighted vs a dominant generic prior. **Retrieval failure** (fact not in context) is what RAG fixes; **salience failure** (fact present but under-weighted) is what standing-tier injection would fix. Phase 0 tests whether a small capped set of facts injected unconditionally — outside query similarity — would catch this class of failure.

If validated → invest in Phase 1's schema + MCP tools + cap-enforced promote/demote. If invalidated → the bottleneck is elsewhere; revise the hypothesis before building.

## What ships

**`scripts/build_standing_set.py`** — score every live memory on three cheap signals available today:

| Signal | Definition |
|---|---|
| `correction_score` | 1.0 if `content_type='feedback'` AND `confidence ≥ 0.85` AND title/content matches a correction pattern (`^stop\|don't\|never\|always`, `correction\|corrected\|wrong about`). Operator-tunable patterns. |
| `contradiction_score` | count of incoming relations where this memory is the source (winning) side of a `'contradicts'` or `'supersedes'` relation (mnemon's classifier emits these per `contradiction.py`). |
| `breadth_score` | count of distinct `content_type` values among the top-50 FTS neighbors of the memory's title. Cheap cross-domain proxy. |

```
combined = 2.0·correction + 1.0·contradiction + 0.5·breadth
```

Weights provisional (per plan); tune by inspection. Prints top-N candidates (default 30). Operator picks N≤20 IDs by hand and writes `~/.mnemon/standing.json` as `{"ids": [...]}`.

Supports `--db <path>` for scoring a snapshot of the prod Fly vault (operator's local sqlite is the April 12 snapshot; the load-bearing memories live on the Fly remote).

**`hooks/context_surfacing.py` feature flag** — if `MNEMON_STANDING_TIER_FILE` env var points at the JSON file, `build_context` fetches each ID via `memory_get` and prepends a labeled `## Standing context` sub-section inside the existing `<mnemon-context>` envelope, ahead of the query-driven block. Both sub-sections share the same Layer 1 data-marking + nonce fence — standing-tier content flows through the same defense stack.

When the env var is unset → behavior unchanged.

## Phase 0 cost / known limitation

Sequential `memory_get` HTTP calls = ~500ms × N latency per prompt. For N=10 that's ~5s added. Acceptable for the diagnostic; Phase 1 will optimize via local cache or batch fetch.

## Validation workflow (operator-driven; not in this PR)

```bash
# 1. Snapshot prod Fly vault locally (backup API — safe, atomic)
flyctl ssh console -a mnemon-memory -C \
  "python -c 'import sqlite3; src=sqlite3.connect(\"/data/default.sqlite\"); dst=sqlite3.connect(\"/tmp/snap.sqlite\"); src.backup(dst); src.close(); dst.close()'"
flyctl ssh sftp get -a mnemon-memory /tmp/snap.sqlite /tmp/mnemon-prod-snap.sqlite

# 2. Score candidates
.venv/bin/python scripts/build_standing_set.py --db /tmp/mnemon-prod-snap.sqlite --top 30

# 3. Operator picks ~10 IDs by hand, writes:
#    ~/.mnemon/standing.json   →   {"ids": [123, 456, ...]}

# 4. Enable for diagnostic
export MNEMON_STANDING_TIER_FILE=~/.mnemon/standing.json

# 5. Replay the runway conversation with the env var set vs unset.
#    Compare model responses.

# 6. Decide: validated → Phase 1 / invalidated → revise / inconclusive → iterate
#    Record verdict in private/salience-phase0-results-26MMDD.md
```

## Non-goals (per plan)

- No new MCP tool, no CLI command, no schema change
- No "right" weights — scoring is provisional, tuned by inspection
- No regression test suite — the diagnostic artifact is the validation
- No version bump (this is pre-0.7.0rc1; Phase 1 is when 0.7.0rc1 cuts)

## Decision gate

Per plan: **Phase 1 (first-class tier with schema + MCP tools + cap-enforced promote/demote) only starts AFTER Phase 0 produces a recorded "validated" verdict.** Do NOT start Phase 1 on a falsified premise.

If Phase 0 invalidates the two-tier hypothesis (e.g., turns out the bottleneck is snippet size, recency weight, or framing), revise the ROADMAP entry instead of jumping ahead.

## Test plan

- [x] 21/21 hooks tests pass (no behavior change when env var unset)
- [x] Full pytest 801/801
- [x] Harness 13/13
- [x] Smoke: standing-IDs loader handles missing file gracefully; build_context with no input returns empty (default behavior)
- [ ] Operator: complete the validation workflow above, record verdict in `private/salience-phase0-results-26MMDD.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)