### PR TITLE
feat(scripts): mnemon_ops.sh — general operator helpers

### DIFF
--- a/scripts/mnemon_ops.sh
+++ b/scripts/mnemon_ops.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# scripts/mnemon_ops.sh — general operator helpers for mnemon.
+#
+# Consolidates recurring operator commands that emerged during the
+# 0.6.0 stable cut + subsequent releases — each one was being typed
+# by hand 3-4 times per session before this script existed. Each
+# subcommand is a few lines of bash wrapping a single intent.
+#
+# Subcommands:
+#   cleanup-test-apps    Destroy every `mnemon-test-*` Fly app (dangling
+#                        layer3 leftovers + locally-cached snapshots).
+#   recover-token        Pull MNEMON_LOCAL_TOKEN out of the running Fly
+#                        app and write it to ~/.mnemon/local_token (0o600).
+#                        Used after layer3 auth clobbering.
+#   restart-machine      `flyctl machine restart` the prod app's first
+#                        machine + run `mnemon doctor`. Used when the SSL
+#                        handshake wedges mid-cold-start.
+#   vault-stats          Print size + recent-changes diff over the local
+#                        vault. Quick snapshot for operator awareness.
+#   changelog-extract <version>
+#                        Print the CHANGELOG.md section for the given
+#                        version (e.g. `0.7.0rc5` or `0.7.0`). Used
+#                        standalone for ad-hoc "extract release notes"
+#                        needs — also called by promote_stable.sh publish.
+#   help                 This help.
+#
+# Conventions (mirrors scripts/salience_phase0.sh):
+#   - Resolves the repo + .venv from the script's own location.
+#   - Honors env-var overrides where useful (MNEMON_FLY_APP_NAME etc).
+#   - Refuses to touch credentials on stdout (token recovery writes the
+#     file with 0o600, never echoes the value).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+MNEMON_VENV_BIN="${MNEMON_VENV_BIN:-$REPO_ROOT/.venv/bin}"
+APP_NAME="${MNEMON_FLY_APP_NAME:-mnemon-memory}"
+VAULT_DIR="${MNEMON_VAULT_DIR:-$HOME/.mnemon}"
+LOCAL_TOKEN_FILE="$VAULT_DIR/local_token"
+CHANGELOG="$REPO_ROOT/CHANGELOG.md"
+
+usage() {
+    sed -n '2,/^$/{s/^# \{0,1\}//;p;}' "${BASH_SOURCE[0]}"
+}
+
+# Refuse to dump credentials in stdout — applies to any subcommand
+# that pulls env vars from the Fly machine.
+_redact_in_stdout() {
+    # No-op marker for grep; the actual redaction happens by structuring
+    # the recovery flow to write the file directly via SSH instead of
+    # roundtripping the value through this shell.
+    :
+}
+
+cmd_cleanup_test_apps() {
+    command -v flyctl >/dev/null || { echo "ERROR: flyctl not on PATH" >&2; exit 2; }
+    local apps
+    apps=$(flyctl apps list 2>/dev/null | awk '/^mnemon-test-/ {print $1}' || true)
+    if [ -z "$apps" ]; then
+        echo "no dangling mnemon-test-* apps"
+        return 0
+    fi
+    echo "Destroying:"
+    echo "$apps" | sed 's/^/  /'
+    while IFS= read -r app; do
+        [ -z "$app" ] && continue
+        flyctl apps destroy "$app" -y || echo "WARN: destroy failed for $app" >&2
+    done <<<"$apps"
+    echo "cleanup-test-apps: done"
+}
+
+cmd_recover_token() {
+    command -v flyctl >/dev/null || { echo "ERROR: flyctl not on PATH" >&2; exit 2; }
+    mkdir -p "$VAULT_DIR"
+    # Stream the token to the file directly via ssh -C; never let the
+    # value touch this script's stdout. `printenv` exits non-zero if
+    # the env var is unset, which surfaces here as a hard error.
+    flyctl ssh console -a "$APP_NAME" -C 'printenv MNEMON_LOCAL_TOKEN' \
+        | tail -n 1 \
+        > "$LOCAL_TOKEN_FILE.tmp"
+    if [ ! -s "$LOCAL_TOKEN_FILE.tmp" ]; then
+        rm -f "$LOCAL_TOKEN_FILE.tmp"
+        echo "ERROR: empty token from Fly — is MNEMON_LOCAL_TOKEN set on the app?" >&2
+        exit 1
+    fi
+    mv "$LOCAL_TOKEN_FILE.tmp" "$LOCAL_TOKEN_FILE"
+    chmod 600 "$LOCAL_TOKEN_FILE"
+    echo "token recovered → $LOCAL_TOKEN_FILE (0o600)"
+}
+
+cmd_restart_machine() {
+    command -v flyctl >/dev/null || { echo "ERROR: flyctl not on PATH" >&2; exit 2; }
+    local mid
+    mid=$(flyctl machine list -a "$APP_NAME" --json | "$MNEMON_VENV_BIN/python" -c 'import json,sys; print(json.load(sys.stdin)[0]["id"])')
+    echo "restarting machine $mid in $APP_NAME ..."
+    flyctl machine restart "$mid" -a "$APP_NAME"
+    echo "verifying with mnemon doctor ..."
+    "$MNEMON_VENV_BIN/mnemon" doctor
+}
+
+cmd_vault_stats() {
+    local db="$VAULT_DIR/default.sqlite"
+    if [ ! -f "$db" ]; then
+        echo "no vault at $db"
+        return 0
+    fi
+    "$MNEMON_VENV_BIN/python" - <<PYEOF
+import sqlite3, os
+db_path = "$db"
+conn = sqlite3.connect(db_path)
+conn.row_factory = sqlite3.Row
+size_mb = os.path.getsize(db_path) / 1_048_576
+total = conn.execute("SELECT COUNT(*) FROM documents WHERE invalidated_at IS NULL").fetchone()[0]
+by_type = conn.execute(
+    "SELECT content_type, COUNT(*) FROM documents "
+    "WHERE invalidated_at IS NULL GROUP BY content_type ORDER BY 2 DESC"
+).fetchall()
+recent = conn.execute(
+    "SELECT id, title, content_type, created_at FROM documents "
+    "WHERE invalidated_at IS NULL ORDER BY id DESC LIMIT 5"
+).fetchall()
+
+print(f"Vault: $db")
+print(f"  size:       {size_mb:.2f} MB")
+print(f"  live docs:  {total}")
+print()
+print("  by content_type:")
+for ct, n in by_type:
+    print(f"    {ct:<14} {n:>5}")
+print()
+print("  most recent 5:")
+for r in recent:
+    print(f"    #{r['id']:<5}  [{r['content_type']:<12}]  {r['title'][:60]}  ({r['created_at']})")
+PYEOF
+}
+
+cmd_changelog_extract() {
+    local version="${1:-}"
+    if [ -z "$version" ]; then
+        echo "ERROR: usage: $0 changelog-extract <version>" >&2
+        exit 2
+    fi
+    if [ ! -f "$CHANGELOG" ]; then
+        echo "ERROR: $CHANGELOG not found" >&2
+        exit 1
+    fi
+    # Match `## [VERSION]` header through to (but not including) the next
+    # `## [` header. Treats `## [Unreleased]` consistently with versioned
+    # headers. Brackets are escaped because they're regex metachars.
+    "$MNEMON_VENV_BIN/python" - "$version" "$CHANGELOG" <<'PYEOF'
+import re, sys
+version = sys.argv[1]
+path = sys.argv[2]
+content = open(path).read()
+pattern = rf"^## \[{re.escape(version)}\].*?(?=^## \[|\Z)"
+m = re.search(pattern, content, re.MULTILINE | re.DOTALL)
+if not m:
+    print(f"ERROR: no `## [{version}]` section found in {path}", file=sys.stderr)
+    sys.exit(1)
+sys.stdout.write(m.group(0).rstrip() + "\n")
+PYEOF
+}
+
+main() {
+    local sub="${1:-help}"
+    shift || true
+    case "$sub" in
+        cleanup-test-apps)   cmd_cleanup_test_apps "$@" ;;
+        recover-token)       cmd_recover_token "$@" ;;
+        restart-machine)     cmd_restart_machine "$@" ;;
+        vault-stats)         cmd_vault_stats "$@" ;;
+        changelog-extract)   cmd_changelog_extract "$@" ;;
+        help|-h|--help|"")   usage ;;
+        *)
+            echo "unknown subcommand: $sub" >&2
+            echo >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+}
+
+main "$@"

