### PR TITLE
feat(standing-set): vault-derived auto-exemplars (--exemplar-source)

### DIFF
--- a/scripts/build_standing_set.py
+++ b/scripts/build_standing_set.py
@@ -172,6 +172,32 @@ W_TIME_PENALTY = 1.5
 DEFAULT_TOP_N = 10
 HARD_CEILING = 20  # plan invariant: never exceed 20
 
+# Vault-derived exemplars (added 2026-05-27 per ROADMAP P1).
+#
+# The hand-tuned CONSTRAINT_EXEMPLARS / TIME_BOUNDED_EXEMPLARS lists
+# encode the maintainer's prior beliefs about what "constraint shape"
+# and "time-bounded shape" look like. Real prototype-network design
+# samples the user's own vault for exemplars — high-confidence
+# preference/feedback memories represent durable constraints; recent
+# session-handoff memories represent ephemeral status updates.
+# Adapts per-user without hand-tuning maintenance.
+#
+# Defense-in-depth: by default we EXTEND the hand-tuned lists with
+# vault-derived exemplars rather than replacing — hand-tuned encode
+# general institutional patterns the vault may not yet contain; vault-
+# derived encode user-specific patterns the hand-tuned lists miss.
+# Operators can swap the strategy via --exemplar-source.
+VAULT_EXEMPLAR_DEFAULT_COUNT = 15
+VAULT_POSITIVE_CONFIDENCE_FLOOR = 0.80
+# Durable non-decaying SEMANTIC types (decision / preference / antipattern
+# per HALF_LIVES). Excludes observation/research/project/note: those
+# decay and represent context, not constraints.
+VAULT_POSITIVE_TYPES = ("decision", "preference", "antipattern")
+# Handoffs are session summaries — explicitly time-bounded (30d half-life,
+# 0.60 default confidence). The session_extractor hook produces these
+# automatically, so they're the natural negative anchor distribution.
+VAULT_NEGATIVE_TYPES = ("handoff",)
+
 # Minimum content length for standing-tier consideration. A 2-word
 # memory like "halt the run" or "propagate" technically scores via
 # breadth (FTS-matches many queries) but carries no actual constraint
@@ -206,6 +232,69 @@ def _normalize(scores: dict[int, float]) -> dict[int, float]:
     if hi == lo:
         return {k: 0.0 for k in scores}
     return {k: (v - lo) / (hi - lo) for k, v in scores.items()}
+
+
+def _sample_vault_exemplars(
+    conn: sqlite3.Connection, n: int = VAULT_EXEMPLAR_DEFAULT_COUNT,
+) -> tuple[list[str], list[str]]:
+    """Sample positive + negative exemplar texts from the vault itself.
+
+    Positive exemplars: highest-confidence ``preference`` / ``decision`` /
+    ``antipattern`` memories (≥ ``VAULT_POSITIVE_CONFIDENCE_FLOOR``).
+    These types are non-decaying SEMANTIC (per ``HALF_LIVES`` in
+    ``config.py``) — durable by content-type design. Pulled by
+    confidence DESC so the most-load-bearing user-authored constraints
+    anchor the positive class.
+
+    Negative exemplars: most recent ``handoff`` memories. These are
+    session summaries — explicitly time-bounded by both confidence
+    default (0.60) and half-life (30d). The session_extractor hook
+    produces them automatically, so they form a stable negative
+    distribution per vault.
+
+    Returns ``([positive_texts], [negative_texts])``. Each text is
+    ``"{title}: {content[:200]}"`` — title + snippet gives the
+    embedder enough signal to anchor the class without dominating.
+    Returns empty lists when the vault lacks material; caller decides
+    whether to fall back to the hand-tuned lists.
+    """
+    pos_types = ",".join(["?"] * len(VAULT_POSITIVE_TYPES))
+    pos_rows = conn.execute(
+        f"""
+        SELECT d.title, c.doc AS content
+        FROM documents d
+        JOIN content c ON d.hash = c.hash
+        WHERE d.invalidated_at IS NULL
+          AND d.content_type IN ({pos_types})
+          AND d.confidence >= ?
+        ORDER BY d.confidence DESC, d.id DESC
+        LIMIT ?
+        """,
+        (*VAULT_POSITIVE_TYPES, VAULT_POSITIVE_CONFIDENCE_FLOOR, n),
+    ).fetchall()
+
+    neg_types = ",".join(["?"] * len(VAULT_NEGATIVE_TYPES))
+    neg_rows = conn.execute(
+        f"""
+        SELECT d.title, c.doc AS content
+        FROM documents d
+        JOIN content c ON d.hash = c.hash
+        WHERE d.invalidated_at IS NULL
+          AND d.content_type IN ({neg_types})
+        ORDER BY d.created_at DESC
+        LIMIT ?
+        """,
+        (*VAULT_NEGATIVE_TYPES, n),
+    ).fetchall()
+
+    def _fmt(row) -> str:
+        title = (row["title"] or "").strip()
+        snippet = (row["content"] or "")[:200].strip()
+        if title and snippet:
+            return f"{title}: {snippet}"
+        return title or snippet
+
+    return [_fmt(r) for r in pos_rows], [_fmt(r) for r in neg_rows]
 
 
 def _correction_score(title: str, content: str, content_type: str, confidence: float) -> float:
