### PR TITLE
feat(cli): `status` / `search` / `save` honor remote mode

### DIFF
--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -1,16 +1,40 @@
 """CLI entry point for mnemon.
 
-Setup commands configure clients to use a remote vault. Local vault
-commands (status, search, save, forget, sync) operate on the local
-``~/.mnemon/default.sqlite`` and are intended for development or
-server-side administration — they do not interact with a remote vault.
+Setup commands configure clients to use a remote vault. Read/write
+commands (``status``, ``search``, ``save``) auto-route to the live
+remote vault when ``MNEMON_REMOTE_URL`` is set (env var or
+``~/.mnemon/remote_url`` file). Otherwise they hit the local
+``~/.mnemon/default.sqlite``. Local-only commands (``sync``,
+``rebuild``, ``forget``, ``standing``, ``attention-status``,
+``doctor``) intentionally stay on the local path — they're either
+server-administration (rebuild/sync) or operator-explicit gestures
+on the local vault.
 """
 
 from __future__ import annotations
 
+import os
 import sys
 
 from . import __version__
+
+
+def _remote_mode_active() -> bool:
+    """True iff a remote vault is configured.
+
+    Mirrors ``hooks._remote_client.get_remote_url`` resolution order:
+    env var first, then ``~/.mnemon/remote_url`` file. Doesn't validate
+    the URL — that's the caller's job at first network use.
+    """
+    if os.environ.get("MNEMON_REMOTE_URL", "").strip():
+        return True
+    from .hooks._remote_client import REMOTE_URL_FILE
+    if REMOTE_URL_FILE.exists():
+        try:
+            return bool(REMOTE_URL_FILE.read_text().strip())
+        except OSError:
+            return False
+    return False
 
 
 def main() -> None:
@@ -45,41 +69,47 @@ def main() -> None:
             sys.exit(1)
 
     elif command == "status":
-        from .store import Store
-        store = Store()
-        stats = store.status()
-        standing = store.standing_tier_status()
-        print(f"Vault: {stats['vault_path']}")
-        print(f"Total memories: {stats['total_documents']}")
-        print(f"Vectors: {stats['total_vectors']}")
-        print(f"Pinned: {stats['pinned']}")
-        print(f"Standing tier: {standing['count']}/{standing['cap']} "
-              f"(hard ceiling {standing['hard_ceiling']})")
-        print(f"Invalidated: {stats['invalidated']}")
-        print("\nBy type:")
-        for t in stats["by_type"]:
-            print(f"  {t['content_type']}: {t['count']}")
-        store.close()
+        if _remote_mode_active():
+            _status_remote()
+        else:
+            from .store import Store
+            store = Store()
+            stats = store.status()
+            standing = store.standing_tier_status()
+            print(f"Vault: {stats['vault_path']}")
+            print(f"Total memories: {stats['total_documents']}")
+            print(f"Vectors: {stats['total_vectors']}")
+            print(f"Pinned: {stats['pinned']}")
+            print(f"Standing tier: {standing['count']}/{standing['cap']} "
+                  f"(hard ceiling {standing['hard_ceiling']})")
+            print(f"Invalidated: {stats['invalidated']}")
+            print("\nBy type:")
+            for t in stats["by_type"]:
+                print(f"  {t['content_type']}: {t['count']}")
+            store.close()
 
     elif command == "search":
         query = " ".join(args[1:])
         if not query:
             print("Usage: mnemon search <query>", file=sys.stderr)
             sys.exit(1)
-        from .search import search
-        from .store import Store
-        store = Store()
-        results = search(store, query, limit=10)
-        if not results:
-            print("No memories found.")
+        if _remote_mode_active():
+            _search_remote(query)
         else:
