### PR TITLE
chore(version): bump 0.7.0rc2 → 0.7.0rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.7.0] - Unreleased
+## [0.7.0rc3] - 2026-05-22
 
 ### Test coverage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.7.0rc2"
+version = "0.7.0rc3"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.0rc2"
+__version__ = "0.7.0rc3"


### PR DESCRIPTION
## Summary

3-line version bump rolling the test-trio into a soak-substrate release:

- **#158** — every-MCP-tool integration canary (Python-level)
- **#159** — `[server]`-extras CI matrix + `layer3 --exercise-all-tools` (deployment + Fly-level)
- **#160** — coverage gate at 80% + README badge (86% baseline)

Composes with the prior 0.7.0rc2 features (NLI-based contradiction detection, `dry_run` flag). After PyPI publish + Fly redeploy, **this is the version operators should run the Phase 1 standing-tier soak on** per Brian's "all known bugs fixed before soak" standard.

## Diff

```
 CHANGELOG.md           | 2 +-
 pyproject.toml         | 2 +-
 src/mnemon/__init__.py | 2 +-
```

Mirrors the PR #77 / #86 / #128 / #156 3-line bump pattern.

## Post-merge ritual

1. `git tag v0.7.0rc3 && git push origin v0.7.0rc3`
2. `gh release create v0.7.0rc3 --notes-from-tag --prerelease`
3. `python -m build` → `dist/mnemon_memory-0.7.0rc3.{tar.gz,whl}`
4. **`twine upload dist/mnemon_memory-0.7.0rc3*`** (operator hands — auto-mode classifier blocks; happy to retry if a permission rule has since been added)
5. **`mnemon upgrade web --app-name mnemon-memory --mnemon-version 0.7.0rc3`** (operator — Fly auth)
6. `mnemon doctor` 7/7 verify
7. Optional: `scripts/promote_stable.sh layer3 --exercise-all-tools` against a test Fly app (~15 min, validates the new Fly-level probe end-to-end on a real upgrade)

## Then soak

1. From claude.ai / Desktop: `memory_demote 131` + `memory_demote 2402` (clean the standing-tier set per the 8:38 AM audit)
2. `memory_list_standing` → expect 3/15: #2543 + #2401 + #2084
3. In a fresh terminal: `export MNEMON_STANDING_TIER_ENABLED=true`
4. Fresh Claude Code session → confirm `## Standing context (always-on; …)` sub-section is present
5. Begin ≥1 week soak

## Test plan

- [x] `mnemon --version` returns `0.7.0rc3`
- [x] Full suite 855 passing
- [x] Coverage 86% (above the new 80% CI gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)