### PR TITLE
feat(attention-report): Phase B access-count consolidation feedback loop

### DIFF
--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -334,6 +334,34 @@ def main() -> None:
             print(f"downgrade failed: {exc}", file=sys.stderr)
             sys.exit(1)
 
+    elif command == "attention-report":
+        # Capture attention Phase B — access-count consolidation feedback.
+        # Ranks live memories by access_count × recency so the operator
+        # can see which fragments are load-bearing — those are exactly
+        # the candidates for standing-tier promotion (composes with
+        # Salience Phase 2).
+        from .store import Store
+        limit = 20
+        min_count = 2
+        for i, a in enumerate(args[1:], start=1):
+            if a == "--limit" and i + 1 < len(args):
+                try:
+                    limit = int(args[i + 1])
+                except ValueError:
+                    print(f"Error: --limit must be an integer", file=sys.stderr)
+                    sys.exit(2)
+            elif a == "--min-access" and i + 1 < len(args):
+                try:
+                    min_count = int(args[i + 1])
+                except ValueError:
+                    print(f"Error: --min-access must be an integer", file=sys.stderr)
+                    sys.exit(2)
+        store = Store()
+        try:
+            _print_attention_report(store, limit=limit, min_access_count=min_count)
+        finally:
+            store.close()
+
     elif command == "attention-status":
         # Capture attention Phase A observability — soak monitor.
         # private/mnemon-capture-attention-plan-260522.md
@@ -517,6 +545,32 @@ def _handle_standing(subcommand: str, rest: list[str]) -> None:
             sys.exit(2)
     finally:
         store.close()
+
+
+def _print_attention_report(store, *, limit: int, min_access_count: int) -> None:
+    """Print a ranked list of high-access memories — capture-attention
+    Phase B consolidation feedback. Each row shows the memory's
+    access_count, age, recency factor, and combined score so the
+    operator can spot durable load-bearing memories that would benefit
+    from standing-tier promotion."""
+    rows = store.attention_report(limit=limit, min_access_count=min_access_count)
+    print(f"Attention report — top {limit} live memories by access × recency")
+    print(f"  (filtered access_count ≥ {min_access_count})\n")
+    if not rows:
+        print("  (no memories meet the filter — increase access by using "
+              "memory_search / memory_get, or lower --min-access)")
+        return
+    print(f"  {'id':>5}  {'score':>6}  {'×acc':>5}  {'age':>6}  "
+          f"{'rec':>5}  tier         type           title")
+    for r in rows:
+        tier_label = (r["tier"] or "situational")[:12]
+        ct = (r["content_type"] or "")[:12]
+        title = (r["title"] or "")[:60]
+        print(
+            f"  #{r['id']:>4}  {r['score']:>6.2f}  "
+            f"{r['access_count']:>4}×  {r['age_days']:>5.1f}d  "
+            f"{r['recency']:>5.2f}  {tier_label:<12}  {ct:<13}  {title}"
+        )
 
 
 def _print_attention_status(store) -> tuple[float, float]:
@@ -736,6 +790,9 @@ Local vault (development/server-side only):
                             recent 'restates' relations
                             [--strict: exit 1 if boost-rate > ceiling,
                             for periodic health-check wiring]
+  mnemon attention-report   Phase B consolidation feedback — rank live
+                            memories by access_count × recency
+                            [--limit N] [--min-access N]
 
 Salience tier (standing-context recall):
   mnemon standing list      Show all standing-tier memories + count vs cap

