### PR TITLE
feat(standing-set): LLM-judge opt-in via `--judge anthropic`

### DIFF
--- a/scripts/build_standing_set.py
+++ b/scripts/build_standing_set.py
@@ -189,6 +189,30 @@ HARD_CEILING = 20  # plan invariant: never exceed 20
 # Operators can swap the strategy via --exemplar-source.
 VAULT_EXEMPLAR_DEFAULT_COUNT = 15
 VAULT_POSITIVE_CONFIDENCE_FLOOR = 0.80
+
+# LLM-judge constants (added 2026-05-27 per ROADMAP P2 follow-up).
+# Opt-in via --judge anthropic + ANTHROPIC_API_KEY env var. Default
+# remains the embedding scorer (zero new deps, public-release-friendly).
+JUDGE_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"
+JUDGE_RUBRIC_DIMENSIONS = ("generality", "durability", "imperative_shape", "cross_domain")
+JUDGE_RUBRIC_PROMPT = """\
+You are scoring a memory's fit for a "standing context" tier — a capped
+set of facts that condition reasoning on EVERY future prompt, regardless
+of query similarity. Members must be durable constraints, not ephemeral
+status.
+
+Score the memory on FOUR dimensions, each 1 (very low) to 5 (very high):
+  - generality: how widely does this rule apply? (specific event = 1,
+    cross-cutting principle = 5)
+  - durability: how long does this remain true? (will change in days = 1,
+    multi-year invariant = 5)
+  - imperative_shape: how rule-like vs context-like? (status update = 1,
+    explicit norm = 5)
+  - cross_domain: does this condition reasoning across unrelated query
+    types? (single-domain = 1, conditions advice everywhere = 5)
+
+Return a JSON object with each dimension as a key + a one-sentence
+rationale field. Be terse and consistent."""
 # Durable non-decaying SEMANTIC types (decision / preference / antipattern
 # per HALF_LIVES). Excludes observation/research/project/note: those
 # decay and represent context, not constraints.
@@ -295,6 +319,115 @@ def _sample_vault_exemplars(
         return title or snippet
 
     return [_fmt(r) for r in pos_rows], [_fmt(r) for r in neg_rows]
+
+
+def _score_via_anthropic_judge(docs: list[dict]) -> dict[int, float]:
+    """Score each memory's 'constraint-ness' via Anthropic Haiku rubric.
+
+    Returns {doc_id: score_in_0_to_1} — rubric mean over the 4
+    JUDGE_RUBRIC_DIMENSIONS normalized to [0.2, 1.0] (raw range
+    1-5 / 5 = 0.2-1.0).
+
+    Per-memory rationale is printed to stderr for audit; the existing
+    scoring pipeline downstream only consumes the scalar score, so the
+    rationale is observability not a return value.
+
+    Activation requirements:
+      - ``ANTHROPIC_API_KEY`` env var must be set.
+      - ``anthropic`` SDK must be importable (operator-side install:
+        ``pip install anthropic``).
+
+    Raises ``RuntimeError`` with operator-facing instructions if either
+    requirement is missing — fail loud per the no-silent-fail rule.
+    """
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "--judge anthropic requires ANTHROPIC_API_KEY env var. "
+            "Set it or use --judge embedding (default)."
+        )
+    try:
+        import anthropic
+    except ImportError as e:
+        raise RuntimeError(
+            "--judge anthropic requires the `anthropic` SDK. "
+            "Install via `pip install anthropic`, or use --judge embedding."
+        ) from e
+
+    client = anthropic.Anthropic(api_key=api_key)
+    scores: dict[int, float] = {}
+
+    print(
+        f"# LLM-judge scoring {len(docs)} memories via {JUDGE_ANTHROPIC_MODEL} ...",
+        file=sys.stderr,
+    )
+    for d in docs:
+        prompt = (
+            f"{JUDGE_RUBRIC_PROMPT}\n\n"
+            f"Memory title: {d['title'] or '(no title)'}\n"
+            f"Content type: {d['content_type']}\n"
+            f"Content: {(d['content'] or '')[:1500]}"
+        )
+        try:
+            msg = client.messages.create(
+                model=JUDGE_ANTHROPIC_MODEL,
+                max_tokens=300,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            text = "".join(
+                block.text for block in msg.content
+                if getattr(block, "type", None) == "text"
+            )
+            parsed = _parse_judge_response(text)
+            dim_values = [parsed.get(k, 3) for k in JUDGE_RUBRIC_DIMENSIONS]
+            mean_raw = sum(dim_values) / len(dim_values)
+            scores[d["id"]] = mean_raw / 5.0  # normalize 1-5 → 0.2-1.0
+            rationale = parsed.get("rationale", "")
+            print(
+                f"  #{d['id']:>5}  score={scores[d['id']]:.2f}  "
+                f"({'+'.join(str(v) for v in dim_values)})  {rationale}",
+                file=sys.stderr,
+            )
+        except Exception as exc:
+            # Best-effort — a single failed call shouldn't abort the
+            # whole run. Default to 0.0 (no constraint signal) so the
+            # other behavioral signals (correction, contradiction,
+            # breadth) still rank the memory.
+            print(
+                f"  #{d['id']:>5}  ERROR ({type(exc).__name__}: {exc}); "
+                f"falling back to 0.0",
+                file=sys.stderr,
+            )
+            scores[d["id"]] = 0.0
+
+    return scores
+
+
+def _parse_judge_response(text: str) -> dict:
+    """Extract the rubric JSON object from a Haiku response.
+
+    Haiku reliably returns valid JSON when the system prompt requests it,
+    but the response may include preamble text. Locate the first ``{``
+    through the matching ``}`` via bracket-counting and json.loads that
+    slice. Returns ``{}`` on parse failure — caller defaults all dims
+    to 3 (neutral) when keys are missing.
+    """
+    import json as _json
+    start = text.find("{")
+    if start == -1:
+        return {}
+    depth = 0
+    for i, ch in enumerate(text[start:], start=start):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    return _json.loads(text[start:i + 1])
+                except _json.JSONDecodeError:
+                    return {}
+    return {}
 
 
 def _correction_score(title: str, content: str, content_type: str, confidence: float) -> float:
@@ -438,6 +571,14 @@ def main() -> int:
                     help=f"how many vault exemplars to sample per class (positive + negative) "
                          f"when --exemplar-source ∈ {{hybrid, vault}} (default: "
                          f"{VAULT_EXEMPLAR_DEFAULT_COUNT})")
