### PR TITLE
chore(version): bump 0.6.0 → 0.7.0rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.7.0] - Unreleased
+## [0.7.0rc1] - 2026-05-22
 
 ### Fixes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.6.0"
+version = "0.7.0rc1"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0rc1"


### PR DESCRIPTION
## Summary

3-line version bump sealing the 2026-05-22 substrate arc:
- #153 capture-attention Phase A (recurrence-weighted preserve+relate+boost)
- #154 salience-tier Phase 1 (first-class standing tier, +3 MCP tools)
- #155 \`build_standing_set.py\` exemplar bias fix

Both new feature paths gated default-off (\`CAPTURE_ATTENTION_ENABLED\`, \`STANDING_TIER_ENABLED\`) — operator flips per the soak workflow post-redeploy.

## Diff

\`\`\`
 CHANGELOG.md           | 2 +-
 pyproject.toml         | 2 +-
 src/mnemon/__init__.py | 2 +-
\`\`\`

Mirrors the PR #77 / #86 / #128 3-line bump pattern. Version reads 0.7.0rc1 everywhere; \`mnemon --version\` returns 0.7.0rc1; suite 836 passing.

## Post-merge ritual

1. \`git tag v0.7.0rc1 && git push origin v0.7.0rc1\`
2. \`gh release create v0.7.0rc1 --notes-from-tag\` (or CHANGELOG entry as body)
3. \`.venv/bin/python -m build && .venv/bin/twine upload dist/mnemon-memory-0.7.0rc1*\`
4. \`mnemon upgrade web --app-name mnemon-memory --mnemon-version 0.7.0rc1\`  (operator-driven)
5. \`mnemon doctor\` 7/7 against live remote
6. Operator activates Phase 1 standing tier per soak workflow:
   - Promote 5 career memories via \`memory_promote\` MCP tool: ids 2543, 2084, 131, 2402, 2401
   - \`export MNEMON_STANDING_TIER_ENABLED=true\` in Claude Code launching shell
   - Verify \`## Standing context\` sub-section in \`<mnemon-context>\`
   - Soak ≥1 week

## Test plan

- [x] \`mnemon --version\` returns \`0.7.0rc1\`
- [x] Full suite 836 passing
- [ ] Post-merge: fresh-venv install test against PyPI artifact
- [ ] Post-redeploy: \`mnemon doctor\` 7/7 against live Fly

🤖 Generated with [Claude Code](https://claude.com/claude-code)