### PR TITLE
feat(salience): scripts/salience_phase0.sh — Phase 0 driver script

### DIFF
--- a/scripts/salience_phase0.sh
+++ b/scripts/salience_phase0.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# scripts/salience_phase0.sh — Phase 0 of the salience-tier plan.
+#
+# Drives the operator-side workflow for validating the two-tier
+# (standing context + situational recall) hypothesis without
+# committing to the Phase 1 schema migration.
+#
+# Plan: private/mnemon-salience-tier-plan-260521.md
+# Scoring: scripts/build_standing_set.py
+# Feature flag: src/mnemon/hooks/context_surfacing.py (env-var-gated)
+#
+# Subcommands:
+#   snapshot           Atomic backup of prod Fly vault → local file
+#                      (SQLite online-backup API; safe with running server)
+#   score [--top N]    Run build_standing_set.py against the snapshot
+#                      and print top-N candidates (default 30)
+#   select <IDS>       Write ~/.mnemon/standing.json from a comma-separated
+#                      ID list (e.g. `select 123,456,789`)
+#   status             Show current standing-tier state (file, IDs, env)
+#   disable            Remove ~/.mnemon/standing.json + remind unset env
+#   help               This help
+#
+# Typical flow:
+#   scripts/salience_phase0.sh snapshot
+#   scripts/salience_phase0.sh score
+#   # operator inspects candidates, picks ~10 by hand
+#   scripts/salience_phase0.sh select 123,456,789,...
+#   export MNEMON_STANDING_TIER_FILE=~/.mnemon/standing.json
+#   # replay runway conversation with/without the env var
+#   # record verdict in private/salience-phase0-results-26MMDD.md
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+MNEMON_VENV_BIN="$REPO_ROOT/.venv/bin"
+[ -x "$MNEMON_VENV_BIN/python" ] || { echo "ERROR: $MNEMON_VENV_BIN/python not found — install editable venv first" >&2; exit 1; }
+
+SNAPSHOT_PATH="${SALIENCE_SNAPSHOT_PATH:-/tmp/mnemon-prod-snap.sqlite}"
+STANDING_FILE="$HOME/.mnemon/standing.json"
+FLY_APP="${MNEMON_FLY_APP:-mnemon-memory}"
+
+echo_step() { printf "\n\033[1;34m==> %s\033[0m\n" "$*"; }
+echo_ok()   { printf "  \033[1;32m✓\033[0m %s\n" "$*"; }
+echo_warn() { printf "  \033[1;33m⚠\033[0m %s\n" "$*" >&2; }
+echo_err()  { printf "  \033[1;31m✗\033[0m %s\n" "$*" >&2; }
+die()       { echo_err "$*"; exit 1; }
+
+
+cmd_snapshot() {
+    echo_step "Snapshot prod Fly vault → $SNAPSHOT_PATH"
+
+    flyctl auth whoami >/dev/null 2>&1 || die "flyctl not logged in"
+
+    # 1) Backup-API snapshot on the Fly machine to /tmp/snap.sqlite
+    # 2) sftp get to local
+    # 3) clean up the remote temp file
+    #
+    # Why backup-API not raw cp: live serve-remote has frames in WAL
+    # that raw cp of default.sqlite would miss (verified 2026-05-21).
+    # Connection.backup() handles WAL atomically.
+    echo_step "  Step 1/3 — backup on Fly via online-backup API"
+    flyctl ssh console -a "$FLY_APP" -C \
+        "python -c 'import sqlite3; src=sqlite3.connect(\"/data/default.sqlite\"); dst=sqlite3.connect(\"/tmp/snap.sqlite\"); src.backup(dst); src.close(); dst.close(); print(\"snapshot done\")'" \
+        || die "remote backup failed"
+    echo_ok "remote snapshot written to /tmp/snap.sqlite on $FLY_APP"
+
+    echo_step "  Step 2/3 — sftp download"
+    rm -f "$SNAPSHOT_PATH"
+    # flyctl ssh sftp get takes <remote> <local>
+    flyctl ssh sftp get -a "$FLY_APP" /tmp/snap.sqlite "$SNAPSHOT_PATH" \
+        || die "sftp download failed"
+    [ -f "$SNAPSHOT_PATH" ] || die "sftp succeeded but $SNAPSHOT_PATH missing"
+    local size
+    size="$(stat -f '%z' "$SNAPSHOT_PATH" 2>/dev/null || stat -c '%s' "$SNAPSHOT_PATH")"
+    echo_ok "downloaded ${size}B to $SNAPSHOT_PATH"
+
+    echo_step "  Step 3/3 — clean up remote temp file"
+    flyctl ssh console -a "$FLY_APP" -C "rm -f /tmp/snap.sqlite" \
+        || echo_warn "remote cleanup failed (harmless — /tmp churns on machine restart)"
+    echo_ok "remote /tmp/snap.sqlite removed"
+
+    # Quick sanity: count live memories in the snapshot
+    local live_count
+    live_count="$("$MNEMON_VENV_BIN/python" -c "
+import sqlite3
+c = sqlite3.connect('$SNAPSHOT_PATH')
+print(c.execute('SELECT COUNT(*) FROM documents WHERE invalidated_at IS NULL').fetchone()[0])
+")"
+    echo_step "Snapshot ready"
+    echo "  Path: $SNAPSHOT_PATH"
+    echo "  Live memories: $live_count"
+    echo ""
+    echo "Next: scripts/salience_phase0.sh score"
+}
+
+
+cmd_score() {
+    local top=30
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --top) top="$2"; shift 2 ;;
+            *) die "unknown arg: $1" ;;
+        esac
+    done
+
+    [ -f "$SNAPSHOT_PATH" ] || die "no snapshot at $SNAPSHOT_PATH — run \`$0 snapshot\` first"
+
+    echo_step "Score candidates against $SNAPSHOT_PATH (top $top)"
+    "$MNEMON_VENV_BIN/python" "$REPO_ROOT/scripts/build_standing_set.py" \
+        --db "$SNAPSHOT_PATH" --top "$top"
+
+    echo_step "Next"
+    echo "  Inspect the candidates above; pick N≤20 IDs by hand."
+    echo "  Then: scripts/salience_phase0.sh select 123,456,789,..."
+}
+
+
+cmd_select() {
+    [ $# -eq 1 ] || die "usage: $0 select <id1,id2,id3,...>"
+    local raw="$1"
+
+    # Parse comma-separated, validate each is a positive integer.
+    local ids
+    ids="$("$MNEMON_VENV_BIN/python" - "$raw" <<'PY'
+import json, sys
+raw = sys.argv[1]
+try:
+    parsed = [int(x.strip()) for x in raw.split(",") if x.strip()]
+except ValueError as e:
+    print(f"ERROR: non-integer in id list: {e}", file=sys.stderr)
+    sys.exit(2)
+if not parsed:
+    print("ERROR: empty id list", file=sys.stderr)
+    sys.exit(2)
+if any(i <= 0 for i in parsed):
+    print("ERROR: ids must be positive integers", file=sys.stderr)
+    sys.exit(2)
+if len(parsed) > 20:
+    print(f"WARN: {len(parsed)} ids — Phase 0 plan suggests ≤20 to preserve salience", file=sys.stderr)
+print(json.dumps({"ids": parsed}, indent=2))
+PY
+)" || die "failed to parse id list"
+
+    mkdir -p "$(dirname "$STANDING_FILE")"
+    printf '%s\n' "$ids" > "$STANDING_FILE"
+    echo_step "Wrote $STANDING_FILE"
+    cat "$STANDING_FILE"
+    echo ""
+    echo_step "Next"
+    echo "  In your shell:"
+    echo "    export MNEMON_STANDING_TIER_FILE=$STANDING_FILE"
+    echo ""
+    echo "  Or per-session config for Claude Code (so it auto-loads on every prompt)."
+    echo "  Then replay the runway conversation and compare model responses."
+    echo "  Record the verdict in private/salience-phase0-results-\$(date +%y%m%d).md"
+}
+
+
+cmd_status() {
+    echo_step "Salience Phase 0 state"
+    echo ""
+    if [ -f "$SNAPSHOT_PATH" ]; then
+        local size mtime live
+        size="$(stat -f '%z' "$SNAPSHOT_PATH" 2>/dev/null || stat -c '%s' "$SNAPSHOT_PATH")"
+        mtime="$(stat -f '%Sm' "$SNAPSHOT_PATH" 2>/dev/null || stat -c '%y' "$SNAPSHOT_PATH")"
+        live="$("$MNEMON_VENV_BIN/python" -c "
+import sqlite3
+print(sqlite3.connect('$SNAPSHOT_PATH').execute('SELECT COUNT(*) FROM documents WHERE invalidated_at IS NULL').fetchone()[0])
+" 2>/dev/null || echo '?')"
+        echo "  Snapshot: $SNAPSHOT_PATH ($size B, $live live memories, modified $mtime)"
+    else
+        echo "  Snapshot: (none — run \`$0 snapshot\`)"
+    fi
+
+    if [ -f "$STANDING_FILE" ]; then
+        echo "  Standing file: $STANDING_FILE"
+        local n_ids
+        n_ids="$("$MNEMON_VENV_BIN/python" -c "
+import json
+print(len(json.load(open('$STANDING_FILE')).get('ids', [])))
+" 2>/dev/null || echo '?')"
+        echo "    IDs: $n_ids selected"
+        "$MNEMON_VENV_BIN/python" -c "
+import json
+ids = json.load(open('$STANDING_FILE')).get('ids', [])
+print('    contents:', ids)
+" 2>/dev/null || true
+    else
+        echo "  Standing file: (none — run \`$0 select <IDS>\` after scoring)"
+    fi
+
+    if [ -n "${MNEMON_STANDING_TIER_FILE:-}" ]; then
+        echo "  Env: MNEMON_STANDING_TIER_FILE=$MNEMON_STANDING_TIER_FILE (active)"
+    else
+        echo "  Env: MNEMON_STANDING_TIER_FILE not set in this shell"
+        echo "       (set it to activate: export MNEMON_STANDING_TIER_FILE=$STANDING_FILE)"
+    fi
+}
+
+
+cmd_disable() {
+    if [ -f "$STANDING_FILE" ]; then
+        rm "$STANDING_FILE"
+        echo_ok "removed $STANDING_FILE"
+    else
+        echo_warn "no $STANDING_FILE to remove"
+    fi
+    echo ""
+    echo "  Don't forget to unset the env var in your shell:"
+    echo "    unset MNEMON_STANDING_TIER_FILE"
+}
+
+
+cmd_help() {
+    sed -n '2,29p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+
+case "${1:-help}" in
+    snapshot) shift; cmd_snapshot "$@" ;;
+    score)    shift; cmd_score "$@" ;;
+    select)   shift; cmd_select "$@" ;;
+    status)   shift; cmd_status "$@" ;;
+    disable)  shift; cmd_disable "$@" ;;
+    help|-h|--help) cmd_help ;;
+    *) echo_err "unknown subcommand: $1"; cmd_help; exit 2 ;;
+esac