@@ -339,6 +428,16 @@ def main() -> int:
                          f"(default: {DEFAULT_MIN_CONTENT_LENGTH}; set to 0 to disable). "
                          f"Filters out tiny noise memories like 'halt the run' / 'propagate' that "
                          f"FTS-match many queries but carry no actual constraint.")
+    ap.add_argument("--exemplar-source", choices=("hybrid", "vault", "hand-tuned"),
+                    default="hybrid",
+                    help="exemplar selection strategy: 'hybrid' (default) extends the "
+                         "hand-tuned lists with vault-sampled exemplars (defense-in-depth); "
+                         "'vault' uses only vault-sampled (falls back to hand-tuned on empty "
+                         "vault); 'hand-tuned' uses only the static lists (regression baseline).")
+    ap.add_argument("--vault-exemplar-count", type=int, default=VAULT_EXEMPLAR_DEFAULT_COUNT,
+                    help=f"how many vault exemplars to sample per class (positive + negative) "
+                         f"when --exemplar-source ∈ {{hybrid, vault}} (default: "
+                         f"{VAULT_EXEMPLAR_DEFAULT_COUNT})")
     args = ap.parse_args()
 
     if args.top > HARD_CEILING:
@@ -417,12 +516,50 @@ def main() -> int:
         file=sys.stderr,
     )
 
+    # Resolve exemplar lists per --exemplar-source.
+    # vault-derived exemplars adapt per-user without hand-tuning maintenance;
+    # hand-tuned encode general institutional patterns; hybrid (default)
+    # gives defense-in-depth via both. See ROADMAP P1 vault-derived
+    # auto-exemplars, 2026-05-27.
+    constraint_texts = list(CONSTRAINT_EXEMPLARS)
+    time_texts = list(TIME_BOUNDED_EXEMPLARS)
+    if args.exemplar_source in ("hybrid", "vault"):
+        vault_pos, vault_neg = _sample_vault_exemplars(
+            conn, n=args.vault_exemplar_count,
+        )
+        if args.exemplar_source == "vault":
+            if vault_pos:
+                constraint_texts = vault_pos
+            else:
+                print(
+                    "# WARN: --exemplar-source=vault but vault has no eligible "
+                    "positive exemplars; falling back to hand-tuned list",
+                    file=sys.stderr,
+                )
+            if vault_neg:
+                time_texts = vault_neg
+            else:
+                print(
+                    "# WARN: --exemplar-source=vault but vault has no eligible "
+                    "negative exemplars; falling back to hand-tuned list",
+                    file=sys.stderr,
+                )
+        else:  # hybrid — extend, don't replace
+            constraint_texts = list(CONSTRAINT_EXEMPLARS) + vault_pos
+            time_texts = list(TIME_BOUNDED_EXEMPLARS) + vault_neg
+    print(
+        f"# Exemplars: {len(constraint_texts)} constraint + "
+        f"{len(time_texts)} time-bounded "
+        f"(source: {args.exemplar_source})",
+        file=sys.stderr,
+    )
+
     # Embedding-based signals
     print(f"# Embedding exemplars + memories ...", file=sys.stderr)
     from mnemon.embedder import embed_batch
 
-    constraint_emb = np.vstack(embed_batch(CONSTRAINT_EXEMPLARS))
-    time_emb = np.vstack(embed_batch(TIME_BOUNDED_EXEMPLARS))
+    constraint_emb = np.vstack(embed_batch(constraint_texts))
+    time_emb = np.vstack(embed_batch(time_texts))
 
     embedded_ids, memory_vecs = _load_vectors_for_docs(vecstore_path, docs)
     constraint_raw = dict(zip(embedded_ids, _cosine_max(memory_vecs, constraint_emb).tolist()))