-            for r in results:
-                snippet = r.content[:200]
-                ellipsis = "..." if len(r.content) > 200 else ""
-                print(f"[{r.content_type}] {r.title} (score: {r.composite_score:.3f})")
-                print(f"  {snippet}{ellipsis}")
-                print()
-        store.close()
+            from .search import search
+            from .store import Store
+            store = Store()
+            results = search(store, query, limit=10)
+            if not results:
+                print("No memories found.")
+            else:
+                for r in results:
+                    snippet = r.content[:200]
+                    ellipsis = "..." if len(r.content) > 200 else ""
+                    print(f"[{r.content_type}] {r.title} (score: {r.composite_score:.3f})")
+                    print(f"  {snippet}{ellipsis}")
+                    print()
+            store.close()
 
     elif command == "save":
         if len(args) < 3:
@@ -87,28 +117,31 @@ def main() -> None:
             sys.exit(1)
         title = args[1]
         content = " ".join(args[2:])
-        from .store import Store
-        store = Store()
-        doc_id = store.save(title=title, content=content, source_client="cli")
-        print(f'Saved memory #{doc_id}: "{title}"')
-        try:
-            from .embedder import embed_document
-            doc = store.get(doc_id)
-            if doc:
-                embed_document(store, doc.hash, title, content)
-        except Exception as exc:  # noqa: BLE001
-            # Loud on the CLI — an interactive save that skipped embedding
-            # means vector search won't find this memory. Exit non-zero so
-            # scripts catch it; `mnemon rebuild` is the recovery path.
-            print(
-                f"Warning: embedding failed ({type(exc).__name__}: {exc}). "
-                f"Memory saved to vault but will not surface in vector "
-                f"search until `mnemon rebuild` runs.",
-                file=sys.stderr,
-            )
+        if _remote_mode_active():
+            _save_remote(title, content)
+        else:
+            from .store import Store
+            store = Store()
+            doc_id = store.save(title=title, content=content, source_client="cli")
+            print(f'Saved memory #{doc_id}: "{title}"')
+            try:
+                from .embedder import embed_document
+                doc = store.get(doc_id)
+                if doc:
+                    embed_document(store, doc.hash, title, content)
+            except Exception as exc:  # noqa: BLE001
+                # Loud on the CLI — an interactive save that skipped embedding
+                # means vector search won't find this memory. Exit non-zero so
+                # scripts catch it; `mnemon rebuild` is the recovery path.
+                print(
+                    f"Warning: embedding failed ({type(exc).__name__}: {exc}). "
+                    f"Memory saved to vault but will not surface in vector "
+                    f"search until `mnemon rebuild` runs.",
+                    file=sys.stderr,
+                )
+                store.close()
+                sys.exit(2)
             store.close()
-            sys.exit(2)
-        store.close()
 
     elif command == "rebuild":
         # Re-embed every non-invalidated document. Surfaces per-doc
@@ -324,6 +357,84 @@ def main() -> None:
         print(f"Unknown command: {command}", file=sys.stderr)
         _print_usage()
         sys.exit(1)
