### PR TITLE
feat(memory_save): correction_of inserts 'supersedes' relation

### DIFF
--- a/src/mnemon/server.py
+++ b/src/mnemon/server.py
@@ -152,6 +152,7 @@ def memory_save(
     collection: str = "default",
     source_client: str | None = None,
     source_key: str | None = None,
+    correction_of: int | None = None,
 ) -> str:
     """Save a new memory.
 
@@ -163,6 +164,13 @@ def memory_save(
     insert) instead of accumulating near-duplicates — used by the
     auto-mirror path, keyed to the local memory file's slug, so a
     memory edited several times in one session stays a single document.
+
+    ``correction_of`` is an explicit operator gesture that THIS memory
+    corrects/supersedes a prior one (by its document id). Inserts a
+    ``'supersedes'`` relation so the chain is auditable, and skips the
+    capture-attention auto-boost on the new save (the explicit gesture
+    is canonical signal — automated recurrence detection would be
+    redundant). Raises if the named id doesn't exist.
     """
     store = _get_store()
     doc_id = store.save(
@@ -172,6 +180,7 @@ def memory_save(
         collection=collection,
         source_client=source_client,
         source_key=source_key,
+        correction_of=correction_of,
     )
 
     # Embed asynchronously (non-blocking, failures are non-fatal — the

--- a/src/mnemon/store.py
+++ b/src/mnemon/store.py
@@ -360,11 +360,19 @@ class Store:
         insert-only behaviour is preserved exactly.
 
         ``correction_of`` — when set — is an explicit operator gesture
-        that THIS memory corrects/supersedes a prior one (the Phase 2
-        promotion signal from the salience-tier plan). Reserved here
-        for forward compatibility; today its only effect is to SKIP
-        the capture-attention path (operator gesture beats automated
-        recurrence detection).
+        that THIS memory corrects/supersedes a prior one. Two effects:
+          1. Inserts a ``'supersedes'`` relation from the new doc to the
+             named prior, so the supersession chain is auditable.
+          2. Skips the capture-attention path (operator gesture beats
+             automated recurrence detection per the salience-tier plan
+             composition).
+
+        Raises ``ValueError`` if ``correction_of`` names a non-existent
+        document — fail loud per ``[[feedback_no_silent_fails]]``. We
+        DON'T require the target to be live (invalidated_at IS NULL):
+        an operator may legitimately mark a new memory as superseding
+        an already-forgotten one to record the chain. The relation is
+        the audit trail.
         """
         content_hash = _sha256(content)
         ct = ContentType(content_type)
@@ -372,6 +380,18 @@ class Store:
         conf = confidence if confidence is not None else DEFAULT_CONFIDENCE[ct]
         if source_client in HOOK_SOURCE_CLIENTS:
             conf = min(conf, HOOK_SOURCE_CONFIDENCE_CEILING)
+
+        # Validate correction_of target exists before we commit anything.
+        # Fail loud rather than insert a dangling relation downstream.
+        if correction_of is not None:
+            row = self.db.execute(
+                "SELECT 1 FROM documents WHERE id = ?", (correction_of,),
+            ).fetchone()
+            if row is None:
+                raise ValueError(
+                    f"correction_of={correction_of} names a non-existent "
+                    "document"
+                )
 
         # Upsert content (idempotent)
         self.db.execute(
@@ -470,6 +490,19 @@ class Store:
             "INSERT INTO documents_fts (rowid, title, body) VALUES (?, ?, ?)",
             (doc_id, title, content),
         )
+
+        # Explicit supersession relation. The auto-mirror upsert-by-slug
+        # path above records its OWN supersession via invalidated_by; this
+        # is the operator-explicit cross-id gesture (different memory
+        # entirely, but THIS one corrects the prior). The 'supersedes'
+        # relation makes the chain queryable + auditable downstream.
+        if correction_of is not None:
+            self.db.execute(
+                "INSERT OR REPLACE INTO relations "
+                "(source_id, target_id, relation_type, weight) "
+                "VALUES (?, ?, 'supersedes', 1.0)",
+                (doc_id, correction_of),
+            )
         self.db.commit()
 
         # Capture attention Phase A — preserve+relate+boost. Gated on

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -250,6 +250,7 @@ class TestMemorySave:
             collection="default",
             source_client=None,
             source_key=None,
+            correction_of=None,
         )
 
     @patch("mnemon.server.Store")
@@ -281,6 +282,32 @@ class TestMemorySave:
             collection="work",
             source_client="claude",
             source_key=None,
+            correction_of=None,
+        )
+
+    @patch("mnemon.server.Store")
+    def test_correction_of_threads_to_store(self, MockStore):
+        """The new correction_of MCP param routes through Store.save so
+        operator-explicit supersession becomes a structural 'supersedes'
+        relation. Regression for 2026-05-22 P2 — chat-prose
+        'Supersedes id N' previously didn't insert a relation."""
+        mock_store = MockStore.return_value
+        mock_store.save.return_value = 99
+        mock_store.get.return_value = None
+
+        memory_save(
+            "New framing", "new authoritative content",
+            content_type="decision",
+            correction_of=42,
+        )
+        mock_store.save.assert_called_once_with(
+            title="New framing",
+            content="new authoritative content",
+            content_type="decision",
+            collection="default",
+            source_client=None,
+            source_key=None,
+            correction_of=42,
         )
 
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -2,6 +2,7 @@
 
 import os
 import tempfile
+from unittest.mock import patch
 
 import pytest
 
@@ -273,6 +274,72 @@ class TestRelations:
         # Should find from either direction
         assert len(store.get_related(id1)) == 1
         assert len(store.get_related(id2)) == 1
+
+
+class TestCorrectionOf:
+    """Regression for 2026-05-22 P2 ROADMAP follow-up: ``correction_of``
+    was reserved in Store.save() but only used as a capture-attention
+    skip flag. Surfaced when #2543 was saved with prose 'Supersedes the
+    partial financial framings in id 2402' but no relation was
+    inserted — operator-explicit supersession needs to be a structural
+    'supersedes' relation, not just chat-prose."""
+
+    def test_correction_of_inserts_supersedes_relation(self, store):
+        prior = store.save(title="Old framing", content="old content")
+        new = store.save(
+            title="Corrected framing",
+            content="new authoritative content",
+            correction_of=prior,
+        )
+        # New doc has an outgoing 'supersedes' relation to the prior.
+        related = store.get_related(new)
+        supersedes = [r for r in related if r.relation_type == "supersedes"]
+        assert len(supersedes) == 1
+        assert supersedes[0].id == prior
+
+    def test_correction_of_raises_for_missing_target(self, store):
+        # Fail loud (no silent dangling relation) rather than insert a
+        # 'supersedes' pointing nowhere.
+        import pytest as _pytest
+        with _pytest.raises(ValueError, match="non-existent"):
+            store.save(
+                title="bogus", content="bogus",
+                correction_of=99999,
+            )
+
+    def test_correction_of_works_on_invalidated_target(self, store):
+        # Operator may legitimately mark a new memory as superseding an
+        # already-forgotten one to record the chain — relation is the
+        # audit trail, not a liveness check. get_related() filters
+        # invalidated targets by design, so query the relations table
+        # directly to verify the row was inserted.
+        prior = store.save(title="Old", content="old")
+        store.forget(prior)
+        new = store.save(
+            title="New", content="new",
+            correction_of=prior,
+        )
+        rows = store.db.execute(
+            "SELECT target_id, relation_type FROM relations "
+            "WHERE source_id = ?",
+            (new,),
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0]["target_id"] == prior
+        assert rows[0]["relation_type"] == "supersedes"
+
+    def test_correction_of_skips_capture_attention(self, store, monkeypatch):
+        # The pre-existing skip behavior must still work — operator
+        # gesture beats automated recurrence detection.
+        from mnemon import config
+        monkeypatch.setattr(config, "CAPTURE_ATTENTION_ENABLED", True)
+        prior = store.save(title="P", content="payload")
+        with patch.object(store, "apply_capture_attention") as mock_apply:
+            store.save(
+                title="N", content="payload",
+                correction_of=prior,
+            )
+        mock_apply.assert_not_called()
 
 
 class TestStatus:


### PR DESCRIPTION
## Summary

Closes 2026-05-22 P2 ROADMAP follow-up. The `correction_of` parameter was reserved in `Store.save()` per PR #153 but only wired as a capture-attention skip flag — operator-explicit supersession via chat prose never became a structural relation.

**Surfacing incident:** #2543 was saved with prose *"Supersedes the partial financial framings in id 2402"*. No `'supersedes'` relation was inserted. Both memories co-existed on the standing tier with contradictory liquidity figures, contributing to the 2026-05-22 audit-and-demote of #131 / #2402.

## Behavior

- `Store.save(..., correction_of=<id>)` inserts `INSERT OR REPLACE INTO relations (source_id=new_doc, target_id=correction_of, relation_type='supersedes', weight=1.0)`.
- Pre-validates the target id exists. Raises `ValueError` with a clear message if it doesn't — fail loud per `[[feedback_no_silent_fails]]`, no silent dangling relations.
- Target does NOT need to be live. Operators may mark new memories as superseding already-forgotten ones to record the chain — the relation is the audit trail.
- `memory_save` MCP tool exposes `correction_of` as a new optional parameter. Docstring updated with the dual effect (insert relation + skip capture-attention).

## Test plan

- [x] `TestCorrectionOf` (4 tests in `test_store.py`): inserts `'supersedes'`, raises for missing target, works on invalidated target (queries `relations` directly since `get_related()` filters invalidated by design), still skips capture-attention.
- [x] `TestMemorySave::test_correction_of_threads_to_store` (`test_server.py`): MCP param routes through `Store.save` with correct kwargs.
- [x] Updated 2 existing `TestMemorySave` tests to include `correction_of=None` in expected kwargs.
- [x] Full suite: **897 passed** (was 892 → +5)

## Composes with

- `[[mnemon-salience-tier-plan-260521]]` Phase 2 promotion signals — `correction_of` is the operator-explicit supersession gesture that the salience-tier roadmap reserves for explicit promote/demote signals
- Layer 4 provenance + capture-attention skip — the existing `if correction_of is not None` short-circuit on `apply_capture_attention` remains, mirrored alongside the new relation insertion
- Future P2 follow-up not in this PR: auto-detect `"supersedes id N"` regex in saved content and refuse-without-correction_of-param. Filed as a follow-up; this PR ships the explicit-gesture path that future regex-detect work would gate on.