### PR TITLE
feat(salience): Phase 1 default-on — STANDING_TIER_ENABLED True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [Unreleased]
+
+### Salience tier — Phase 1 default-on
+
+- **`config.STANDING_TIER_ENABLED` flipped to `True`.** Phase 1
+  standing-tier soak passed: activated 2026-05-22 with 3 promoted
+  memories (#2543 composite runway / #2401 recruiter posture / #2084
+  severance), observed ~5 days with no runway-style under-weighting
+  recurrence. Standing-tier injection is now on by default; operators
+  who want to opt out can still set `MNEMON_STANDING_TIER_ENABLED=0`.
+  Note: capture-attention Phase A (`CAPTURE_ATTENTION_ENABLED`) stays
+  default-off — its soak surfaced an over-firing defect (boost-rate
+  0.714 vs 0.25 ceiling) that requires a candidate-filter fix + a
+  re-calibration on live-traffic distribution before re-soak.
+
 ## [0.7.0rc4] - 2026-05-24
 
 ### Capture-attention Phase A — activation infrastructure

--- a/src/mnemon/config.py
+++ b/src/mnemon/config.py
@@ -120,11 +120,12 @@ CAPTURE_ATTENTION_SOAK_BOOST_RATE_MAX = 0.25    # acceptance criterion: boosts/s
 # similarity, conditioning reasoning rather than answering it. The cap
 # is the contract: past ~20, salience degrades and the tier becomes
 # noise again, recreating the failure mode at a different scale.
-# Default-off through soak per the 2026-05-22 reframing — Phase 1 ships
-# the substrate gated; promote ≤5 career-context memories via the new
-# memory_promote MCP tool; flip the flag; observe ≥1 week soak for
-# runway-style under-weighting recurrence vs absence.
-STANDING_TIER_ENABLED = False                   # feature flag — flip after soak
+# Default-on since 2026-05-27 — Phase 1 soak passed (activated 2026-05-22
+# with 3 promoted memories: #2543 / #2401 / #2084; ~5 day window with no
+# runway-style under-weighting recurrence). Env-var override
+# (MNEMON_STANDING_TIER_ENABLED) remains available for operators who want
+# to opt out without a code change.
+STANDING_TIER_ENABLED = True                    # default-on; env-var override remains
 STANDING_TIER_DEFAULT_CAP = 15                  # operator-tunable runtime cap
 STANDING_TIER_HARD_CEILING = 20                 # invariant — never exceed
 # Reuse Layer 4 hook-sourced set: hook-sourced memories cannot be promoted —

--- a/tests/test_hooks_extended.py
+++ b/tests/test_hooks_extended.py
@@ -582,7 +582,10 @@ class TestContextSurfacingMain:
         ) as mock_write, patch(
             "mnemon.hooks._remote_client.call_tool_sync",
             return_value=(raw_tool_output, 0.5),
-        ) as mock_call:
+        ) as mock_call, patch(
+            "mnemon.hooks.context_surfacing._standing_tier_enabled",
+            return_value=False,
+        ):
             main()
 
         mock_call.assert_called_once()


### PR DESCRIPTION
## Summary

Phase 1 standing-tier soak passed — flipping `config.STANDING_TIER_ENABLED` from `False` to `True`.

- **Soak window:** activated 2026-05-22 with 3 operator-promoted memories (#2543 composite runway / #2401 recruiter posture / #2084 severance). Observed ~5 days; no runway-style under-weighting recurrence in operator-facing experience.
- **Opt-out preserved:** `MNEMON_STANDING_TIER_ENABLED=0` env-var override still flips it off at request time without a code change.
- **Note:** capture-attention Phase A (`CAPTURE_ATTENTION_ENABLED`) stays default-off. Its parallel soak surfaced an over-firing defect — boost-rate 232/325 = 0.714 vs the 0.25 ceiling, with session-handoff fragments being treated as canonicals. That fix is tracked in a separate PR + ROADMAP entry; not bundled here so the standing-tier flip ships clean.

## Test plan

- [x] Full suite green: `PYTHONPATH=src pytest` → 873 passed
- [x] `tests/test_standing_tier.py` (22 tests, all explicit-monkeypatch) — unaffected by the default change
- [x] `tests/test_hooks_extended.py::test_full_pipeline_calls_remote_and_emits_context` updated to patch `_standing_tier_enabled=False` so its single-call assertion on `memory_search` isn't affected by the flip
- [ ] Post-merge: verify `## Standing context (always-on; …)` block continues to render in fresh Claude Code sessions without the operator needing to export `MNEMON_STANDING_TIER_ENABLED=true`