--- a/tests/test_build_standing_set.py
+++ b/tests/test_build_standing_set.py
@@ -1,0 +1,147 @@
+"""Tests for scripts/build_standing_set.py — vault-derived auto-exemplars.
+
+Focused unit tests for the new ``_sample_vault_exemplars`` function added
+in the 2026-05-27 vault-derived-auto-exemplars PR. The function pulls
+positive exemplars (high-confidence preference / decision / antipattern)
+and negative exemplars (recent handoffs) from the operator's own vault
+so the embedding-based scorer adapts per-user without hand-tuning
+maintenance.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "build_standing_set.py"
+
+
+@pytest.fixture(scope="module")
+def bss():
+    """Load build_standing_set.py as a module via importlib."""
+    spec = importlib.util.spec_from_file_location(
+        "build_standing_set", SCRIPT_PATH,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["build_standing_set"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def conn():
+    """In-memory sqlite seeded with the documents + content schema the
+    script's SQL targets. Mirrors the production schema's columns we
+    actually query (id, hash, title, content_type, confidence,
+    invalidated_at, created_at) without pulling the full Store
+    machinery."""
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.executescript("""
+        CREATE TABLE documents (
+            id INTEGER PRIMARY KEY,
+            hash TEXT NOT NULL,
+            title TEXT,
+            content_type TEXT,
+            confidence REAL,
+            invalidated_at TEXT,
+            created_at TEXT
+        );
+        CREATE TABLE content (
+            hash TEXT PRIMARY KEY,
+            doc TEXT
+        );
+    """)
+    return db
+
+
+def _seed(conn, doc_id, content_type, confidence, title, content,
+          invalidated=None, created_at="2026-05-01"):
+    h = f"h{doc_id}"
+    conn.execute(
+        "INSERT INTO content (hash, doc) VALUES (?, ?)", (h, content),
+    )
+    conn.execute(
+        """INSERT INTO documents
+           (id, hash, title, content_type, confidence, invalidated_at, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        (doc_id, h, title, content_type, confidence, invalidated, created_at),
+    )
+
+
+class TestSampleVaultExemplars:
+    def test_pulls_high_conf_preferences_and_decisions_as_positives(self, bss, conn):
+        _seed(conn, 1, "preference", 0.85, "Pref one", "always X")
+        _seed(conn, 2, "decision", 0.90, "Dec one", "chose Y over Z")
+        _seed(conn, 3, "antipattern", 0.80, "Anti one", "do not Q")
+        pos, neg = bss._sample_vault_exemplars(conn, n=10)
+        assert len(pos) == 3
+        assert any("Pref one" in p for p in pos)
+        assert any("Dec one" in p for p in pos)
+        assert any("Anti one" in p for p in pos)
+        assert neg == []  # no handoffs seeded
+
+    def test_excludes_below_confidence_floor(self, bss, conn):
+        _seed(conn, 1, "preference", 0.85, "Strong", "high conf preference")
+        _seed(conn, 2, "preference", 0.50, "Weak", "below floor")
+        pos, _ = bss._sample_vault_exemplars(conn, n=10)
+        assert len(pos) == 1
+        assert "Strong" in pos[0]
+
+    def test_excludes_non_durable_types(self, bss, conn):
+        _seed(conn, 1, "observation", 0.95, "Obs", "passes confidence but wrong type")
+        _seed(conn, 2, "research", 0.90, "Res", "also wrong type")
+        _seed(conn, 3, "note", 0.95, "Note", "still wrong type")
+        _seed(conn, 4, "project", 0.95, "Proj", "wrong type")
+        _seed(conn, 5, "preference", 0.80, "Pref", "right type")
+        pos, _ = bss._sample_vault_exemplars(conn, n=10)
+        assert len(pos) == 1
+        assert "Pref" in pos[0]
+
+    def test_excludes_invalidated_memories(self, bss, conn):
+        _seed(conn, 1, "preference", 0.90, "Live", "active",
+              invalidated=None)
+        _seed(conn, 2, "preference", 0.90, "Dead", "soft-deleted",
+              invalidated="2026-05-20")
+        pos, _ = bss._sample_vault_exemplars(conn, n=10)
+        assert len(pos) == 1
+        assert "Live" in pos[0]
+
+    def test_pulls_recent_handoffs_as_negatives(self, bss, conn):
+        _seed(conn, 1, "handoff", 0.60, "Session A",
+              "first session", created_at="2026-05-20")
+        _seed(conn, 2, "handoff", 0.60, "Session B",
+              "second session", created_at="2026-05-25")
+        _seed(conn, 3, "handoff", 0.60, "Session C",
+              "third session", created_at="2026-05-15")
+        _, neg = bss._sample_vault_exemplars(conn, n=10)
+        assert len(neg) == 3
+        # Most-recent-first ordering — recency is the negative signal.
+        assert "Session B" in neg[0]
+        assert "Session A" in neg[1]
+        assert "Session C" in neg[2]
+
+    def test_n_caps_sample_size(self, bss, conn):
+        for i in range(20):
+            _seed(conn, i + 1, "preference", 0.85,
+                  f"Pref {i}", f"content for memory {i}")
+        pos, _ = bss._sample_vault_exemplars(conn, n=5)
+        assert len(pos) == 5
+
+    def test_format_combines_title_and_snippet(self, bss, conn):
+        _seed(conn, 1, "preference", 0.90, "Short title",
+              "longer body content with multiple words")
+        pos, _ = bss._sample_vault_exemplars(conn, n=10)
+        assert pos[0].startswith("Short title: ")
+        assert "longer body content" in pos[0]
+
+    def test_empty_vault_returns_empty_lists(self, bss, conn):
+        pos, neg = bss._sample_vault_exemplars(conn, n=10)
+        assert pos == []
+        assert neg == []