+    ap.add_argument("--judge", choices=("embedding", "anthropic"),
+                    default="embedding",
+                    help="constraint-score backend: 'embedding' (default, no deps — "
+                         "max cosine vs exemplars) or 'anthropic' (opt-in higher-fidelity "
+                         "Haiku rubric scoring; requires ANTHROPIC_API_KEY env var + "
+                         "`pip install anthropic`). LLM-judge replaces the embedding "
+                         "constraint signal only; correction/contradiction/breadth/time "
+                         "signals remain.")
     args = ap.parse_args()
 
     if args.top > HARD_CEILING:
@@ -554,16 +695,29 @@ def main() -> int:
         file=sys.stderr,
     )
 
-    # Embedding-based signals
+    # Embedding-based signals (time-penalty always uses embedding —
+    # the negative class isn't a fit for rubric scoring; "is this
+    # ephemeral?" is what the time exemplars measure structurally).
     print(f"# Embedding exemplars + memories ...", file=sys.stderr)
     from mnemon.embedder import embed_batch
 
-    constraint_emb = np.vstack(embed_batch(constraint_texts))
     time_emb = np.vstack(embed_batch(time_texts))
-
     embedded_ids, memory_vecs = _load_vectors_for_docs(vecstore_path, docs)
-    constraint_raw = dict(zip(embedded_ids, _cosine_max(memory_vecs, constraint_emb).tolist()))
     time_raw = dict(zip(embedded_ids, _cosine_max(memory_vecs, time_emb).tolist()))