### PR DESCRIPTION
## Summary

Wraps the operator-side Phase 0 workflow in a single subcommand-style script. Reduces the 7-step manual dance from PR #145 to 3 commands:

```bash
scripts/salience_phase0.sh snapshot
scripts/salience_phase0.sh score
scripts/salience_phase0.sh select 123,456,789
export MNEMON_STANDING_TIER_FILE=~/.mnemon/standing.json
# replay runway conversation, compare with/without env var, record verdict
```

## Subcommands

| Subcommand | Purpose |
|---|---|
| `snapshot` | Atomic backup of prod Fly vault → local file via SQLite online-backup API on Fly (safe with running serve-remote; same primitive as PR #142/#143's `_fly_dump_vault`). Default target: `/tmp/mnemon-prod-snap.sqlite` (override via `SALIENCE_SNAPSHOT_PATH`). |
| `score [--top N]` | Runs `scripts/build_standing_set.py` against the snapshot. Default top=30. Read-only. |
| `select <IDS>` | Writes `~/.mnemon/standing.json` from comma-separated ID list. Validates positive integers, warns if >20 (Phase 0 plan suggests ≤20 to preserve salience). Prints the env-var to export. |
| `status` | Shows snapshot path/size/age, standing file IDs, env var status. No mutations. |
| `disable` | Removes `~/.mnemon/standing.json` + reminds operator to unset env var. |
| `help` | Renders the header docstring. |

## Why this script vs leaving the dance manual

Each Phase 0 iteration would otherwise require:
1. `flyctl ssh` + Python heredoc for backup
2. `flyctl ssh sftp get` to download
3. `flyctl ssh` again to clean up `/tmp/snap.sqlite`
4. `python scripts/build_standing_set.py --db ...`
5. Mental parsing of the candidates
6. `cat > ~/.mnemon/standing.json << EOF ...`
7. `export MNEMON_STANDING_TIER_FILE=...`

Wrapping into `snapshot`/`score`/`select` collapses the operational friction without removing any operator judgment from the critical step (which IDs to pick — that's still by hand from inspecting the printed candidates).

## Defense: the script doesn't bypass operator judgment

The `select` subcommand only writes JSON from explicit IDs. It does NOT auto-pick. That preserves the Phase 0 plan invariant: "Operator picks N≤20 by hand. The cap is the contract."

## Verified

- `bash -n` clean
- Help renders the header docstring correctly
- `status` reports "no snapshot / no standing file" state correctly
- `select 9999,8888` writes valid JSON with `{"ids": [9999, 8888]}` shape
- `disable` removes the file + reminds env unset

`snapshot` requires flyctl + prod credentials; exercised on first Phase 0 validation run (can't unit-test against prod).

## ROADMAP follow-up filed

`scripts/mnemon_ops.sh — general operator helpers` — recurring ops commands that emerged during the 14-PR 0.6.0 stable cut and would benefit from the same subcommand-style driver pattern:

- Dangling test-app cleanup
- Token recovery from running Fly app
- Machine restart for SSL handshake warmup
- Vault size + recent-changes diff
- CHANGELOG section extractor (standalone)

Filed in `private/ROADMAP.md` (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)