+
+
+def _status_remote() -> None:
+    """``mnemon status`` against the configured remote vault.
+
+    Reads ``memory_status`` + ``memory_list_standing`` to produce the
+    same shape the local-mode path prints. Closes the 2026-05-21 gap
+    where the CLI silently fell back to a fresh empty SQLite instead
+    of reflecting the live remote.
+    """
+    import json as _json
+    from .hooks._remote_client import call_tool_sync, RemoteClientConfigError
+
+    try:
+        raw, _ = call_tool_sync("memory_status", {}, timeout=8.0)
+        stats = _json.loads(raw)
+        std_raw, _ = call_tool_sync("memory_list_standing", {}, timeout=5.0)
+        standing_docs = _json.loads(std_raw)
+    except (RemoteClientConfigError, Exception) as exc:
+        print(f"remote status failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Vault (remote): {stats.get('vault_path', '<remote>')}")
+    print(f"Total memories: {stats.get('total_documents', 0)}")
+    print(f"Vectors: {stats.get('total_vectors', 0)}")
+    print(f"Pinned: {stats.get('pinned', 0)}")
+    print(f"Standing tier: {len(standing_docs) if isinstance(standing_docs, list) else 0}")
+    print(f"Invalidated: {stats.get('invalidated', 0)}")
+    print("\nBy type:")
+    for t in stats.get("by_type", []):
+        print(f"  {t['content_type']}: {t['count']}")
+
+
+def _search_remote(query: str) -> None:
+    """``mnemon search <query>`` against the configured remote vault."""
+    import json as _json
+    from .hooks._remote_client import call_tool_sync, RemoteClientConfigError
+
+    try:
+        raw, _ = call_tool_sync(
+            "memory_search", {"query": query, "limit": 10}, timeout=8.0,
+        )
+        results = _json.loads(raw)
+    except (RemoteClientConfigError, Exception) as exc:
+        print(f"remote search failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if not results:
+        print("No memories found.")
+        return
+    for r in results:
+        content = r.get("content", "")
+        snippet = content[:200]
+        ellipsis = "..." if len(content) > 200 else ""
+        print(f"[{r.get('content_type', 'note')}] {r.get('title', '')} "
+              f"(score: {r.get('composite_score', 0):.3f})")
+        print(f"  {snippet}{ellipsis}")
+        print()
+
+
+def _save_remote(title: str, content: str) -> None:
+    """``mnemon save <title> <content>`` against the configured remote
+    vault. Tags ``source_client='cli'`` so the save is treated as an
+    explicit user gesture (no HOOK_SOURCE_CONFIDENCE_CEILING cap)."""
+    from .hooks._remote_client import call_tool_sync, RemoteClientConfigError
+
+    try:
+        raw, _ = call_tool_sync(
+            "memory_save",
+            {"title": title, "content": content, "source_client": "cli"},
+            timeout=10.0,
+        )
+    except (RemoteClientConfigError, Exception) as exc:
+        print(f"remote save failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+    # Server returns a human-facing confirmation line like
+    # `Saved memory #N: "Title" [note]` — pass through.
+    print(raw)
 
 
 def _handle_standing(subcommand: str, rest: list[str]) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,31 @@
 """Tests for CLI command dispatcher."""
 
 import sys
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import pytest
 
 from mnemon import __version__
 from mnemon.cli import main, _print_usage
+
+
+@pytest.fixture(autouse=True)
+def _isolate_remote_mode(monkeypatch, tmp_path_factory):
+    """Force remote-mode OFF by default for every test.
+
+    Without this, operator machines with ``~/.mnemon/remote_url`` populated
+    (the typical web-mode install) route the local-path tests through
+    ``call_tool_sync`` and hit the live Fly vault instead of the mocked
+    Store. Tests that exercise the remote path explicitly override via
+    setenv("MNEMON_REMOTE_URL", ...) or by writing the REMOTE_URL_FILE
+    patched in their own fixture.
+    """
+    monkeypatch.delenv("MNEMON_REMOTE_URL", raising=False)
+    bogus = tmp_path_factory.mktemp("no_remote") / "remote_url"
+    monkeypatch.setattr(
+        "mnemon.hooks._remote_client.REMOTE_URL_FILE", bogus,
+    )
 
 
 class TestVersionAndHelp:
@@ -799,6 +818,134 @@ class TestStandingCli:
         assert exc.value.code == 2
         err = capsys.readouterr().err
         assert "Unknown subcommand" in err
+
+
+class TestCliRemoteMode:
+    """Closes ROADMAP follow-up: status/search/save now honor remote
+    mode. The 2026-05-21 Layer-3 test surfaced the gap where these
+    commands silently fell back to a fresh empty SQLite instead of
+    routing through call_tool_sync against the live Fly vault.
+
+    Activation: MNEMON_REMOTE_URL env var OR ~/.mnemon/remote_url file.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolate(self, monkeypatch, tmp_path):
+        # Default: no remote configured. Per-test sets the env var or
+        # creates the remote_url file fixture.
+        monkeypatch.delenv("MNEMON_REMOTE_URL", raising=False)
+        monkeypatch.setattr(
+            "mnemon.hooks._remote_client.REMOTE_URL_FILE",
+            tmp_path / "remote_url",
+        )
+
+    def test_status_falls_back_to_local_when_no_remote_set(self):
+        """When neither env var nor remote_url file present, status
+        uses the local Store path — preserves pre-existing local-only
+        operator workflow."""
+        with patch("mnemon.cli._status_remote") as mock_remote:
+            with patch("mnemon.store.Store") as MockStore:
+                MockStore.return_value.status.return_value = {
+                    "vault_path": "/tmp/local.sqlite",
+                    "total_documents": 0, "total_vectors": 0,
+                    "pinned": 0, "invalidated": 0, "by_type": [],
+                }
+                MockStore.return_value.standing_tier_status.return_value = {
+                    "count": 0, "cap": 15, "hard_ceiling": 20,
+                }
+                with patch("sys.argv", ["mnemon", "status"]):
+                    main()
+        mock_remote.assert_not_called()
+
+    def test_status_routes_remote_when_env_var_set(self, monkeypatch, capsys):
+        monkeypatch.setenv("MNEMON_REMOTE_URL", "https://test.fly.dev/mcp")
+        import json as _j
+        status_payload = _j.dumps({
+            "vault_path": "<remote>",
+            "total_documents": 100, "total_vectors": 95,
+            "pinned": 5, "invalidated": 2,
+            "by_type": [{"content_type": "preference", "count": 50}],
+        })
+        standing_payload = _j.dumps([{"id": 1}, {"id": 2}, {"id": 3}])
+        with patch(
+            "mnemon.hooks._remote_client.call_tool_sync",
+            side_effect=[(status_payload, 0.1), (standing_payload, 0.05)],
+        ) as mock_call:
+            with patch("sys.argv", ["mnemon", "status"]):
+                main()
+        out = capsys.readouterr().out
+        assert "Vault (remote)" in out
+        assert "Total memories: 100" in out
+        assert "Standing tier: 3" in out
+        assert "preference: 50" in out
+        assert mock_call.call_count == 2
+
+    def test_search_routes_remote_when_env_var_set(self, monkeypatch, capsys):
+        monkeypatch.setenv("MNEMON_REMOTE_URL", "https://test.fly.dev/mcp")
+        import json as _j
+        payload = _j.dumps([{
+            "doc_id": 42, "title": "Hit", "content": "Matched content here",
+            "content_type": "preference", "composite_score": 0.91,
+        }])
+        with patch(
+            "mnemon.hooks._remote_client.call_tool_sync",
+            return_value=(payload, 0.1),
+        ) as mock_call:
+            with patch("sys.argv", ["mnemon", "search", "matched"]):
+                main()
+        out = capsys.readouterr().out
+        assert "Hit" in out
+        assert "score: 0.910" in out
+        mock_call.assert_called_once()
+        args = mock_call.call_args
+        assert args[0][0] == "memory_search"
+        assert args[0][1]["query"] == "matched"
+
+    def test_save_routes_remote_when_env_var_set(self, monkeypatch, capsys):
+        monkeypatch.setenv("MNEMON_REMOTE_URL", "https://test.fly.dev/mcp")
+        with patch(
+            "mnemon.hooks._remote_client.call_tool_sync",
+            return_value=('Saved memory #99: "Title" [note]', 0.1),
+        ) as mock_call:
+            with patch("sys.argv", ["mnemon", "save", "Title", "the", "content"]):
+                main()
+        out = capsys.readouterr().out
+        assert "Saved memory #99" in out
+        mock_call.assert_called_once()
+        args = mock_call.call_args
+        assert args[0][0] == "memory_save"
+        assert args[0][1]["title"] == "Title"
+        assert args[0][1]["content"] == "the content"
+        assert args[0][1]["source_client"] == "cli"
+
+    def test_search_remote_error_exits_1(self, monkeypatch, capsys):
+        monkeypatch.setenv("MNEMON_REMOTE_URL", "https://test.fly.dev/mcp")
+        with patch(
+            "mnemon.hooks._remote_client.call_tool_sync",
+            side_effect=RuntimeError("network down"),
+        ):
+            with patch("sys.argv", ["mnemon", "search", "q"]):
+                with pytest.raises(SystemExit) as exc:
+                    main()
+        assert exc.value.code == 1
+        assert "remote search failed" in capsys.readouterr().err
+
+    def test_remote_url_file_activates_remote_mode(self, monkeypatch, tmp_path):
+        """The file path (~/.mnemon/remote_url) is the canonical
+        operator-installed path; env var is the override. Both must
+        activate remote mode."""
+        url_file = tmp_path / "remote_url"
+        url_file.write_text("https://from-file.fly.dev/mcp")
+        monkeypatch.setattr(
+            "mnemon.hooks._remote_client.REMOTE_URL_FILE", url_file,
+        )
+        with patch(
+            "mnemon.hooks._remote_client.call_tool_sync",
+            return_value=("[]", 0.05),
+        ) as mock_call:
+            with patch("sys.argv", ["mnemon", "search", "q"]):
+                main()
+        mock_call.assert_called_once()
 
 
 class TestAttentionStatusPrint:


### PR DESCRIPTION
## Summary

Closes 2026-05-21 ROADMAP follow-up. The `mnemon` CLI was silently local-only even when `MNEMON_REMOTE_URL` or `~/.mnemon/remote_url` was configured. The 2026-05-21 Layer-3 test caught it (the `save via remote` + `status via remote` steps silently fell back to a fresh empty SQLite, masking the real failure); `scripts/promote_stable.sh layer3` worked around it via `_layer3_remote_helper.py`. This PR closes the gap at the canonical CLI surface.

## Mechanism

Mirrors `mnemon doctor`'s branching:
- New `_remote_mode_active()` helper checks `MNEMON_REMOTE_URL` env var, then `~/.mnemon/remote_url` file (same resolution order as `hooks._remote_client.get_remote_url`)
- `status` / `search` / `save` branch on the helper:
  - **Remote mode:** route through `call_tool_sync` to `memory_status` / `memory_search` / `memory_save` (the same MCP path the hooks already use)
  - **Local mode:** existing `Store()` path — unchanged for current local-only operators
- Three private helpers (`_status_remote`, `_search_remote`, `_save_remote`) own the remote rendering shape

## Scope

**In scope (auto-routes):** `status`, `search`, `save` — the read/write operator-facing surfaces.

**Intentionally local-only:**
- `sync push|pull` — file ops on the local vault, the remote side handles its own backup
- `rebuild` — re-embed local sqlite
- `forget` — operator gesture against the local vault (the live remote would need a separate explicit pathway)
- `standing list|promote|demote` — admin commands; the MCP equivalents already exist (`memory_promote` / `memory_demote` / `memory_list_standing`) for remote operators
- `attention-status` — soak monitor for the local vault

## Test plan

- [x] `TestCliRemoteMode` (6 tests): status local-fallback, status/search/save remote-route, search remote network error → exit 1, `~/.mnemon/remote_url` file alone activates remote mode
- [x] Module-level autouse `_isolate_remote_mode` fixture: prevents the pre-existing local-path tests from picking up the operator's real `~/.mnemon/remote_url` file on dev machines (would route them through the new remote path and break the mocked-Store assertions)
- [x] Full suite: **943 passed**

## Composes with

- `[[feedback_no_silent_fails]]` — the prior silent local-fallback was exactly the failure mode the rule rejects
- ROADMAP follow-up: drop `_layer3_remote_helper.py` workaround once `promote_stable.sh layer3` can rely on this CLI honoring remote mode (separate PR)