### PR TITLE
fix(capture-attention): hook-source provenance gate — early-return on HOOK_SOURCE_CLIENTS saves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,30 @@
   who want to opt out can still set `MNEMON_STANDING_TIER_ENABLED=0`.
   Note: capture-attention Phase A (`CAPTURE_ATTENTION_ENABLED`) stays
   default-off — its soak surfaced an over-firing defect (boost-rate
-  0.714 vs 0.25 ceiling) that requires a candidate-filter fix + a
-  re-calibration on live-traffic distribution before re-soak.
+  0.714 vs 0.25 ceiling); the candidate-filter half of that fix lands
+  in the section below; a live-traffic threshold re-calibration + fresh
+  ≥1 week re-soak gate the eventual default-on flip.
+
+### Capture-attention — hook-source provenance gate
+
+- **`Store.apply_capture_attention()` early-returns when the saving
+  doc's `source_client` is in `HOOK_SOURCE_CLIENTS`.** Mirrors the
+  existing Layer 4 demotion + `STANDING_TIER_BLOCKED_SOURCE_CLIENTS`
+  policy: the same provenance set that's capped at
+  `HOOK_SOURCE_CONFIDENCE_CEILING` at save and demoted by
+  `PROVENANCE_DEMOTION_FACTOR` at recall — and forbidden from
+  standing-tier promotion — also cannot drive capture-attention
+  boosts. Surfaced 2026-05-27 by the Phase A soak: boost-rate hit
+  232/325 = 0.714 vs the documented 0.25 ceiling, with canonicals
+  like "Session: pr merged, continue" — session_extractor hook output
+  self-boosting. The gate restores the mechanism to its intent
+  (consolidate operator-authored signal, not session noise).
+- **2 new regression tests** (`TestHookSourcedSaveSkipped`):
+  hook-sourced saves must not emit `'restates'` relations or
+  increment `recurrence_count` on neighbors; user-authored saves
+  with hook-sourced neighbors continue to fire (the defense is
+  one-sided on purpose — consolidating operator signal against
+  hook-source echoes is still valid).
 
 ## [0.7.0rc4] - 2026-05-24
 

--- a/src/mnemon/store.py
+++ b/src/mnemon/store.py
@@ -758,6 +758,28 @@ class Store:
         vecstore is unreachable. Callers in best-effort paths
         (session_extractor, auto_mirror) must catch + log + continue.
         """
+        # Hook-source provenance gate. Hook-sourced saves are best-effort
+        # transcripts of a chat session, not deliberate operator
+        # assertions — already capped at HOOK_SOURCE_CONFIDENCE_CEILING
+        # and demoted by PROVENANCE_DEMOTION_FACTOR at recall. Letting
+        # them drive capture-attention means "the hook-extractor recorded
+        # N echoes of session noise; boost the first echo," which is the
+        # inverse of the mechanism's intent (consolidate operator signal).
+        # Composes with Layer 4 (PR #126) + STANDING_TIER_BLOCKED_SOURCE_CLIENTS:
+        # the same provenance set that can't be promoted to standing tier
+        # also can't drive an auto-boost.
+        #
+        # Surfaced 2026-05-27 — Phase A soak boost-rate hit 232/325 = 0.714
+        # (ceiling 0.25); canonicals were "Session: pr merged, continue"
+        # handoff fragments. Skipping here brings firing back to the
+        # operator-authored signal the mechanism was designed for.
+        if source_client in HOOK_SOURCE_CLIENTS:
+            return {
+                "fired": False, "canonical_id": None,
+                "neighbors": [], "boost_applied": 0.0,
+                "reason": "hook_sourced_save",
+            }
+
         # Lazy import — keep store.py module-load cheap; FastEmbed's
         # ONNX model only materializes on first embed() call anyway.
         try:

--- a/tests/test_capture_attention.py
+++ b/tests/test_capture_attention.py
@@ -338,6 +338,87 @@ class TestHookCeiling:
                 f"doc {doc_id} confidence {row['confidence']} exceeded hook ceiling"
 
 
+class TestHookSourcedSaveSkipped:
+    """Regression for 2026-05-27 Phase A soak failure (boost-rate 0.714
+    vs 0.25 ceiling). Hook-sourced saves are best-effort transcripts of
+    chat sessions — the same provenance set that's blocked from
+    standing-tier promotion. They must NOT drive capture-attention,
+    otherwise session-handoff fragments inflate confidence on
+    near-neighbors (e.g. "Session: pr merged, continue" patterns
+    self-boosting via the session_extractor hook)."""
+
+    def test_hook_sourced_save_does_not_trigger_capture_attention(
+        self, store, attention_on
+    ):
+        """Two user-authored priors at distinct dates would normally
+        trigger. Saving a hook-sourced new doc with the same embedding
+        must NOT create 'restates' relations or increment
+        recurrence_count — the gate fires upstream."""
+        with patch("mnemon.embedder.embed", _fake_embed_constant):
+            id1 = store.save(title="A", content="content one")
+            _index_with(store, id1, "content one", _fake_embed_constant)
+            _set_created_at(store, id1, days_ago=5)
+
+            id2 = store.save(title="B", content="content two")
+            _index_with(store, id2, "content two", _fake_embed_constant)
+            _set_created_at(store, id2, days_ago=3)
+
+            # Hook-sourced save — should be filtered out at the gate.
+            id3 = store.save(
+                title="Session: something extracted",
+                content="content three",
+                source_client="claude-code-hook",
+            )
+
+        # No 'restates' relations from id3 → priors.
+        rels = store.db.execute(
+            "SELECT * FROM relations WHERE source_id = ?", (id3,)
+        ).fetchall()
+        assert len(rels) == 0, "hook-sourced save must not emit restates"
+
+        # Neither prior had its recurrence_count incremented.
+        counts = store.db.execute(
+            "SELECT SUM(recurrence_count) AS s FROM documents "
+            "WHERE id IN (?, ?)",
+            (id1, id2),
+        ).fetchone()
+        assert counts["s"] == 0, (
+            "hook-sourced save must not boost a canonical's recurrence_count"
+        )
+
+    def test_user_save_still_triggers_against_hook_sourced_neighbors(
+        self, store, attention_on
+    ):
+        """Defense isn't symmetric: an OPERATOR save with hook-sourced
+        neighbors still fires (operator-authored signal is the intent).
+        This guards against an over-aggressive future tightening that
+        would also exclude hook-source neighbors and lose the
+        consolidation signal entirely."""
+        with patch("mnemon.embedder.embed", _fake_embed_constant):
+            id1 = store.save(
+                title="Session A", content="content one",
+                source_client="claude-code-hook",
+            )
+            _index_with(store, id1, "content one", _fake_embed_constant)
+            _set_created_at(store, id1, days_ago=5)
+
+            id2 = store.save(
+                title="Session B", content="content two",
+                source_client="claude-code-hook",
+            )
+            _index_with(store, id2, "content two", _fake_embed_constant)
+            _set_created_at(store, id2, days_ago=3)
+
+            # User save → should trigger; hook-source ceiling caps the
+            # boost on the canonical, but the trigger itself fires.
+            id3 = store.save(title="User assertion", content="content three")
+
+        rels = store.db.execute(
+            "SELECT * FROM relations WHERE source_id = ?", (id3,)
+        ).fetchall()
+        assert len(rels) == 2, "user save must trigger against hook-source neighbors"
+
+
 class TestUserUncapped:
     def test_user_canonical_can_exceed_hook_ceiling(self, store, attention_on):
         """User-authored canonical (source_client=None) can be boosted