+
+    # Constraint signal: --judge picks embedding (default) or anthropic.
+    # Falls back to embedding scoring if LLM-judge errors out at activation.
+    if args.judge == "anthropic":
+        try:
+            constraint_raw = _score_via_anthropic_judge(docs)
+        except RuntimeError as exc:
+            print(f"# ERROR: {exc}", file=sys.stderr)
+            return 2
+    else:
+        constraint_emb = np.vstack(embed_batch(constraint_texts))
+        constraint_raw = dict(
+            zip(embedded_ids, _cosine_max(memory_vecs, constraint_emb).tolist())
+        )
 
     # Behavioral + breadth signals (cheap, all docs)
     correction = {

--- a/tests/test_build_standing_set.py
+++ b/tests/test_build_standing_set.py
@@ -145,3 +145,145 @@ class TestSampleVaultExemplars:
         pos, neg = bss._sample_vault_exemplars(conn, n=10)
         assert pos == []
         assert neg == []
+
+
+class TestParseJudgeResponse:
+    """The judge parses Haiku's JSON response. Robust against preamble
+    text, missing keys, or invalid JSON — never raises, returns {}
+    on failure so caller can default missing keys."""
+
+    def test_pure_json_object(self, bss):
+        text = '{"generality": 4, "durability": 5, "imperative_shape": 3, "cross_domain": 4, "rationale": "Multi-year preference"}'
+        parsed = bss._parse_judge_response(text)
+        assert parsed["generality"] == 4
+        assert parsed["durability"] == 5
+        assert parsed["rationale"] == "Multi-year preference"
+
+    def test_json_with_preamble(self, bss):
+        text = (
+            "Here is my assessment:\n\n"
+            '{"generality": 5, "durability": 5, "imperative_shape": 5, '
+            '"cross_domain": 5, "rationale": "perfect rule"}'
+        )
+        parsed = bss._parse_judge_response(text)
+        assert parsed["generality"] == 5
+        assert parsed["rationale"] == "perfect rule"
+
+    def test_invalid_json_returns_empty(self, bss):
+        text = "This is not JSON at all { not-valid"
+        assert bss._parse_judge_response(text) == {}
+
+    def test_no_braces_returns_empty(self, bss):
+        text = "no object here, just prose"
+        assert bss._parse_judge_response(text) == {}
+
+    def test_nested_json_returns_outermost(self, bss):
+        # Nested object inside a value — the bracket counter handles it.
+        text = '{"a": {"b": 1}, "c": 2}'
+        parsed = bss._parse_judge_response(text)
+        assert parsed == {"a": {"b": 1}, "c": 2}
+
+
+class TestScoreViaAnthropicJudge:
+    """Tests for the LLM-judge backend (opt-in --judge anthropic).
+    All Anthropic API calls are mocked — no real API key needed."""
+
+    def test_missing_api_key_raises_runtime_error(self, bss, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        import pytest as _p
+        with _p.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
+            bss._score_via_anthropic_judge([{"id": 1, "title": "T", "content": "C", "content_type": "preference"}])
+
+    def test_missing_sdk_raises_runtime_error(self, bss, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-not-real")
+        # Simulate `anthropic` SDK absence by injecting None into sys.modules
+        # AND patching the import mechanism.
+        import sys as _sys
+        sentinel = object()
+        # Save + clear
+        prior = _sys.modules.get("anthropic", sentinel)
+        _sys.modules["anthropic"] = None  # makes `import anthropic` raise ImportError
+        try:
+            import pytest as _p
+            with _p.raises(RuntimeError, match="pip install anthropic"):
+                bss._score_via_anthropic_judge([{"id": 1, "title": "T", "content": "C", "content_type": "preference"}])
+        finally:
+            if prior is sentinel:
+                del _sys.modules["anthropic"]
+            else:
+                _sys.modules["anthropic"] = prior
+
+    def _inject_fake_anthropic(self, monkeypatch, mock_client):
+        """Inject a fake ``anthropic`` module into sys.modules so the
+        script's lazy ``import anthropic`` resolves to our stub. The
+        SDK isn't a hard dependency of mnemon-memory (operator-side
+        opt-in), so tests can't rely on it being installed."""
+        import sys as _sys
+        import types as _types
+
+        fake_module = _types.ModuleType("anthropic")
+        # The script does `anthropic.Anthropic(api_key=...)`. Make the
+        # class a no-arg factory that ignores kwargs and returns the
+        # mock client.
+        fake_module.Anthropic = lambda *a, **kw: mock_client
+        monkeypatch.setitem(_sys.modules, "anthropic", fake_module)
+
+    def test_happy_path_scores_each_doc(self, bss, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-not-real")
+        from unittest.mock import MagicMock
+
+        # Mock the Anthropic client end-to-end. Each messages.create
+        # returns a fixed rubric — score = mean(4,4,4,4)/5 = 0.8
+        mock_block = MagicMock()
+        mock_block.type = "text"
+        mock_block.text = (
+            '{"generality": 4, "durability": 4, "imperative_shape": 4, '
+            '"cross_domain": 4, "rationale": "solid"}'
+        )
+        mock_response = MagicMock()
+        mock_response.content = [mock_block]
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = mock_response
+        self._inject_fake_anthropic(monkeypatch, mock_client)
+
+        scores = bss._score_via_anthropic_judge([
+            {"id": 1, "title": "A", "content": "first", "content_type": "preference"},
+            {"id": 2, "title": "B", "content": "second", "content_type": "decision"},
+        ])
+
+        assert scores[1] == pytest.approx(0.8)
+        assert scores[2] == pytest.approx(0.8)
+        assert mock_client.messages.create.call_count == 2
+
+    def test_classify_failure_falls_back_to_zero(self, bss, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-not-real")
+        from unittest.mock import MagicMock
+
+        mock_client = MagicMock()
+        mock_client.messages.create.side_effect = RuntimeError("rate limit")
+        self._inject_fake_anthropic(monkeypatch, mock_client)
+
+        scores = bss._score_via_anthropic_judge([
+            {"id": 1, "title": "A", "content": "x", "content_type": "preference"},
+        ])
+        assert scores[1] == 0.0  # fallback, doesn't crash the run
+
+    def test_missing_dims_default_to_neutral(self, bss, monkeypatch):
+        """When the rubric JSON is missing a dimension, the caller
+        defaults it to 3 (neutral). Score = (5 + 1 + 3 + 3) / 4 / 5 = 0.6"""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-not-real")
+        from unittest.mock import MagicMock
+
+        mock_block = MagicMock()
+        mock_block.type = "text"
+        mock_block.text = '{"generality": 5, "durability": 1}'
+        mock_response = MagicMock()
+        mock_response.content = [mock_block]
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = mock_response
+        self._inject_fake_anthropic(monkeypatch, mock_client)
+
+        scores = bss._score_via_anthropic_judge([
+            {"id": 1, "title": "T", "content": "C", "content_type": "preference"},
+        ])
+        assert scores[1] == pytest.approx(0.6)


### PR DESCRIPTION
## Summary

Closes 2026-05-21 ROADMAP follow-up. Adds an optional higher-fidelity constraint scorer for `build_standing_set.py`. Gated behind both an env var AND a flag so the public-release default behavior is unchanged.

## Activation

**Default unchanged:** `--judge embedding` (no new deps, max cosine vs exemplars).

**Opt-in path:** `--judge anthropic` + `ANTHROPIC_API_KEY` env var + `pip install anthropic`. The SDK is lazy-imported in the script — NOT added to mnemon-memory's pyproject deps. Operators who don't want LLM in their mnemon stay completely unaffected.

**Failure modes:**
- Missing `ANTHROPIC_API_KEY` → `RuntimeError` with operator-facing instructions
- Missing `anthropic` SDK → `RuntimeError` with `pip install anthropic` instructions
- Per-doc API failure → score = 0.0 fallback so the run completes; other signals still rank the memory

Fails loud on activation-time gaps, falls back gracefully on per-call rate-limits. No silent fall-through to embedding when the operator explicitly asked for LLM.

## Rubric

4 dimensions, each 1–5, mean / 5 → score in [0.2, 1.0]:
- **generality** — how widely does this rule apply?
- **durability** — how long does this remain true?
- **imperative_shape** — how rule-like vs context-like?
- **cross_domain** — does this condition reasoning across unrelated query types?

Per-memory scores + rationale streamed to stderr for audit. The downstream scoring pipeline consumes only the scalar — rationale is observability.

## Scope

LLM-judge replaces ONLY the **constraint signal** (the cosine-vs-exemplars score). The other signals — correction, contradiction, breadth, time-penalty — remain on their existing paths. Time-penalty stays embedding-based because the "is this ephemeral?" question is what the time-bounded exemplars structurally measure; rubric scoring wouldn't add signal there.

## Test plan

10 new tests, all SDK-free (inject a fake `anthropic` ModuleType into `sys.modules` so CI doesn't need the dep installed):

- `TestParseJudgeResponse` (5): pure JSON, JSON with preamble, invalid JSON returns `{}`, no braces returns `{}`, nested objects handled
- `TestScoreViaAnthropicJudge` (5): missing API key raises, missing SDK raises, happy path scores each doc, classify failure falls back to 0.0, missing rubric dims default to 3 (neutral)

Full suite: **911 passed** (was 901 → +10).

## Composes with

- `[[feedback_sota_institutional_default_no_shortcuts]]` — embedding scorer is the SOTA-for-public-release default; LLM-judge is the higher-fidelity opt-in
- alpha-engine-research `evals/judge.py` rubric+rationale precedent
- `mnemon.llm` module pattern (existing optional-LLM via QMD-1.7B GGUF)
- PR #168 vault-derived auto-exemplars — both PRs are pluggable scoring backends; this PR adds the second axis