### PR TITLE
chore(version): bump 0.7.0rc4 → 0.7.0rc5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.7.0rc5] - 2026-05-27
 
 ### Salience tier — Phase 1 default-on
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.7.0rc4"
+version = "0.7.0rc5"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.0rc4"
+__version__ = "0.7.0rc5"


### PR DESCRIPTION
## Summary

Release bump to ship the two soak-closure PRs to PyPI + Fly:

- **#164** `feat(salience): Phase 1 default-on — STANDING_TIER_ENABLED True` (merged)
- **#165** `fix(capture-attention): hook-source provenance gate — early-return on HOOK_SOURCE_CLIENTS saves` (merged)

3-line bump per the established pattern:
- `pyproject.toml` version field
- `src/mnemon/__init__.py` `__version__`
- `CHANGELOG.md` header seal (`[Unreleased]` → `[0.7.0rc5] - 2026-05-27`); entry bodies unchanged

## Test plan

- [x] Suite: 875 passed (no change vs rc4 baseline post-#165)
- [x] `mnemon --version` returns `0.7.0rc5`
- [ ] Post-merge (user-only): `twine upload` to PyPI
- [ ] Post-merge (user-only): `mnemon upgrade web --app-name mnemon-memory --mnemon-version 0.7.0rc5`
- [ ] Post-merge: `mnemon doctor` 7/7 against live remote
- [ ] Post-merge: tag `v0.7.0rc5` + GitHub Release
- [ ] Post-merge: verify `## Standing context (always-on; …)` block continues to render in fresh Claude Code sessions WITHOUT `MNEMON_STANDING_TIER_ENABLED=true` exported (the flag flip's behavioral test)
- [ ] Post-merge: verify `mnemon attention-status` on Fly shows boost-rate dropping toward 0 over the first ~24h (hook-source filter's behavioral test — without it the rate would re-climb toward the 0.714 baseline)

## What this unblocks

Starts the **Phase A re-soak clock** (ROADMAP P0 gate): ≥1 week window with `boost_rate ≤ 0.25` post-filter, then a live-traffic threshold re-calibration, then flip `CAPTURE_ATTENTION_ENABLED` default-on in a follow-up PR.

Standing-tier (Phase 1) is already default-on as of this RC — env-var opt-out remains via `MNEMON_STANDING_TIER_ENABLED=0`.