### PR DESCRIPTION
## Summary

Closes 2026-05-21 P1 ROADMAP item — replaces the maintainer's hand-tuned exemplar lists in `build_standing_set.py` with a vault-derived option that adapts per-user.

**Today:** `CONSTRAINT_EXEMPLARS` (30 entries) + `TIME_BOUNDED_EXEMPLARS` (18 entries) are statically encoded in the script. They drift as the operator's posture / patterns evolve, and they're maintainer-biased — anyone else running mnemon sees my prior beliefs about what "constraint shape" looks like.

**This PR:** prototype-network design done properly — sample the vault's own high-confidence durable memories (positives) and recent handoffs (negatives) as exemplars. Embedding-based, no LLM dependency. Adapts per-user without hand-tuning maintenance.

## New surface

- `_sample_vault_exemplars(conn, n)` pulls `(positive_texts, negative_texts)`:
  - **Positives:** SEMANTIC non-decaying types (`decision` / `preference` / `antipattern` per `HALF_LIVES`) at `confidence ≥ 0.80`, ordered by confidence DESC
  - **Negatives:** `handoff` type, ordered by `created_at` DESC
  - Each text formatted as `"{title}: {content[:200]}"`
- `--exemplar-source {hybrid, vault, hand-tuned}`:
  - **hybrid (default)** — extends hand-tuned lists with vault samples (defense-in-depth: vault adapts, hand-tuned anchors the institutional baseline)
  - **vault** — vault-only (falls back to hand-tuned + warning if vault is empty)
  - **hand-tuned** — static lists only (regression baseline / pre-existing behavior)
- `--vault-exemplar-count N` (default 15 per class)
- Operator-facing stderr surfaces which source + count was used so `standing.json` audit trails record provenance

## Test plan

- [x] 8 new tests in `TestSampleVaultExemplars`:
  - pulls high-conf decision/preference/antipattern as positives
  - excludes below confidence floor
  - excludes non-durable types (observation/research/note/project)
  - excludes invalidated memories
  - pulls recent handoffs as negatives, ordered created_at DESC
  - n caps sample size
  - format combines title + snippet
  - empty vault returns empty lists
- [x] Loads the script via `importlib` (scripts/ has no `__init__.py`)
- [x] Full suite: **883 passed** (was 875 at rc5 baseline → +8)
- [ ] Operator-side (post-merge): rerun `scripts/salience_phase0.sh score` against Brian's vault with `--exemplar-source hybrid` and `--exemplar-source vault`; compare auto-selected top-10 against the current hand-tuned baseline. Vault-derived top-10 should still surface the load-bearing engineering rules AND pick up career-context / posture constraints that the original imperative-bias exemplars under-weighted.

## Composes with

- `[[feedback_sota_institutional_default_no_shortcuts]]` — the embedding-based scorer was the SOTA-for-public-release choice; vault-derived exemplars complete the prototype-network design without adding an LLM dep
- The 2026-05-22 declarative-posture exemplar fix (PR #155) — that PR closed the imperative-vs-declarative bias by adding 10 declarative exemplars by hand; this PR generalizes the principle by sampling whatever the operator's vault actually contains