### PR DESCRIPTION
## Summary

Phase A soak surfaced a noise-floor failure: **boost-rate 232/325 = 0.714** vs the documented `CAPTURE_ATTENTION_SOAK_BOOST_RATE_MAX = 0.25` ceiling. Top canonicals were session-handoff fragments self-boosting via the session_extractor hook:

```
# 2396  ×3  conf=0.59  Session: pr merged, continue on success
# 2558  ×2  conf=0.59  Session: should we go ahead and make these fixes now?
# 2675  ×2  conf=0.59  Session: pr merged, continue
```

Root cause: `Store.apply_capture_attention()` was firing on `source_client in HOOK_SOURCE_CLIENTS` saves. Capture-attention's intent is to consolidate operator-authored signal — but the same provenance set that gets capped at `HOOK_SOURCE_CONFIDENCE_CEILING` at save, demoted by `PROVENANCE_DEMOTION_FACTOR` at recall, and blocked from standing-tier promotion was driving auto-boosts. Incoherent across the stack.

## Fix

- `apply_capture_attention()` early-returns with `reason="hook_sourced_save"` when the saving doc is hook-sourced. Composes with Layer 4 (PR #126) + `STANDING_TIER_BLOCKED_SOURCE_CLIENTS`: same set, same policy.
- **The gate is one-sided on purpose.** A user-authored save with hook-sourced neighbors still fires — operator consolidation against hook-source echoes is exactly the mechanism's intent, and the hook-source CEILING already caps boost on the resulting canonical. A regression test locks this behavior so a future over-tightening doesn't silently drop the signal.

## Test plan

- [x] Full suite: 873 → **875** passed (+2 new regression tests)
- [x] `TestHookSourcedSaveSkipped::test_hook_sourced_save_does_not_trigger_capture_attention` — hook-source save with two valid neighbors emits zero relations, zero recurrence increments
- [x] `TestHookSourcedSaveSkipped::test_user_save_still_triggers_against_hook_sourced_neighbors` — operator-authored save still fires against hook-source neighbors
- [x] Existing `TestHookCeiling::test_hook_canonical_capped_at_hook_ceiling` still passes (user-authored trigger saves still boost a hook-source canonical, capped at the ceiling)

## Out of scope (filed as follow-ups)

- **Re-calibrate `CAPTURE_ATTENTION_THRESHOLD` on live-traffic distribution.** The 0.85 was tuned on operator-tagged near-neighbor pairs from a static 2026-05-24 snapshot; live `session_extractor` output has a different distribution than the calibration sampled. Once the gate lands, re-run `scripts/calibrate_capture_threshold.py` with anchors sampled from the last 7 days of saves.
- **Re-soak before flipping `CAPTURE_ATTENTION_ENABLED` default-on.** Acceptance criterion stays `boost_rate ≤ 0.25` over a fresh ≥1 week window post-fix. Flag stays default-off until that closes green.

Both filed in `private/ROADMAP.md` as part of the wind-down.