### PR TITLE
refactor(downgrade): drop _FLY_DUMP_SCRIPT — invoke `mnemon sync push` directly

### DIFF
--- a/src/mnemon/downgrade.py
+++ b/src/mnemon/downgrade.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 
 import os
 import re
-import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -133,56 +132,13 @@ def _reconfigure_clients_local(detected: list[str]) -> list[str]:
     return reconfigured
 
 
-_FLY_DUMP_SCRIPT = """
-import sqlite3, os, subprocess, sys
-
-SRC = '/data/default.sqlite'
-SNAP = '/tmp/_mnemon_snapshot.sqlite'
-
-# Clean prior snapshot, if any.
-try:
-    os.remove(SNAP)
-except FileNotFoundError:
-    pass
-
-# Online-backup API produces an atomic snapshot regardless of WAL
-# state — see _fly_dump_vault docstring for the rationale.
-src = sqlite3.connect(SRC, timeout=10)
-dst = sqlite3.connect(SNAP)
-src.backup(dst)
-src.close()
-dst.close()
-
-bucket = os.environ['MNEMON_S3_BUCKET']
-prefix = os.environ.get('MNEMON_S3_PREFIX', 'mnemon/vaults')
-name = os.environ.get('MNEMON_VAULT_NAME', 'default')
-
-# Upload sqlite snapshot.
-subprocess.run(
-    ['aws', 's3', 'cp', SNAP, f's3://{bucket}/{prefix}/{name}.sqlite',
-     '--only-show-errors'],
-    check=True,
-)
-
-# Upload vector store too if present (best-effort — embeddings
-# regenerate on demand, but skipping the cp would leave the local
-# vault with stale vectors post-downgrade).
-vec_path = f'/data/{name}.vec.npz'
-if os.path.exists(vec_path):
-    subprocess.run(
-        ['aws', 's3', 'cp', vec_path, f's3://{bucket}/{prefix}/{name}.vec.npz',
-         '--only-show-errors'],
-        check=False,
-    )
-
-# Cleanup snapshot.
-try:
-    os.remove(SNAP)
-except FileNotFoundError:
-    pass
-
-print('fly dump: snapshot uploaded')
-"""
+# `mnemon sync push` (canonical primitive, sync.push() at sync.py:110)
+# now does the SQLite-backup-API snapshot + S3 upload + best-effort
+# vec.npz upload that this script used to inline. Simplified
+# 2026-05-27 once Fly was reliably on a mnemon version with the
+# backup-API push (rc4+; see ROADMAP "sync.push uses SQLite's
+# online-backup API" SHIPPED 2026-05-21).
+_FLY_DUMP_CMD = "mnemon sync push"
 
 
 def _fly_dump_vault(app_name: str) -> None:
@@ -216,9 +172,14 @@ def _fly_dump_vault(app_name: str) -> None:
     got '3'" — PR #139 added the SSH'd sync push, PR #140 added an
     in-push checkpoint that doesn't work cross-process, PR #141
     added an inline checkpoint that *also* doesn't work cross-process.
