### PR TITLE
chore: batch A polish — 4 ROADMAP quick-wins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,16 @@ RUN python -c "from fastembed import TextEmbedding; TextEmbedding(model_name='BA
 # Without this, the first contradiction check pays a 5-15 second
 # download cost AND risks Anthropic's MCP-proxy timeout on the call.
 # Model lives in /app/.cache/huggingface (default HF cache root).
+#
+# NLI cache resolution (audit 2026-05-27): nli.py:_model_dir() reads
+# MNEMON_NLI_MODEL_DIR with a default of ~/.cache/huggingface/hub.
+# HF_HOME=/app/.cache/huggingface (set here) is the huggingface_hub
+# library's own cache-root convention; with HOME=/root the two paths
+# coincide at /app/.cache/huggingface/hub via hf_hub's internal
+# resolution. If a future operator needs to override the location,
+# set BOTH env vars (HF_HOME for the hf_hub download path AND
+# MNEMON_NLI_MODEL_DIR for the runtime load path) to avoid a
+# silent-divergence trap.
 ENV HF_HOME=/app/.cache/huggingface
 RUN python -c "from huggingface_hub import hf_hub_download; \
     hf_hub_download(repo_id='cross-encoder/nli-deberta-v3-xsmall', filename='onnx/model_qint8_avx512.onnx'); \

--- a/scripts/calibrate_capture_threshold.py
+++ b/scripts/calibrate_capture_threshold.py
@@ -37,6 +37,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 FIXTURE_PATH = REPO_ROOT / "tests" / "fixtures" / "capture_attention_pairs.json"
+FIXTURE_EXAMPLE_PATH = REPO_ROOT / "tests" / "fixtures" / "capture_attention_pairs.example.json"
 DEFAULT_DB = "/tmp/mnemon-prod-snap.sqlite"
 DEFAULT_N = 20
 THRESHOLDS = (0.70, 0.75, 0.80, 0.85, 0.90)
@@ -242,9 +243,22 @@ def main() -> int:
     args = parser.parse_args()
 
     if args.use_fixture:
-        if not FIXTURE_PATH.exists():
-            sys.exit(f"no fixture at {FIXTURE_PATH} — drop --use-fixture")
-        tagged = json.loads(FIXTURE_PATH.read_text())
+        # Operator output fixture is gitignored (see 2026-05-24 privacy
+        # hardening — real titles + snippets must not land in the repo).
+        # Fall back to the tracked .example.json template so a fresh-clone
+        # run can still exercise the recompute path. P3 follow-up filed
+        # 2026-05-24, closed 2026-05-27.
+        if FIXTURE_PATH.exists():
+            tagged = json.loads(FIXTURE_PATH.read_text())
+        elif FIXTURE_EXAMPLE_PATH.exists():
+            print(f"# {FIXTURE_PATH.name} not present — falling back to "
+                  f"{FIXTURE_EXAMPLE_PATH.name}", file=sys.stderr)
+            tagged = json.loads(FIXTURE_EXAMPLE_PATH.read_text())
+        else:
+            sys.exit(
+                f"no fixture at {FIXTURE_PATH} or {FIXTURE_EXAMPLE_PATH} "
+                "— drop --use-fixture"
+            )
     else:
         db_path = Path(args.db)
         if not db_path.exists():

--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -305,11 +305,14 @@ def main() -> None:
         # Capture attention Phase A observability — soak monitor.
         # private/mnemon-capture-attention-plan-260522.md
         from .store import Store
+        strict = "--strict" in args[1:]
         store = Store()
         try:
-            _print_attention_status(store)
+            rate, ceiling = _print_attention_status(store)
         finally:
             store.close()
+        if strict and rate > ceiling:
+            sys.exit(1)
 
     elif command == "standing":
         # Salience tier Phase 1 — operator-facing tier management.
@@ -405,12 +408,15 @@ def _handle_standing(subcommand: str, rest: list[str]) -> None:
         store.close()
 
 
