### PR TITLE
fix(scripts): salience_phase0.sh — flyctl ssh -C is exec, not shell

### DIFF
--- a/scripts/salience_phase0.sh
+++ b/scripts/salience_phase0.sh
@@ -78,10 +78,16 @@ cmd_snapshot() {
     echo_ok "remote /tmp/snap.sqlite written"
 
     echo_step "  Step 2/4 — vecstore copy on Fly (numpy savez is atomic)"
-    flyctl ssh console -a "$FLY_APP" -C \
-        "cp /data/default.vec.npz /tmp/snap.vec.npz && echo 'vec copy done'" \
-        || echo_warn "remote vecstore copy failed — embedding signals will be zero"
-    echo_ok "remote /tmp/snap.vec.npz written"
+    # flyctl ssh -C does NOT spawn a shell — it execs the command directly,
+    # so shell operators like `&& echo X` get passed as literal cp args
+    # (caught 2026-05-21: cp tried to use "vec copy done" as a destination).
+    # Single command only. If we need chaining, wrap in `sh -c "..."`.
+    if flyctl ssh console -a "$FLY_APP" -C \
+        "cp /data/default.vec.npz /tmp/snap.vec.npz"; then
+        echo_ok "remote /tmp/snap.vec.npz written"
+    else
+        echo_warn "remote vecstore copy failed — embedding signals will be zero"
+    fi
 
     echo_step "  Step 3/4 — sftp download (sqlite + vec.npz)"
     rm -f "$SNAPSHOT_PATH" "$VEC_PATH"
@@ -100,9 +106,11 @@ cmd_snapshot() {
     fi
 
     echo_step "  Step 4/4 — clean up remote temp files"
-    flyctl ssh console -a "$FLY_APP" -C "rm -f /tmp/snap.sqlite /tmp/snap.vec.npz" \
-        || echo_warn "remote cleanup failed (harmless — /tmp churns on machine restart)"
-    echo_ok "remote /tmp files removed"
+    if flyctl ssh console -a "$FLY_APP" -C "rm -f /tmp/snap.sqlite /tmp/snap.vec.npz"; then
+        echo_ok "remote /tmp files removed"
+    else
+        echo_warn "remote cleanup failed (harmless — /tmp churns on machine restart)"
+    fi
 
     # Quick sanity: count live memories + verify vec.npz is loadable
     local live_count vec_count


### PR DESCRIPTION
## Summary

Two bugs in `cmd_snapshot` caught on first real prod-snapshot run:

### Bug 1: flyctl ssh -C doesn't interpret shell operators

`flyctl ssh console -a X -C "cp A B && echo done"` execs the command directly without a `sh -c` wrapper. So `&&` and following tokens become literal args to `cp`:

```
cp /data/default.vec.npz /tmp/snap.vec.npz "vec copy done"
   └─ cp tried to use "vec copy done" as a destination directory
```

The python -c command in Step 1 (sqlite backup) worked fine because it was a single command + single quoted arg — no shell operators involved.

**Fix:** drop the `&& echo X` confirmation from Step 2's cp invocation. Single command only. If chaining is needed in future, wrap in `sh -c "..."` explicitly.

### Bug 2: success message printed unconditionally even on failure

```bash
flyctl ... -C "cp ..." || echo_warn "...failed..."
echo_ok "remote ... written"      # ← runs ALWAYS, including on failure
```

Resulted in contradictory output during the live run:

```
⚠ remote vecstore copy failed — embedding signals will be zero
✓ remote /tmp/snap.vec.npz written        ← false!
```

**Fix:** switch from `cmd || warn` (followed by unconditional ok) to `if cmd; then ok; else warn; fi`. Applied to Step 2 (vec copy) AND Step 4 (remote cleanup) — same pattern bug at both sites.

## After this fix

```bash
git checkout main && git pull
scripts/salience_phase0.sh snapshot
```

Expected output:
- Step 2: `✓ remote /tmp/snap.vec.npz written` (and ONLY this line — no contradictory warn)
- Step 3: `downloaded sqlite=8036352B vec.npz=~3000000B`
- Result block: `Vectors: ~2433` (matching `Live memories: 2433`)

Then `scripts/salience_phase0.sh score` will use the embedding signals (constraint_score, time_penalty) as designed — picks should look fundamentally different from the all-zeros-c-and-tp output you saw.

## Verified

- `bash -n` clean
- Locally can't test flyctl interaction directly — but the cp command is now a single execv-style call, matching the working Step 1 python -c pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)