-    This PR uses the backup API which actually works.
+    PR #142 added the backup API which actually works.
+
+    Simplification 2026-05-27: now invokes ``mnemon sync push`` on the
+    Fly machine rather than inlining a ~40-line Python script that
+    duplicates what sync.push() already does. The installed mnemon
+    on Fly is the source of truth for the snapshot primitive; this
+    function just routes the call.
     """
-    remote_cmd = f"python -c {shlex.quote(_FLY_DUMP_SCRIPT)}"
     subprocess.run(
         [
             "flyctl",
@@ -227,7 +188,7 @@ def _fly_dump_vault(app_name: str) -> None:
             "--app",
             app_name,
             "-C",
-            remote_cmd,
+            _FLY_DUMP_CMD,
         ],
         check=True,
     )

--- a/tests/test_downgrade.py
+++ b/tests/test_downgrade.py
@@ -376,45 +376,23 @@ class TestFlyDumpVaultBeforePull:
             downgrade_local(skip_doctor=True)
         mock_dump.assert_not_called()
 
-    def test_fly_dump_runs_ssh_console_with_backup_api(self, tmp_path):
+    def test_fly_dump_runs_ssh_console_with_mnemon_sync_push(self, tmp_path):
         # Direct test that _fly_dump_vault issues the expected flyctl
-        # command. Must use SQLite's online backup API (not PRAGMA
-        # wal_checkpoint, which returns busy=0/checkpointed=0 when
-        # another process holds the WAL — exactly the long-running
-        # serve-remote scenario on Fly). Regression for the
-        # 2026-05-21 backup-vs-checkpoint correctness bug.
+        # command. Simplified 2026-05-27: the inlined ~40-line Python
+        # snapshot script collapsed to `mnemon sync push` once the
+        # backup-API push was canonical on Fly (mnemon-memory==0.6.0+
+        # ships sync.push using Connection.backup() per PR #142).
+        # The installed mnemon on the Fly machine is the source of
+        # truth for the snapshot primitive; this function just routes.
         from mnemon import downgrade as dgmod
         with patch("mnemon.downgrade.subprocess.run") as mock_run:
             dgmod._fly_dump_vault("mnemon-test-abc")
         mock_run.assert_called_once()
         call_args = mock_run.call_args.args[0]
-        # Outer shape: flyctl ssh console --app NAME -C <remote_cmd>
+        # Outer shape: flyctl ssh console --app NAME -C "mnemon sync push"
         assert call_args[0] == "flyctl"
         assert call_args[1:5] == ["ssh", "console", "--app", "mnemon-test-abc"]
         assert call_args[5] == "-C"
-        remote_cmd = call_args[6]
-        # Must be `python -c <quoted-script>`.
-        assert remote_cmd.startswith("python -c "), (
-            f"expected `python -c ...`, got: {remote_cmd[:80]}"
-        )
-        # The inlined script must use the backup API (not PRAGMA
-        # wal_checkpoint — that didn't work cross-process).
-        assert "src.backup(dst)" in remote_cmd, (
-            f"missing sqlite3 backup API call in: {remote_cmd}"
-        )
-        # Must aws s3 cp the snapshot up.
-        assert "aws" in remote_cmd and "s3" in remote_cmd and "cp" in remote_cmd, (
-            f"missing aws s3 cp in: {remote_cmd}"
-        )
-        # Should NOT use mnemon CLI sync push (version-skew —
-        # rc18 doesn't have the checkpoint, and we're now doing
-        # the upload directly in Python anyway).
-        assert "mnemon sync push" not in remote_cmd, (
-            f"should not delegate to mnemon CLI sync push: {remote_cmd}"
-        )
-        # Should NOT use PRAGMA wal_checkpoint as the primary mechanism
-        # — backup API is what actually works cross-process. (We allow
-        # the script to mention sqlite3 generally.)
-        assert "PRAGMA wal_checkpoint" not in remote_cmd, (
-            f"should not rely on PRAGMA wal_checkpoint (cross-process broken): {remote_cmd}"
+        assert call_args[6] == "mnemon sync push", (
+            f"expected `mnemon sync push`, got: {call_args[6]!r}"
         )


### PR DESCRIPTION
## Summary

Closes the 2026-05-21 ROADMAP follow-up to drop the inline-Python workaround in `_fly_dump_vault` now that Fly is reliably on a mnemon version with the backup-API `sync push`.

`mnemon sync push` (`sync.push()` at `sync.py:110`) already does the SQLite backup-API snapshot + S3 sqlite upload + best-effort vec.npz upload. The `_FLY_DUMP_SCRIPT` constant duplicated that work as 40+ lines of inline Python — a substrate weakness from when Fly was pinned to a pre-0.6.0 mnemon without the canonical primitive.

## Changes

- `src/mnemon/downgrade.py`: `_FLY_DUMP_SCRIPT` (40+ lines) → `_FLY_DUMP_CMD = "mnemon sync push"` (1 line); `_fly_dump_vault` invokes `flyctl ssh console --app NAME -C "mnemon sync push"`
- Dropped unused `import shlex`
- `tests/test_downgrade.py`: test renamed `test_fly_dump_runs_ssh_console_with_backup_api` → `test_fly_dump_runs_ssh_console_with_mnemon_sync_push`. Assertion simplified to `call_args[6] == "mnemon sync push"` (was substring checks for `python -c ...` + `src.backup(dst)`)
- Net diff: **-45 lines**

## Test plan

- [x] `tests/test_downgrade.py` (18 tests) — all green
- [x] Full suite: **892 passed**
- [ ] Operator-side (post-merge): the full downgrade integration is exercised by the next `promote_stable.sh layer3` against a throwaway test app. The unit test asserts call-shape; real S3 + Fly interaction is operator-driven.

## Composes with

- ROADMAP top-of-file "`sync.push` uses SQLite's online-backup API" (SHIPPED 2026-05-21, PR #142) — that PR made `mnemon sync push` the canonical primitive. This PR completes the simplification arc by routing `_fly_dump_vault` through it.