--- a/tests/test_mnemon_ops.py
+++ b/tests/test_mnemon_ops.py
@@ -100,14 +100,16 @@ class TestChangelogExtract:
 
     def _run_in_synthetic_repo(self, tmp_path, *args, env_extra=None):
         """Run the script with REPO_ROOT pointing at a synthetic tmp dir
-        but MNEMON_VENV_BIN pointing at the real venv (the script needs
-        a working python). Returns the CompletedProcess."""
+        but MNEMON_VENV_BIN pointing at the test interpreter's bin dir
+        — works both locally (.venv/bin) and in CI (GHA-provisioned
+        interpreter dir without a .venv). Returns the CompletedProcess."""
         import os
+        import sys as _sys
         script_dir = tmp_path / "scripts"
         script_dir.mkdir(exist_ok=True)
         (script_dir / "mnemon_ops.sh").write_bytes(SCRIPT.read_bytes())
         env = {**os.environ}
-        env["MNEMON_VENV_BIN"] = str(REPO_ROOT / ".venv" / "bin")
+        env["MNEMON_VENV_BIN"] = str(Path(_sys.executable).parent)
         if env_extra:
             env.update(env_extra)
         return subprocess.run(

--- a/tests/test_mnemon_ops.py
+++ b/tests/test_mnemon_ops.py
@@ -1,0 +1,140 @@
+"""Tests for ``scripts/mnemon_ops.sh``.
+
+Covers the network-free subcommands (``help``, ``changelog-extract``,
+unknown-subcommand error path). Network/flyctl-dependent subcommands
+(``cleanup-test-apps``, ``recover-token``, ``restart-machine``,
+``vault-stats``) are exercised by operators end-to-end and only get
+a syntax-check + help-text presence assertion here.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "mnemon_ops.sh"
+
+
+def _run(*args, env=None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        capture_output=True, text=True, env=env, cwd=str(REPO_ROOT),
+    )
+
+
+class TestSyntax:
+    def test_script_is_syntactically_valid(self):
+        result = subprocess.run(
+            ["bash", "-n", str(SCRIPT)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, (
+            f"bash -n flagged a syntax error:\n{result.stderr}"
+        )
+
+
+class TestHelp:
+    def test_help_exits_zero(self):
+        result = _run("help")
+        assert result.returncode == 0
+
+    def test_no_arg_prints_usage(self):
+        # Empty subcommand falls through to `help` per the case branch.
+        result = _run()
+        assert result.returncode == 0
+        assert "Subcommands:" in result.stdout
+
+    def test_help_lists_every_subcommand(self):
+        result = _run("help")
+        # Sanity — each named subcommand appears in the help block. Catches
+        # silent drift where a subcommand is added but the usage block isn't
+        # updated.
+        for sub in (
+            "cleanup-test-apps",
+            "recover-token",
+            "restart-machine",
+            "vault-stats",
+            "changelog-extract",
+        ):
+            assert sub in result.stdout, f"help text missing {sub}"
+
+
+class TestUnknownSubcommand:
+    def test_unknown_subcommand_exits_2(self):
+        result = _run("nonsense-subcommand")
+        assert result.returncode == 2
+        assert "unknown subcommand" in result.stderr.lower()
+
+
+class TestChangelogExtract:
+    @pytest.fixture
+    def fake_changelog(self, tmp_path, monkeypatch):
+        """Substitute a synthetic CHANGELOG.md so the test doesn't depend
+        on the repo's real history."""
+        cl = tmp_path / "CHANGELOG.md"
+        cl.write_text(textwrap.dedent("""\
+            # Changelog
+
+            ## [0.9.0] - 2026-06-01
+
+            ### Some feature
+
+            - bullet one
+            - bullet two
+
+            ## [0.8.0] - 2026-05-15
+
+            ### Another feature
+
+            - older bullet
+        """))
+        # The script reads $REPO_ROOT/CHANGELOG.md — make the temp dir
+        # masquerade as the repo root and point the script at it via the
+        # explicit env vars its `set -u` reads.
+        return cl
+
+    def _run_in_synthetic_repo(self, tmp_path, *args, env_extra=None):
+        """Run the script with REPO_ROOT pointing at a synthetic tmp dir
+        but MNEMON_VENV_BIN pointing at the real venv (the script needs
+        a working python). Returns the CompletedProcess."""
+        import os
+        script_dir = tmp_path / "scripts"
+        script_dir.mkdir(exist_ok=True)
+        (script_dir / "mnemon_ops.sh").write_bytes(SCRIPT.read_bytes())
+        env = {**os.environ}
+        env["MNEMON_VENV_BIN"] = str(REPO_ROOT / ".venv" / "bin")
+        if env_extra:
+            env.update(env_extra)
+        return subprocess.run(
+            ["bash", str(script_dir / "mnemon_ops.sh"), *args],
+            capture_output=True, text=True, cwd=str(tmp_path), env=env,
+        )
+
+    def test_extracts_named_version(self, fake_changelog, tmp_path):
+        result = self._run_in_synthetic_repo(
+            tmp_path, "changelog-extract", "0.9.0",
+        )
+        assert result.returncode == 0, result.stderr
+        assert "## [0.9.0] - 2026-06-01" in result.stdout
+        assert "Some feature" in result.stdout
+        assert "bullet one" in result.stdout
+        # The next-version section must NOT bleed into the output.
+        assert "0.8.0" not in result.stdout
+        assert "Another feature" not in result.stdout
+
+    def test_missing_version_exits_1(self, fake_changelog, tmp_path):
+        result = self._run_in_synthetic_repo(
+            tmp_path, "changelog-extract", "9.9.9",
+        )
+        assert result.returncode == 1
+        assert "no `## [9.9.9]`" in result.stderr or "9.9.9" in result.stderr
+
+    def test_no_version_arg_exits_2(self):
+        result = _run("changelog-extract")
+        assert result.returncode == 2
+        assert "usage:" in result.stderr.lower()


### PR DESCRIPTION
## Summary

Closes 2026-05-21 ROADMAP follow-up. The 0.6.0 stable cut + subsequent releases produced recurring operator commands that got typed by hand 3-4 times per session. Consolidates them into a single dispatcher mirroring the established `scripts/salience_phase0.sh` pattern.

## Subcommands

| Subcommand | Purpose |
|---|---|
| `cleanup-test-apps` | Destroy every `mnemon-test-*` Fly app left dangling by interrupted layer3 runs |
| `recover-token` | Pull `MNEMON_LOCAL_TOKEN` from the live Fly app → `~/.mnemon/local_token` (0o600). Never echoes the value to stdout |
| `restart-machine` | `flyctl machine restart` + `mnemon doctor` — SSL handshake warmup for cold-start wedges |
| `vault-stats` | Size + recent-changes summary over the local vault |
| `changelog-extract <version>` | Python regex returning the matching `## [VERSION]` CHANGELOG section. Standalone use + future `promote_stable.sh publish` integration |

## Test plan

- [x] `test_mnemon_ops.py` (8 tests):
  - `bash -n` syntax check
  - `help` exits 0, lists every named subcommand
  - Unknown subcommand exits 2
  - `changelog-extract`: extracts named version, errors on missing (exit 1), errors on no-arg (exit 2). Synthetic CHANGELOG fixture via `tmp_path`
- [x] Full suite: **900 passed** (was 892 at branch-off → +8)
- [x] Local smoke: `bash scripts/mnemon_ops.sh help`, `vault-stats`, `changelog-extract 0.7.0rc5` all produce expected output
- [ ] Network/flyctl subcommands (`cleanup-test-apps`, `recover-token`, `restart-machine`) exercised by operator during next Layer-3 run — unit tests cover shape, integration is operator-driven

## Conventions

- `MNEMON_VENV_BIN` env-var override for CI / non-`.venv` operators
- `MNEMON_FLY_APP_NAME` env-var override for multi-app operators
- Self-documenting `help` subcommand using `sed` over the file header (DRY — single source of truth for usage docs)
- No credentials touch stdout: `recover-token` uses `flyctl ssh -C 'printenv ...' > file` then `chmod 600`

## Composes with

- `scripts/salience_phase0.sh` — the existing operator-script pattern this mirrors
- `scripts/promote_stable.sh` — future integration point: the publish step can call `mnemon_ops.sh changelog-extract` instead of redoing the regex inline