### PR TITLE
test(scripts): smoke harness — exec `--help` on every scripts/*.py

### DIFF
--- a/tests/test_scripts_smoke.py
+++ b/tests/test_scripts_smoke.py
@@ -1,0 +1,101 @@
+"""Smoke tests for ``scripts/*.py`` operator-facing CLIs.
+
+Closes the 2026-05-24 ROADMAP P2 follow-up: scripts live outside
+``src/`` and aren't picked up by the coverage gate, so import-time
+and arg-parse defects (like the 2026-05-24 ``VecStore.get`` bug
+that shipped in PR #153 because the call site was never exercised
+end-to-end before merge) don't surface until an operator runs the
+script for real.
+
+Each public script under ``scripts/`` (excluding underscore-prefixed
+helpers like ``_layer3_remote_helper.py``) is invoked with ``--help``.
+``--help`` exits 0 if the script's module loads cleanly + ``argparse``
+constructs without error. That's the minimum bar — it catches:
+
+- Import errors from a missing dependency
+- Attribute errors at module scope (e.g. referencing ``VecStore.get``
+  before it existed)
+- Syntax errors from a typo
+- ``argparse`` mis-configuration
+
+It does NOT catch logic errors inside the script's runtime path —
+those need full integration tests (see ``test_promote_stable.sh`` for
+the bash-harness pattern). This is the lightweight gate-keeper layer.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+
+def _public_scripts() -> list[Path]:
+    """Every ``scripts/*.py`` that isn't a helper (underscore-prefixed).
+
+    Underscore-prefixed files are internal helpers invoked by other
+    scripts (e.g. ``_layer3_remote_helper.py`` is exec'd inside the
+    promote_stable.sh layer3 step); they aren't user-facing CLIs and
+    don't carry ``--help``.
+    """
+    return sorted(
+        p for p in SCRIPTS_DIR.glob("*.py")
+        if not p.name.startswith("_")
+    )
+
+
+@pytest.mark.parametrize(
+    "script_path",
+    _public_scripts(),
+    ids=lambda p: p.name,
+)
+def test_script_help_exits_zero(script_path: Path):
+    """Running ``python <script> --help`` must exit 0.
+
+    Catches: import errors, syntax errors, argparse mis-configuration,
+    module-scope attribute errors. Caught the
+    2026-05-24 ``VecStore.get`` regression pattern at PR-review time
+    rather than first-operator-run time."""
+    result = subprocess.run(
+        [sys.executable, str(script_path), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, (
+        f"{script_path.name} --help exited {result.returncode}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    # Sanity — argparse always renders a "usage:" line in --help output.
+    assert "usage:" in result.stdout.lower() or "usage:" in result.stderr.lower(), (
+        f"{script_path.name} --help produced no recognizable usage block\n"
+        f"stdout:\n{result.stdout}"
+    )
+
+
+def test_smoke_covers_every_public_script():
+    """Meta-check: confirm the parameterization actually picks up every
+    .py file we'd expect. Catches the case where a script lands but
+    its name happens to start with `_` (would be silently skipped) or
+    where a refactor moves something out of scripts/."""
+    found = {p.name for p in _public_scripts()}
+    # Anchor: scripts that exist today. Update this set when adding /
+    # removing public scripts; the smoke harness should grow with them.
+    expected_minimum = {
+        "build_standing_set.py",
+        "calibrate_capture_threshold.py",
+        "check_health.py",
+    }
+    missing = expected_minimum - found
+    assert not missing, (
+        f"smoke harness lost coverage of: {missing}. "
+        f"Either restore the scripts or update the expected_minimum set."
+    )


### PR DESCRIPTION
## Summary

Closes 2026-05-24 ROADMAP P2 follow-up. `scripts/` lives outside `src/` and isn't picked up by the coverage gate, so import-time and arg-parse defects ship undetected. The canonical example: 2026-05-24 `VecStore.get` bug in PR #153 — the call site existed in `scripts/calibrate_capture_threshold.py` but the method didn't. The defect surfaced on first operator invocation, not at review time.

## Approach

`subprocess python <script> --help` for every public `scripts/*.py` (excluding underscore-prefixed helpers like `_layer3_remote_helper.py`). `--help` exits 0 only if:
- Module imports cleanly (all deps resolve)
- Module-scope code runs without `AttributeError`
- `argparse` constructs without misconfiguration
- The file is syntactically valid

It does NOT catch logic errors in the runtime path — that's still the bash harness's job (`tests/test_promote_stable.sh`) and operator-driven Layer-3 runs. This is the lightweight gate-keeper layer.

## Test plan

- [x] 3 parametrized tests over current scripts: `build_standing_set.py`, `calibrate_capture_threshold.py`, `check_health.py` — all green
- [x] 1 meta-check that the expected_minimum coverage set is still satisfied (guards against future renames silently dropping coverage)
- [x] Full suite: **896 passed** (was 892 → +4)
- [x] Runs in the existing CI matrix (no new workflow file)
- [x] Local invocation: `pytest tests/test_scripts_smoke.py` — ~150ms total

## Composes with

- `tests/test_promote_stable.sh` — the bash-harness pattern for promote_stable.sh smoke testing
- `[[feedback_audit_findings_become_roadmap_followups]]` — PR #153 audit surfaced the defect class; this PR is the chokepoint that prevents the next recurrence