### PR TITLE
feat(memory_promote): NLI coherence check surfaces warnings post-promote

### DIFF
--- a/src/mnemon/server.py
+++ b/src/mnemon/server.py
@@ -224,6 +224,17 @@ def memory_promote(id: int) -> str:
 
     Hook-sourced memories (auto-mirror, session_extractor) cannot be
     promoted — operator-explicit gesture only (Layer 4 composition).
+
+    Coherence check (added 2026-05-27): after a successful promote,
+    runs NLI bidirectional classification between the new member and
+    each existing standing-tier member. If any pair classifies as
+    ``contradiction`` or ``update``, the warning is surfaced in the
+    return message — the operator can audit + demote either side.
+    Warning-only, not blocking, per the 2026-05-22 audit which found
+    that hard-rejecting on naive NLI hits would false-negative
+    "value updated over time" patterns. Composes with
+    [[mnemon-salience-tier-plan-260521]] invariant 6 (promotion is
+    operator-approved, not auto).
     """
     from .store import (
         StandingTierCapReached,
@@ -234,17 +245,86 @@ def memory_promote(id: int) -> str:
     try:
         ok = store.promote_to_standing(id)
         status = store.standing_tier_status()
-        return (
+        if not ok:
+            return f"Memory #{id} could not be promoted."
+
+        base_msg = (
             f"Promoted memory #{id} to standing tier "
             f"({status['count']}/{status['cap']})."
-            if ok else f"Memory #{id} could not be promoted."
         )
+        warning = _coherence_warning_for_promote(store, id)
+        return base_msg if not warning else f"{base_msg}\n\n{warning}"
     except StandingTierCapReached as e:
         return f"Cap reached: {e}"
     except StandingTierProvenanceRejected as e:
         return f"Provenance rejected: {e}"
     except StandingTierError as e:
         return f"Error: {e}"
+
+
+def _coherence_warning_for_promote(store, new_id: int) -> str:
+    """Run NLI bidirectional classification between the just-promoted
+    memory and the rest of the standing tier; return a warning block
+    naming any contradiction/update pairs, or empty string if clean.
+
+    Best-effort — NLI load failure or any classify error returns ""
+    (warning is observability, not a load-bearing primitive). Logged
+    to stderr for the operator who wants to know.
+
+    Skips comparison against the just-promoted doc itself.
+    """
+    try:
+        from .nli import classify_pair_bidirectional, NLIUnavailableError
+    except ImportError:
+        return ""
+
+    new_doc = store.get(new_id)
+    if not new_doc:
+        return ""
+
+    # Other live standing-tier members
+    rows = store.db.execute(
+        "SELECT d.id, d.title, c.doc AS content FROM documents d "
+        "JOIN content c ON d.hash = c.hash "
+        "WHERE d.tier = 'standing' AND d.invalidated_at IS NULL "
+        "AND d.id != ?",
+        (new_id,),
+    ).fetchall()
+    if not rows:
+        return ""
+
+    new_text = f"{new_doc.title or ''}: {new_doc.content or ''}"
+    conflicts: list[tuple[int, str, str]] = []  # (id, title, label)
+    for r in rows:
+        other_text = f"{r['title'] or ''}: {r['content'] or ''}"
+        try:
+            result = classify_pair_bidirectional(other_text, new_text)
+        except NLIUnavailableError:
+            logger.warning("memory_promote coherence: NLI unavailable, skipping check")
+            return ""
+        except Exception as exc:
+            logger.warning(
+                "memory_promote coherence: classify failed for #%d (%s); "
+                "skipping that pair", r["id"], exc,
+            )
+            continue
+        if result.mnemon_label in ("contradiction", "update"):
+            conflicts.append((r["id"], r["title"] or "", result.mnemon_label))
+
+    if not conflicts:
+        return ""
+
+    lines = [
+        "⚠ Coherence check surfaced potential conflicts within standing tier:",
+    ]
+    for cid, title, label in conflicts:
+        lines.append(f"  - {label}: #{cid} \"{title[:60]}\"")
+    lines.append(
+        "  Review the pair — `memory_get` each, then either keep both "
+        "(false positive — NLI has a known false-negative on factual "
+        "value updates) or `memory_demote` one to resolve."
+    )
+    return "\n".join(lines)
 
 
 @mcp.tool()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,6 +12,7 @@ from mnemon.server import (
     memory_forget,
     memory_get,
     memory_pin,
+    memory_promote,
     memory_rebuild,
     memory_related,
     memory_save,
@@ -316,6 +317,106 @@ class TestMemoryForget:
         MockStore.return_value.forget.return_value = False
         result = memory_forget(999)
         assert result == "Memory #999 not found or already forgotten."
+
+
+# ── memory_promote (coherence check) ─────────────────────────────────────────
+
+
+class TestMemoryPromoteCoherenceCheck:
+    """Regression for 2026-05-22 P1 ROADMAP follow-up. After a successful
+    memory_promote, NLI bidirectional classification runs between the
+    new member and existing standing-tier members. Contradictions /
+    updates surface as a warning in the return message (operator-
+    facing observability, NOT a hard reject — NLI has known
+    false-negatives on factual-value-updated-over-time patterns)."""
+
+    def _setup_store(self, MockStore, *, other_members):
+        """Wire a MagicMock store with the rows the coherence helper
+        queries: ``store.get(new_id)`` and ``store.db.execute(...)``
+        returning ``other_members``."""
+        mock_store = MockStore.return_value
+        mock_store.promote_to_standing.return_value = True
+        mock_store.standing_tier_status.return_value = {
+            "count": len(other_members) + 1, "cap": 15,
+        }
+        # The promoted memory itself
+        mock_doc = MagicMock()
+        mock_doc.title = "new standing memory"
+        mock_doc.content = "new authoritative content"
+        mock_store.get.return_value = mock_doc
+        # `store.db.execute(...).fetchall()` returns row dicts
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = other_members
+        mock_store.db.execute.return_value = mock_cursor
+        return mock_store
+
+    @patch("mnemon.server.Store")
+    def test_no_other_members_no_warning(self, MockStore):
+        self._setup_store(MockStore, other_members=[])
+        result = memory_promote(1)
+        assert "Promoted memory #1" in result
+        assert "Coherence check" not in result
+        assert "⚠" not in result
+
+    @patch("mnemon.server.Store")
+    def test_contradiction_surfaces_warning(self, MockStore):
+        # 1 existing standing member returns 'contradiction' from NLI
+        self._setup_store(MockStore, other_members=[
+            {"id": 42, "title": "prior member",
+             "content": "old assertion that conflicts"},
+        ])
+        with patch("mnemon.nli.classify_pair_bidirectional") as mock_nli:
+            mock_result = MagicMock()
+            mock_result.mnemon_label = "contradiction"
+            mock_nli.return_value = mock_result
+            result = memory_promote(1)
+        assert "Promoted memory #1" in result
+        assert "⚠ Coherence check" in result
+        assert "contradiction: #42" in result
+        assert "prior member" in result
+
+    @patch("mnemon.server.Store")
+    def test_update_label_also_surfaces(self, MockStore):
+        # 'update' is a softer conflict (one supersedes the other) —
+        # still surfaced so the operator can decide whether to demote
+        # the older one.
+        self._setup_store(MockStore, other_members=[
+            {"id": 7, "title": "older framing", "content": "outdated phrasing"},
+        ])
+        with patch("mnemon.nli.classify_pair_bidirectional") as mock_nli:
+            mock_result = MagicMock()
+            mock_result.mnemon_label = "update"
+            mock_nli.return_value = mock_result
+            result = memory_promote(1)
+        assert "update: #7" in result
+
+    @patch("mnemon.server.Store")
+    def test_same_label_does_not_surface(self, MockStore):
+        # `same` and `unrelated` are not conflicts — promote silently.
+        self._setup_store(MockStore, other_members=[
+            {"id": 99, "title": "related memory", "content": "..."},
+        ])
+        with patch("mnemon.nli.classify_pair_bidirectional") as mock_nli:
+            mock_result = MagicMock()
+            mock_result.mnemon_label = "same"
+            mock_nli.return_value = mock_result
+            result = memory_promote(1)
+        assert "⚠" not in result
+        assert "#99" not in result
+
+    @patch("mnemon.server.Store")
+    def test_nli_unavailable_skips_check_does_not_fail(self, MockStore):
+        # NLIUnavailableError → return empty warning, promote succeeds.
+        # Coherence check is observability, not load-bearing.
+        from mnemon.nli import NLIUnavailableError
+        self._setup_store(MockStore, other_members=[
+            {"id": 1, "title": "x", "content": "y"},
+        ])
+        with patch("mnemon.nli.classify_pair_bidirectional",
+                   side_effect=NLIUnavailableError("model missing")):
+            result = memory_promote(1)
+        assert "Promoted memory #1" in result
+        assert "⚠" not in result
 
 
 # ── memory_status ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes 2026-05-22 P1 ROADMAP follow-up. After a successful `memory_promote`, runs NLI bidirectional classification between the new standing-tier member and every existing standing-tier member. Contradictions / updates surface as a warning in the return message.

## Shape choice

The ROADMAP entry named three options; this PR ships **option (c) — operator-facing warning surface, not hard reject**.

Why not (a) "extract numeric/dated claims structurally": that's a substantial classifier-design lift, and the underlying NLI false-neg on "factual value updated over time" patterns (P3 follow-up from rc3) means even a correct structural extraction would need an LLM judge to interpret. Option (a) is the SOTA path but not in scope today.

Why not (b) "opt-in LLM-judge mode": filed as a separate P2 item (B14); the public-release "no LLM in mnemon by default" decision from 2026-05-21 holds.

Why (c): warning-only lets the operator audit + demote either side based on the actual claim shape. Hard-rejecting would block legitimate supersession edits whenever NLI sees a numeric mismatch — which is exactly the false-negative pattern the standing-tier coherence check exists to *catch*, not perpetuate.

## Behavior

- `memory_promote(id)` runs as before; standing-tier validation + cap + provenance gate still fire upstream
- After successful promote, the new `_coherence_warning_for_promote(store, new_id)` helper queries other live standing-tier members and runs `classify_pair_bidirectional` for each pair
- Conflicts (`contradiction` or `update` labels) get listed in the return message under "⚠ Coherence check surfaced potential conflicts"; the operator is told to `memory_get` each and `memory_demote` to resolve, with a note about the NLI false-neg edge case
- NLI unavailable / classify exception → empty warning, promote still succeeds. Best-effort observability, not load-bearing.

## Test plan

- [x] `TestMemoryPromoteCoherenceCheck` (5 tests): no other members → no warning, contradiction surfaces, update surfaces, same/unrelated stays silent, NLI unavailable skips gracefully
- [x] Full suite: **901 passed**
- [x] Existing `TestPromote` in test_standing_tier.py (store-layer) untouched; this PR only adds at the MCP-server layer

## Composes with

- `[[mnemon-salience-tier-plan-260521]]` invariant 6 (promotion is operator-approved, not auto)
- Layer 4 provenance demotion — hook-sourced rejection fires upstream in `store.promote_to_standing`; coherence runs only post-successful promote
- PR #157 NLI rebuild — reuses `cross-encoder/nli-deberta-v3-xsmall` infra
- B10 (PR #171) — `correction_of` is the operator-explicit supersession gesture; this PR is the audit-time discovery layer

## Out of scope (separate follow-ups)

- B14 LLM-judge opt-in mode for higher-fidelity classification (P2)
- Structural numeric-claim extraction for the cases NLI false-negatives on (still open; defer pending observed soak hits)