-def _print_attention_status(store) -> None:
+def _print_attention_status(store) -> tuple[float, float]:
     """Print capture-attention soak metrics for the operator.
 
     Surfaces the two acceptance criteria from the plan-doc:
       1. boost_rate = (boosts in last 7d) / (saves in last 7d) ≤ 0.25
       2. precision floor (operator-judged via --review, not auto-checked)
+
+    Returns ``(boost_rate, ceiling)`` so a caller can drive --strict
+    exit codes without re-running the SQL.
     """
     from .config import (
         CAPTURE_ATTENTION_THRESHOLD,
@@ -479,6 +485,8 @@ def _print_attention_status(store) -> None:
             print(f"    {r['created_at']}  "
                   f"#{r['source_id']:>5} → #{r['target_id']:>5}  "
                   f"w={r['weight']:.3f}")
+
+    return rate, CAPTURE_ATTENTION_SOAK_BOOST_RATE_MAX
 
 
 def _parse_upgrade_args(args: list[str]) -> dict:
@@ -615,6 +623,8 @@ Local vault (development/server-side only):
   mnemon attention-status   Capture-attention soak monitor — boost rate,
                             recurrence distribution, top canonicals,
                             recent 'restates' relations
+                            [--strict: exit 1 if boost-rate > ceiling,
+                            for periodic health-check wiring]
 
 Salience tier (standing-context recall):
   mnemon standing list      Show all standing-tier memories + count vs cap

--- a/src/mnemon/hooks/context_surfacing.py
+++ b/src/mnemon/hooks/context_surfacing.py
@@ -48,6 +48,28 @@ SEARCH_LIMIT = 8
 # content length.
 _SNIPPET_CHARS = 300
 
+
+def _balance_bold(snippet: str) -> str:
+    """Strip a dangling ``**`` if the snippet has an odd count.
+
+    The 300-char slice can land mid-``**bold**``, leaving an unclosed
+    marker. Downstream markdown renderers then emit ``</n>`` or similar
+    artifacts where the closing tag should be. Cheapest robust form:
+    when ``**`` count is odd, truncate the snippet at the last ``**``
+    so the rendered output ends cleanly without dangling emphasis.
+
+    Examples:
+      "foo **bar"      → "foo "
+      "foo **bar**"    → "foo **bar**"     (unchanged — balanced)
+      "foo **bar** baz **q" → "foo **bar** baz "
+    """
+    if snippet.count("**") % 2 == 0:
+        return snippet
+    last = snippet.rfind("**")
+    if last == -1:  # paranoia — odd count without finding ** is impossible
+        return snippet
+    return snippet[:last].rstrip()
+
 # Layer 1 (stored-injection defense) — spotlighting / data-marking.
 # Recalled memory content is untrusted input replayed into a privileged
 # context. Layers 0/2/4 reduce what reaches here and neutralize the
@@ -134,7 +156,7 @@ def _fetch_standing_via_mcp() -> str:
         content = str(d.get("content", ""))
         content_type = str(d.get("content_type", "note"))
         doc_id = d.get("doc_id", "?")
-        snippet = defang_control_markup(content[:_SNIPPET_CHARS])
+        snippet = _balance_bold(defang_control_markup(content[:_SNIPPET_CHARS]))
         ellipsis = "..." if len(content) > _SNIPPET_CHARS else ""
         lines.append(
             f"- [{content_type}] **{title}** (id={doc_id})\n"
@@ -219,7 +241,7 @@ def _fetch_standing_block(ids: list[int]) -> str:
         title = defang_control_markup(str(data.get("title", "")))
         content = str(data.get("content", ""))
         content_type = str(data.get("content_type", "note"))
-        snippet = defang_control_markup(content[:_SNIPPET_CHARS])
+        snippet = _balance_bold(defang_control_markup(content[:_SNIPPET_CHARS]))
         ellipsis = "..." if len(content) > _SNIPPET_CHARS else ""
         lines.append(
             f"- [{content_type}] **{title}** (id={doc_id})\n"
@@ -237,7 +259,7 @@ def _format_results(results: list[dict]) -> str:
     lines: list[str] = []
     for i, r in enumerate(results, 1):
         content = r.get("content", "")
-        snippet = defang_control_markup(content[:_SNIPPET_CHARS])
+        snippet = _balance_bold(defang_control_markup(content[:_SNIPPET_CHARS]))
         ellipsis = "..." if len(content) > _SNIPPET_CHARS else ""
         lines.append(
             f"{i}. [{r.get('content_type', 'note')}] "

--- a/src/mnemon/nli.py
+++ b/src/mnemon/nli.py
@@ -64,7 +64,15 @@ _init_lock: Any = None
 def _model_dir() -> Path:
     """Where downloaded NLI files live. Honors ``MNEMON_NLI_MODEL_DIR``
     so an operator can point at a baked-in location (e.g., the Fly
-    image's ``/app/.cache/huggingface``)."""
+    image's ``/app/.cache/huggingface``).
+
+    Cache resolution interacts with ``HF_HOME`` (set on Fly to
+    ``/app/.cache/huggingface``): the huggingface_hub library writes
+    its downloads under ``{HF_HOME}/hub``; this function's default
+    resolves to ``$HOME/.cache/huggingface/hub`` which coincides
+    with the HF_HOME path when HOME=/root. Override both env vars
+    together if you need to point at a non-default location — see
+    the audit comment in ``Dockerfile`` (2026-05-27)."""
     return Path(os.environ.get(
         "MNEMON_NLI_MODEL_DIR",
         Path.home() / ".cache" / "huggingface" / "hub",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -611,3 +611,47 @@ class TestUnknownCommand:
         combined = capsys.readouterr()
         assert "Unknown command: badcmd" in combined.err
         assert "mnemon setup" in combined.out
+
+
+class TestAttentionStatusStrict:
+    """Regression: --strict exits 1 when boost-rate > ceiling so the
+    soak gate can drive periodic health checks. Without this, a soak
+    regression like 2026-05-27 (boost-rate hit 0.714) requires manual
+    eyeball during a "close the soak" prompt to surface."""
+
+    def test_default_exits_zero_even_when_over_ceiling(self):
+        with patch("mnemon.cli._print_attention_status") as mock_status:
+            mock_status.return_value = (0.714, 0.25)
+            with patch("mnemon.store.Store") as mock_store_cls:
+                mock_store_cls.return_value = MagicMock()
+                with patch("sys.argv", ["mnemon", "attention-status"]):
+                    # Default mode = print + return 0 even when over ceiling.
+                    main()
+
+    def test_strict_exits_one_when_over_ceiling(self):
+        with patch("mnemon.cli._print_attention_status") as mock_status:
+            mock_status.return_value = (0.714, 0.25)
+            with patch("mnemon.store.Store") as mock_store_cls:
+                mock_store_cls.return_value = MagicMock()
+                with patch("sys.argv", ["mnemon", "attention-status", "--strict"]):
+                    with pytest.raises(SystemExit) as exc_info:
+                        main()
+        assert exc_info.value.code == 1
+
+    def test_strict_exits_zero_when_under_ceiling(self):
+        with patch("mnemon.cli._print_attention_status") as mock_status:
+            mock_status.return_value = (0.12, 0.25)
+            with patch("mnemon.store.Store") as mock_store_cls:
+                mock_store_cls.return_value = MagicMock()
+                with patch("sys.argv", ["mnemon", "attention-status", "--strict"]):
+                    # Under-ceiling rate → exits 0 (no SystemExit raised).
+                    main()
+
+    def test_strict_exits_zero_at_exact_ceiling(self):
+        """Boundary: rate == ceiling is still passing (≤, not <)."""
+        with patch("mnemon.cli._print_attention_status") as mock_status:
+            mock_status.return_value = (0.25, 0.25)
+            with patch("mnemon.store.Store") as mock_store_cls:
+                mock_store_cls.return_value = MagicMock()
+                with patch("sys.argv", ["mnemon", "attention-status", "--strict"]):
+                    main()

--- a/tests/test_hooks_extended.py
+++ b/tests/test_hooks_extended.py
@@ -472,6 +472,40 @@ class TestBuildContext:
         assert "[truncated]" not in ctx
 
 
+class TestBoldBalance:
+    """Regression for the </n> rendering artifact: 300-char truncation
+    can land mid-**bold**, leaving a dangling ** that downstream
+    markdown handling translates to garbage. _balance_bold strips the
+    last unmatched ** when the count is odd."""
+
+    def test_balanced_pattern_unchanged(self):
+        from mnemon.hooks.context_surfacing import _balance_bold
+
+        assert _balance_bold("foo **bar** baz") == "foo **bar** baz"
+
+    def test_no_emphasis_unchanged(self):
+        from mnemon.hooks.context_surfacing import _balance_bold
+
+        assert _balance_bold("plain content with no markdown") == \
+            "plain content with no markdown"
+
+    def test_single_dangling_open_stripped(self):
+        from mnemon.hooks.context_surfacing import _balance_bold
+
+        assert _balance_bold("foo **bar") == "foo"
+
+    def test_mid_truncation_with_prior_balanced_pair(self):
+        from mnemon.hooks.context_surfacing import _balance_bold
+
+        # "foo **bar** baz **q" — first pair balanced, trailing ** dangles.
+        assert _balance_bold("foo **bar** baz **q") == "foo **bar** baz"
+
+    def test_truncation_trailing_whitespace_stripped(self):
+        from mnemon.hooks.context_surfacing import _balance_bold
+
+        assert _balance_bold("foo **") == "foo"
+
+
 # ── context_surfacing.py: Layer 1 spotlight envelope ──────────────────────────
 
 


### PR DESCRIPTION
## Summary

First polish batch from the pre-Phase-A-re-soak ROADMAP audit (2026-05-27). Four commits, all independent, all small, all under ~30 lines diff each:

| Commit | What |
|---|---|
| `feat(attention-status): --strict exit-code mode` | New `--strict` flag exits 1 when boost-rate > ceiling, so a periodic health-check job can page automatically. Would have caught 2026-05-27's 0.714 boost-rate days earlier. 4 regression tests. |
| `fix(context-surfacing): balance dangling **` | 300-char snippet truncation can land mid-`**bold**`; strip the unmatched marker at all three render sites (`memory_list_standing`, `memory_get` standing-fallback, `memory_search` situational). Closes 2026-05-22 P3 `</n>` rendering artifact. 5 regression tests. |
| `fix(calibration): --use-fixture .example.json fallback` | `--use-fixture` only knew about the gitignored `.json`; fresh-clone runs fail. Falls back to tracked `.example.json` with stderr notice. Closes 2026-05-24 P3 follow-up from PR #162. Smoke-tested. |
| `docs(nli): document MNEMON_NLI_MODEL_DIR ⊥ HF_HOME` | Audit-only — verified Fly's dual-env-var path resolves cleanly today; added comments at both call sites so a future operator who needs to override the cache location sets BOTH together. Closes 2026-05-22 P2 follow-up. |

Plus two stale-checkboxes from the same audit, ticked in ROADMAP (no PR work needed): A5 ambiguous `mnemon uninstall` message (already reworded in a prior session), A6 shadow warning extension (already wired for Desktop; Cursor/Gemini don't sync MCP from claude.ai by design).

## Test plan

- [x] Suite: **884 passed** (was 875 pre-batch → +9 new regression tests)
- [x] `TestAttentionStatusStrict` (4 tests) — default mode, --strict over/under/at-ceiling
- [x] `TestBoldBalance` (5 tests) — balanced/no-emphasis/dangling-open/mid-truncation/trailing-whitespace
- [x] `scripts/calibrate_capture_threshold.py --use-fixture` smoke-tested with `.json` absent — fallback fires cleanly
- [x] Dockerfile + nli.py docstring comments line up

## Out of scope (separate PR)

- A7: vault-derived auto-exemplars in `build_standing_set.py` — algorithmic change, not polish. Coming next.