--- a/src/mnemon/search.py
+++ b/src/mnemon/search.py
@@ -281,4 +281,22 @@ def search(
     if content_type:
         scored = [r for r in scored if r.content_type == content_type]
 
-    return mmr_rerank(scored[:limit])
+    reranked = mmr_rerank(scored[:limit])
+
+    # Capture-attention Phase B: increment access_count for every
+    # surfaced doc. The column already accumulates on memory_get, so
+    # wiring search hits closes the loop on `mnemon attention-report`
+    # (high-access fragments are the load-bearing facts the salience
+    # tier should consider). Batched in one UPDATE … IN (…) so the
+    # cost is one round-trip regardless of `limit`.
+    if reranked:
+        ids = [r.doc_id for r in reranked]
+        placeholders = ",".join("?" * len(ids))
+        store.db.execute(
+            f"UPDATE documents SET access_count = access_count + 1 "
+            f"WHERE id IN ({placeholders})",
+            ids,
+        )
+        store.db.commit()
+
+    return reranked

--- a/src/mnemon/store.py
+++ b/src/mnemon/store.py
@@ -29,6 +29,7 @@ from .config import (
     MEMORY_TYPE_MAP,
     DEFAULT_CONFIDENCE,
     PIN_BOOST,
+    RECENCY_HALF_LIFE_DAYS,
     STANDING_TIER_BLOCKED_SOURCE_CLIENTS,
     STANDING_TIER_DEFAULT_CAP,
     STANDING_TIER_HARD_CEILING,
@@ -1095,6 +1096,63 @@ class Store:
                ORDER BY d.created_at DESC"""
         ).fetchall()
         return [_row_to_document(r) for r in rows]
+
+    def attention_report(
+        self, limit: int = 20, min_access_count: int = 2,
+    ) -> list[dict[str, Any]]:
+        """Rank live memories by ``access_count × recency`` for the
+        capture-attention Phase B consolidation feedback loop.
+
+        Recency factor: e^(-age_days / RECENCY_HALF_LIFE_DAYS) so a
+        memory accessed 30 days ago counts roughly half as much as one
+        accessed today, mirroring the search composite-score recency
+        decay. High-access fragments are the load-bearing facts the
+        standing tier should consider promoting (composes with the
+        Salience Phase 2 promotion-signals work — both surface the
+        same "this memory is actually being used a lot" signal).
+
+        ``min_access_count`` filters out the tail (every memory has at
+        least one access from creation-time get). Default 2 keeps the
+        report relevant.
+        """
+        rows = self.db.execute(
+            """SELECT d.id, d.title, d.content_type, d.confidence,
+                      d.access_count, d.created_at, d.tier
+               FROM documents d
+               WHERE d.invalidated_at IS NULL
+                 AND d.access_count >= ?
+               ORDER BY d.access_count DESC
+               LIMIT ?""",
+            (min_access_count, limit * 4),  # over-fetch for recency rerank
+        ).fetchall()
+
+        import datetime as _dt
+        import math as _math
+        now = _dt.datetime.now()
+        scored: list[dict[str, Any]] = []
+        for r in rows:
+            try:
+                created = _dt.datetime.fromisoformat(
+                    str(r["created_at"]).replace("Z", "")
+                )
+                age_days = max((now - created).total_seconds() / 86400.0, 0.0)
+            except (ValueError, TypeError):
+                age_days = 0.0
+            recency = _math.exp(-age_days / RECENCY_HALF_LIFE_DAYS)
+            score = r["access_count"] * recency
+            scored.append({
+                "id": r["id"],
+                "title": r["title"],
+                "content_type": r["content_type"],
+                "confidence": r["confidence"],
+                "access_count": r["access_count"],
+                "age_days": round(age_days, 1),
+                "recency": round(recency, 3),
+                "score": round(score, 2),
+                "tier": r["tier"],
+            })
+        scored.sort(key=lambda x: x["score"], reverse=True)
+        return scored[:limit]
 
     def standing_tier_status(self) -> dict[str, Any]:
         """Stats for ``mnemon status`` + dashboards: current count vs cap."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -948,6 +948,60 @@ class TestCliRemoteMode:
         mock_call.assert_called_once()
 
 
+class TestAttentionReport:
+    """Coverage for the new `mnemon attention-report` subcommand —
+    Capture-attention Phase B operator surface."""
+
+    @patch("mnemon.store.Store")
+    def test_renders_rows(self, MockStore, capsys):
+        mock_store = MockStore.return_value
+        mock_store.attention_report.return_value = [
+            {"id": 42, "title": "load-bearing fact", "content_type": "preference",
+             "confidence": 0.85, "access_count": 12, "age_days": 5.2,
+             "recency": 0.88, "score": 10.56, "tier": "situational"},
+        ]
+        with patch("sys.argv", ["mnemon", "attention-report"]):
+            main()
+        out = capsys.readouterr().out
+        assert "Attention report" in out
+        assert "#  42" in out
+        assert "load-bearing fact" in out
+        assert "10.56" in out
+        mock_store.attention_report.assert_called_once_with(
+            limit=20, min_access_count=2,
+        )
+
+    @patch("mnemon.store.Store")
+    def test_empty_message(self, MockStore, capsys):
+        mock_store = MockStore.return_value
+        mock_store.attention_report.return_value = []
+        with patch("sys.argv", ["mnemon", "attention-report"]):
+            main()
+        out = capsys.readouterr().out
+        assert "no memories meet the filter" in out
+
+    @patch("mnemon.store.Store")
+    def test_limit_and_min_access_flags(self, MockStore, capsys):
+        mock_store = MockStore.return_value
+        mock_store.attention_report.return_value = []
+        with patch("sys.argv",
+                   ["mnemon", "attention-report",
+                    "--limit", "5", "--min-access", "10"]):
+            main()
+        mock_store.attention_report.assert_called_once_with(
+            limit=5, min_access_count=10,
+        )
+
+    @patch("mnemon.store.Store")
+    def test_non_integer_limit_exits_2(self, MockStore, capsys):
+        with patch("sys.argv",
+                   ["mnemon", "attention-report", "--limit", "abc"]):
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 2
+        assert "must be an integer" in capsys.readouterr().err
+
+
 class TestAttentionStatusPrint:
     """Coverage for _print_attention_status — the largest uncovered
     cli.py block after _handle_standing."""

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -221,3 +221,33 @@ class TestSearch:
         results = search(store, "Python", use_vector=False)
         assert len(results) >= 1
         assert results[0].vector_similarity is None
+
+    def test_search_increments_access_count_for_surfaced_results(self, store):
+        """Capture-attention Phase B: surfaced search results bump
+        access_count so the attention-report can identify the
+        load-bearing fragments."""
+        doc_id = store.save(title="Python", content="Python is great")
+        # Reset access_count to 0 (Store.save left it implicit; we want
+        # to assert only the search-side increment).
+        store.db.execute(
+            "UPDATE documents SET access_count = 0 WHERE id = ?", (doc_id,),
+        )
+        store.db.commit()
+        search(store, "Python", use_vector=False)
+        row = store.db.execute(
+            "SELECT access_count FROM documents WHERE id = ?", (doc_id,),
+        ).fetchone()
+        assert row["access_count"] == 1
+        # Second hit on the same query bumps it again.
+        search(store, "Python", use_vector=False)
+        row = store.db.execute(
+            "SELECT access_count FROM documents WHERE id = ?", (doc_id,),
+        ).fetchone()
+        assert row["access_count"] == 2
+
+    def test_search_no_results_does_not_error_on_access_increment(self, store):
+        """Empty-result path must not attempt the IN () update — that's
+        a malformed SQL statement. Regression for the branch."""
+        results = search(store, "nonexistent xyz term", use_vector=False)
+        assert results == []
+        # Just reaching here without an OperationalError is the assertion.

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -342,6 +342,66 @@ class TestCorrectionOf:
         mock_apply.assert_not_called()
 
 
+class TestAttentionReport:
+    """Capture-attention Phase B: access_count × recency rank for
+    consolidation candidates. The column already accumulates on
+    Store.get + Store.save dedup; this test set covers the report
+    surface that turns it into operator-actionable signal."""
+
+    def test_filters_by_min_access_count(self, store):
+        a = store.save(title="A", content="frequent")
+        b = store.save(title="B", content="rarely accessed")
+        # Bump a's access_count via repeated get()s
+        for _ in range(5):
+            store.get(a)
+        rows = store.attention_report(limit=10, min_access_count=2)
+        ids = [r["id"] for r in rows]
+        assert a in ids
+        assert b not in ids
+
+    def test_recency_weights_score(self, store):
+        import datetime as _dt
+        new = store.save(title="New", content="recent")
+        old = store.save(title="Old", content="ancient")
+        store.db.execute(
+            "UPDATE documents SET created_at = ?, access_count = 10 "
+            "WHERE id = ?",
+            ((_dt.datetime.now() - _dt.timedelta(days=60)).isoformat(sep=" "), old),
+        )
+        store.db.execute(
+            "UPDATE documents SET access_count = 10 WHERE id = ?", (new,),
+        )
+        store.db.commit()
+        rows = store.attention_report(limit=10, min_access_count=2)
+        scores = {r["id"]: r["score"] for r in rows}
+        # New should outscore old at same access_count (recency decay)
+        assert scores[new] > scores[old]
+
+    def test_limit_caps_output(self, store):
+        for i in range(15):
+            doc_id = store.save(title=f"M{i}", content=f"content {i}")
+            store.db.execute(
+                "UPDATE documents SET access_count = 5 WHERE id = ?", (doc_id,),
+            )
+        store.db.commit()
+        rows = store.attention_report(limit=5, min_access_count=2)
+        assert len(rows) == 5
+
+    def test_excludes_invalidated(self, store):
+        a = store.save(title="A", content="live")
+        b = store.save(title="B", content="forgotten")
+        store.db.execute(
+            "UPDATE documents SET access_count = 10 WHERE id IN (?, ?)",
+            (a, b),
+        )
+        store.db.commit()
+        store.forget(b)
+        rows = store.attention_report(limit=10, min_access_count=2)
+        ids = [r["id"] for r in rows]
+        assert a in ids
+        assert b not in ids
+
+
 class TestStatus:
     def test_status_counts(self, store):
         store.save(title="A", content="a", content_type="note")


### PR DESCRIPTION
## Summary

Closes 2026-05-22 P1 ROADMAP follow-up — Capture-attention Phase B. The `documents.access_count` column already accumulated on `Store.get` + `Store.save` dedup, but nothing read it. Wiring search-side increments + a new `mnemon attention-report` CLI turns it into operator-actionable signal (high-access fragments = load-bearing facts the standing tier should consider promoting).

## Mechanism

- **`search.py`** — every `memory_search` hit batches an `UPDATE documents SET access_count = access_count + 1 WHERE id IN (...)` in one round-trip post-MMR rerank. Skips the empty-result path to avoid a malformed `IN ()` SQL.
- **`Store.attention_report(limit, min_access_count)`** — ranks live memories by `access_count × exp(-age_days / RECENCY_HALF_LIFE_DAYS)`. Mirrors the recency decay the search composite-score already uses, so high-access-but-stale memories don't dominate over high-access-recent ones. `min_access_count=2` default filters out the long tail of creation-time-only accesses.
- **`mnemon attention-report [--limit N] [--min-access N]`** — compact table: score / access / age / recency / tier / type / title.

## Test plan

- `TestAttentionReport` in `test_store.py` (4): `min_access_count` filter, recency weighting (60d-old loses to fresh at same access count), `--limit` cap, excludes invalidated
- `test_search.py` (2): surfaced results bump access_count; empty-results path does not raise (regression-locks the `IN ()` defense)
- `TestAttentionReport` in `test_cli.py` (4): rendered rows, empty-message path, flag parsing, non-integer flag → exit 2
- Full suite: **947 passed**

## Composes with

- Capture-attention Phase A (#153 + #165) — Phase A boosts on save-time recurrence; Phase B surfaces on read-time access. Together they identify durable consolidation candidates.
- Salience Phase 2 (still open — P1 promotion signals) — both surface "this memory is being used a lot" signal; this PR's report becomes Phase 2's candidate-promotion source.
- Phase C (consolidation pass, still open) — the report's top-N feeds the merge proposals.