### PR TITLE
feat(salience): Phase 2 promotion signals — correction + contradiction-win counters

### DIFF
--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -334,6 +334,26 @@ def main() -> None:
             print(f"downgrade failed: {exc}", file=sys.stderr)
             sys.exit(1)
 
+    elif command == "salience-report":
+        # Salience tier Phase 2 — promotion-signal candidate ranking.
+        # Surfaces the situational-tier memories with the highest
+        # correction_count + contradiction_win_count so the operator
+        # can review and promote the genuinely load-bearing ones.
+        from .store import Store
+        limit = 20
+        for i, a in enumerate(args[1:], start=1):
+            if a == "--limit" and i + 1 < len(args):
+                try:
+                    limit = int(args[i + 1])
+                except ValueError:
+                    print("Error: --limit must be an integer", file=sys.stderr)
+                    sys.exit(2)
+        store = Store()
+        try:
+            _print_salience_report(store, limit=limit)
+        finally:
+            store.close()
+
     elif command == "attention-report":
         # Capture attention Phase B — access-count consolidation feedback.
         # Ranks live memories by access_count × recency so the operator
@@ -545,6 +565,34 @@ def _handle_standing(subcommand: str, rest: list[str]) -> None:
             sys.exit(2)
     finally:
         store.close()
+
+
+def _print_salience_report(store, *, limit: int) -> None:
+    """Render the Salience Phase 2 promotion-signal report. Each row
+    shows correction_count + contradiction_win_count + combined score
+    so the operator can decide which memories deserve standing-tier
+    promotion (via `mnemon standing promote <id>`)."""
+    rows = store.salience_report(limit=limit)
+    print(f"Salience report — top {limit} situational memories by promotion signal\n")
+    if not rows:
+        print("  (no candidates — correction_count + contradiction_win_count "
+              "are 0 across the situational tier; mechanism is observe-only "
+              "until an operator gesture or NLI win fires)")
+        return
+    print(f"  {'id':>5}  {'score':>5}  {'corr':>4}  {'wins':>4}  "
+          f"{'conf':>4}  type           title")
+    for r in rows:
+        ct = (r["content_type"] or "")[:12]
+        title = (r["title"] or "")[:60]
+        print(
+            f"  #{r['id']:>4}  {r['score']:>5}  "
+            f"{r['correction_count']:>4}  {r['contradiction_win_count']:>4}  "
+            f"{r['confidence']:>.2f}  {ct:<13}  {title}"
+        )
+    print(
+        "\n  Promote a candidate via `mnemon standing promote <id>` "
+        "(operator-approved per salience-tier plan invariant 6)."
+    )
 
 
 def _print_attention_report(store, *, limit: int, min_access_count: int) -> None:
@@ -793,6 +841,9 @@ Local vault (development/server-side only):
   mnemon attention-report   Phase B consolidation feedback — rank live
                             memories by access_count × recency
                             [--limit N] [--min-access N]
+  mnemon salience-report    Phase 2 promotion-signal candidates — rank
+                            situational memories by correction_count +
+                            contradiction_win_count [--limit N]
 
 Salience tier (standing-context recall):
   mnemon standing list      Show all standing-tier memories + count vs cap

--- a/src/mnemon/contradiction.py
+++ b/src/mnemon/contradiction.py
@@ -189,6 +189,15 @@ def check_contradictions(
                     "UPDATE documents SET confidence = ?, updated_at = datetime('now') WHERE id = ?",
                     (new_confidence, candidate.doc_id),
                 )
+                # Salience Phase 2: the new doc "won" — bump its
+                # contradiction_win_count so the promotion-signal
+                # scorer can identify structurally load-bearing memories
+                # (those that regularly demote others).
+                store.db.execute(
+                    "UPDATE documents SET contradiction_win_count = "
+                    "contradiction_win_count + 1 WHERE id = ?",
+                    (new_doc_id,),
+                )
                 store.db.commit()
                 store.add_relation(new_doc_id, candidate.doc_id, "supersedes", 0.8)
                 decayed += 1
@@ -200,6 +209,12 @@ def check_contradictions(
                 store.db.execute(
                     "UPDATE documents SET confidence = ?, updated_at = datetime('now') WHERE id = ?",
                     (new_confidence, candidate.doc_id),
+                )
+                # Salience Phase 2: see `update` branch above.
+                store.db.execute(
+                    "UPDATE documents SET contradiction_win_count = "
+                    "contradiction_win_count + 1 WHERE id = ?",
+                    (new_doc_id,),
                 )
                 store.db.commit()
                 store.add_relation(new_doc_id, candidate.doc_id, "contradicts", 0.9)

--- a/src/mnemon/store.py
+++ b/src/mnemon/store.py
@@ -255,6 +255,43 @@ class Store:
         self._migrate_source_key()
         self._migrate_recurrence_count()
         self._migrate_tier()
+        self._migrate_promotion_signals()
+
+    def _migrate_promotion_signals(self) -> None:
+        """Additive migration: ``documents.correction_count`` and
+        ``documents.contradiction_win_count`` count operator-explicit
+        corrections + contradiction-classifier wins respectively.
+        Salience tier Phase 2 (added 2026-05-27) —
+        private/mnemon-salience-tier-plan-260521.md.
+
+        - ``correction_count``: incremented on the TARGET of a
+          ``Store.save(correction_of=<id>)`` call. High value means
+          this memory keeps getting corrected — load-bearing signal
+          for the standing-tier promotion candidate score.
+        - ``contradiction_win_count``: incremented on the WINNING
+          side (the new doc) when ``contradiction.check_contradictions``
+          classifies a pair as ``update`` or ``contradiction``. High
+          value means this memory regularly demotes others —
+          structurally load-bearing.
+
+        Pre-existing rows get a count of 0. Schema is additive +
+        harmless if salience-report is never invoked.
+        """
+        cols = {
+            r["name"]
+            for r in self.db.execute("PRAGMA table_info(documents)").fetchall()
+        }
+        if "correction_count" not in cols:
+            self.db.execute(
+                "ALTER TABLE documents ADD COLUMN "
+                "correction_count INTEGER NOT NULL DEFAULT 0"
+            )
+        if "contradiction_win_count" not in cols:
+            self.db.execute(
+                "ALTER TABLE documents ADD COLUMN "
+                "contradiction_win_count INTEGER NOT NULL DEFAULT 0"
+            )
+        self.db.commit()
 
     def _migrate_tier(self) -> None:
         """Additive migration: ``documents.tier`` distinguishes
@@ -497,12 +534,22 @@ class Store:
         # is the operator-explicit cross-id gesture (different memory
         # entirely, but THIS one corrects the prior). The 'supersedes'
         # relation makes the chain queryable + auditable downstream.
+        #
+        # Salience Phase 2 (2026-05-27): also bumps the TARGET's
+        # correction_count so the operator-explicit correction signal
+        # accumulates per memory. High correction_count = "this fact
+        # keeps getting corrected" = load-bearing promotion candidate.
         if correction_of is not None:
             self.db.execute(
                 "INSERT OR REPLACE INTO relations "
                 "(source_id, target_id, relation_type, weight) "
                 "VALUES (?, ?, 'supersedes', 1.0)",
                 (doc_id, correction_of),
+            )
+            self.db.execute(
+                "UPDATE documents SET correction_count = correction_count + 1 "
+                "WHERE id = ?",
+                (correction_of,),
             )
         self.db.commit()
 
@@ -1096,6 +1143,61 @@ class Store:
                ORDER BY d.created_at DESC"""
         ).fetchall()
         return [_row_to_document(r) for r in rows]
+
+    def salience_report(
+        self, limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        """Rank live situational memories by Phase 2 promotion-signal
+        score = ``correction_count + contradiction_win_count``.
+
+        Operator surfaces the candidates that have been corrected or
+        won contradictions most often — those are the load-bearing
+        facts the standing-tier should consider promoting. Excludes
+        memories already on the standing tier (no point recommending
+        promotion of something already promoted) and any hook-sourced
+        memory (Layer 4 + STANDING_TIER_BLOCKED_SOURCE_CLIENTS apply
+        at the recommendation surface too).
+
+        Returns ``[]`` when no candidates meet the
+        ``correction_count > 0 OR contradiction_win_count > 0``
+        filter — surface stays empty rather than spamming creation-time
+        zeros.
+        """
+        rows = self.db.execute(
+            """SELECT id, title, content_type, confidence,
+                      correction_count, contradiction_win_count,
+                      source_client, created_at
+               FROM documents
+               WHERE invalidated_at IS NULL
+                 AND tier = 'situational'
+                 AND (correction_count > 0 OR contradiction_win_count > 0)
+               ORDER BY (correction_count + contradiction_win_count) DESC,
+                        correction_count DESC,
+                        contradiction_win_count DESC,
+                        id DESC
+               LIMIT ?""",
+            (limit * 4,),
+        ).fetchall()
+
+        results: list[dict[str, Any]] = []
+        for r in rows:
+            if r["source_client"] in STANDING_TIER_BLOCKED_SOURCE_CLIENTS:
+                # Hook-sourced can't be promoted to standing tier anyway —
+                # don't recommend them.
+                continue
+            results.append({
+                "id": r["id"],
+                "title": r["title"],
+                "content_type": r["content_type"],
+                "confidence": r["confidence"],
+                "correction_count": r["correction_count"],
+                "contradiction_win_count": r["contradiction_win_count"],
+                "score": r["correction_count"] + r["contradiction_win_count"],
+                "created_at": r["created_at"],
+            })
+            if len(results) >= limit:
+                break
+        return results
 
     def attention_report(
         self, limit: int = 20, min_access_count: int = 2,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -948,6 +948,54 @@ class TestCliRemoteMode:
         mock_call.assert_called_once()
 
 
+class TestSalienceReport:
+    """Coverage for `mnemon salience-report` — Salience tier Phase 2
+    promotion-signal candidate ranking surface."""
+
+    @patch("mnemon.store.Store")
+    def test_renders_rows(self, MockStore, capsys):
+        mock_store = MockStore.return_value
+        mock_store.salience_report.return_value = [
+            {"id": 7, "title": "load-bearing rule",
+             "content_type": "preference", "confidence": 0.85,
+             "correction_count": 3, "contradiction_win_count": 2,
+             "score": 5, "created_at": "2026-05-01"},
+        ]
+        with patch("sys.argv", ["mnemon", "salience-report"]):
+            main()
+        out = capsys.readouterr().out
+        assert "Salience report" in out
+        assert "#   7" in out
+        assert "load-bearing rule" in out
+        mock_store.salience_report.assert_called_once_with(limit=20)
+
+    @patch("mnemon.store.Store")
+    def test_empty_message(self, MockStore, capsys):
+        mock_store = MockStore.return_value
+        mock_store.salience_report.return_value = []
+        with patch("sys.argv", ["mnemon", "salience-report"]):
+            main()
+        out = capsys.readouterr().out
+        assert "no candidates" in out
+
+    @patch("mnemon.store.Store")
+    def test_limit_flag(self, MockStore, capsys):
+        mock_store = MockStore.return_value
+        mock_store.salience_report.return_value = []
+        with patch("sys.argv",
+                   ["mnemon", "salience-report", "--limit", "5"]):
+            main()
+        mock_store.salience_report.assert_called_once_with(limit=5)
+
+    @patch("mnemon.store.Store")
+    def test_non_integer_limit_exits_2(self, MockStore, capsys):
+        with patch("sys.argv",
+                   ["mnemon", "salience-report", "--limit", "abc"]):
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 2
+
+
 class TestAttentionReport:
     """Coverage for the new `mnemon attention-report` subcommand —
     Capture-attention Phase B operator surface."""

--- a/tests/test_contradiction.py
+++ b/tests/test_contradiction.py
@@ -117,6 +117,60 @@ class TestCheckContradictions:
         expected = max(CONFIDENCE_FLOOR, original_confidence - CONTRADICTION_DECAY)
         assert abs(doc1_after.confidence - expected) < 1e-6
 
+    def test_update_bumps_winner_contradiction_win_count(self, store):
+        """Salience Phase 2: the new doc (winner side) gets its
+        contradiction_win_count bumped on an `update` outcome."""
+        id1 = store.save(title="Old framing", content="prior phrasing")
+        id2 = store.save(title="New framing", content="stronger phrasing")
+
+        mock_results = [
+            SearchResult(
+                doc_id=id1, title="Old framing", content="prior phrasing",
+                content_type="note", memory_type="semantic", confidence=0.8,
+                created_at="2026-01-01", score=0.85, source="vector",
+            )
+        ]
+        with patch.object(store, "search_vector", return_value=mock_results), \
+             patch("mnemon.embedder.embed", return_value=_mock_embedding()), \
+             patch("mnemon.nli.classify_pair_bidirectional",
+                   return_value=_bidir("update")):
+            check_contradictions(store, "New framing", "stronger phrasing", id2)
+
+        row = store.db.execute(
+            "SELECT contradiction_win_count FROM documents WHERE id = ?",
+            (id2,),
+        ).fetchone()
+        assert row["contradiction_win_count"] == 1
+        # Loser side stays at 0.
+        row_loser = store.db.execute(
+            "SELECT contradiction_win_count FROM documents WHERE id = ?",
+            (id1,),
+        ).fetchone()
+        assert row_loser["contradiction_win_count"] == 0
+
+    def test_contradiction_bumps_winner_contradiction_win_count(self, store):
+        id1 = store.save(title="A", content="prior")
+        id2 = store.save(title="B", content="contradicts prior")
+
+        mock_results = [
+            SearchResult(
+                doc_id=id1, title="A", content="prior",
+                content_type="note", memory_type="semantic", confidence=0.8,
+                created_at="2026-01-01", score=0.9, source="vector",
+            )
+        ]
+        with patch.object(store, "search_vector", return_value=mock_results), \
+             patch("mnemon.embedder.embed", return_value=_mock_embedding()), \
+             patch("mnemon.nli.classify_pair_bidirectional",
+                   return_value=_bidir("contradiction")):
+            check_contradictions(store, "B", "contradicts prior", id2)
+
+        row = store.db.execute(
+            "SELECT contradiction_win_count FROM documents WHERE id = ?",
+            (id2,),
+        ).fetchone()
+        assert row["contradiction_win_count"] == 1
+
     def test_same_classification_adds_relation(self, store):
         id1 = store.save(title="Deploy step", content="Deploy via Lambda")
         id2 = store.save(title="Deploy step copy", content="We deploy using Lambda")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -342,6 +342,91 @@ class TestCorrectionOf:
         mock_apply.assert_not_called()
 
 
+class TestSalienceReport:
+    """Salience tier Phase 2 promotion signals — correction_count +
+    contradiction_win_count event-counter wiring + salience_report
+    ranking surface."""
+
+    def test_correction_of_increments_target_correction_count(self, store):
+        """The Phase 2 promotion signal: when a new memory corrects an
+        existing one (`correction_of=<id>`), the TARGET's
+        correction_count bumps."""
+        prior = store.save(title="Old", content="old payload")
+        store.save(title="New", content="new payload", correction_of=prior)
+        row = store.db.execute(
+            "SELECT correction_count FROM documents WHERE id = ?", (prior,),
+        ).fetchone()
+        assert row["correction_count"] == 1
+
+    def test_repeated_corrections_accumulate(self, store):
+        prior = store.save(title="Drift-prone", content="initial content")
+        for i in range(4):
+            store.save(
+                title=f"Correction {i}",
+                content=f"refined content version {i}",
+                correction_of=prior,
+            )
+        row = store.db.execute(
+            "SELECT correction_count FROM documents WHERE id = ?", (prior,),
+        ).fetchone()
+        assert row["correction_count"] == 4
+
+    def test_salience_report_ranks_by_combined_score(self, store):
+        # Three memories with different signal levels
+        high = store.save(title="High signal", content="much-corrected fact")
+        mid = store.save(title="Mid signal", content="some-corrected fact")
+        low = store.save(title="Low signal", content="rarely touched fact")
+        store.db.execute(
+            "UPDATE documents SET correction_count = 5, "
+            "contradiction_win_count = 3 WHERE id = ?", (high,),
+        )
+        store.db.execute(
+            "UPDATE documents SET correction_count = 0, "
+            "contradiction_win_count = 2 WHERE id = ?", (mid,),
+        )
+        store.db.execute(
+            "UPDATE documents SET correction_count = 0, "
+            "contradiction_win_count = 0 WHERE id = ?", (low,),
+        )
+        store.db.commit()
+        rows = store.salience_report(limit=10)
+        ids = [r["id"] for r in rows]
+        # high outranks mid; low is filtered out (zero signal).
+        assert ids == [high, mid]
+        assert rows[0]["score"] == 8
+        assert rows[1]["score"] == 2
+
+    def test_salience_report_excludes_standing_tier(self, store):
+        already_standing = store.save(title="Standing", content="promoted")
+        store.db.execute(
+            "UPDATE documents SET tier = 'standing', correction_count = 10 "
+            "WHERE id = ?", (already_standing,),
+        )
+        store.db.commit()
+        rows = store.salience_report(limit=10)
+        assert all(r["id"] != already_standing for r in rows)
+
+    def test_salience_report_excludes_hook_sourced(self, store):
+        # Layer 4 composition — hook-sourced can't be promoted anyway,
+        # so don't recommend them.
+        hook = store.save(
+            title="Hook fragment", content="captured by extractor",
+            source_client="claude-code-hook",
+        )
+        store.db.execute(
+            "UPDATE documents SET correction_count = 5 WHERE id = ?",
+            (hook,),
+        )
+        store.db.commit()
+        rows = store.salience_report(limit=10)
+        assert all(r["id"] != hook for r in rows)
+
+    def test_salience_report_empty_when_no_signal(self, store):
+        store.save(title="A", content="never corrected")
+        store.save(title="B", content="never contradicted")
+        assert store.salience_report(limit=10) == []
+
+
 class TestAttentionReport:
     """Capture-attention Phase B: access_count × recency rank for
     consolidation candidates. The column already accumulates on


### PR DESCRIPTION
## Summary

Closes 2026-05-21 ROADMAP Phase 2 follow-up. Wires the two promotion signals named in the salience-tier plan into existing event sites, adds the schema columns, and ships `mnemon salience-report` as the operator-facing candidate-ranking surface.

## Signals

- **`correction_count`** — bumped on the TARGET of a `Store.save(correction_of=<id>)` call. Composes with B10 (#171) which made `correction_of` a structural relation; this PR makes it a queryable counter signal. High value means "this fact keeps getting corrected" → load-bearing candidate.
- **`contradiction_win_count`** — bumped on the WINNING side (the new doc) when `contradiction.check_contradictions` classifies a pair as `update` or `contradiction`. Loser side stays at 0 (its confidence already decays via `UPDATE_DECAY` / `CONTRADICTION_DECAY` — losing twice would be double-jeopardy). High value means "this memory regularly demotes others" → structurally load-bearing.

## Schema

```
documents.correction_count INTEGER NOT NULL DEFAULT 0
documents.contradiction_win_count INTEGER NOT NULL DEFAULT 0
```

Additive ALTER TABLE via `_migrate_promotion_signals()` — harmless on pre-existing rows (default 0), follows the same migration pattern as `_migrate_tier` / `_migrate_recurrence_count`.

## Operator surface

**`Store.salience_report(limit=20)`** ranks live SITUATIONAL memories by `(correction_count + contradiction_win_count)`. Excludes:
- Standing-tier members (no point recommending what's already promoted)
- Hook-sourced (Layer 4 / `STANDING_TIER_BLOCKED_SOURCE_CLIENTS` — can't be promoted anyway)
- Zero-signal memories (SQL-level filter — no creation-time spam)

**`mnemon salience-report [--limit N]`** prints the candidate table with score + per-signal columns + a closing instruction (`mnemon standing promote <id>` to act on a candidate).

## Test plan

12 new tests, all green:

- `test_store.py::TestSalienceReport` (6): `correction_of` increments target, repeated corrections accumulate, ranking, excludes standing tier, excludes hook-sourced, empty-when-no-signal
- `test_contradiction.py` (2): `update` bumps winner contradiction_win_count (loser stays 0), `contradiction` bumps winner
- `test_cli.py::TestSalienceReport` (4): rendered rows, empty message, `--limit` flag, non-integer flag → exit 2

Full suite: **965 passed** (was 953 → +12).

## Composes with

- `[[mnemon-salience-tier-plan-260521]]` Phase 2 — this IS the implementation
- B10 / PR #171 `correction_of` — the explicit-gesture event source
- B9 / PR #173 NLI coherence check — sibling at promote-time; this PR is the candidate-*discovery* layer
- C26 / PR #177 `attention-report` — sibling consolidation-feedback ranking; salience-report ranks by **editorial** signal (corrections/wins), attention-report ranks by **usage** signal (access × recency). Operators cross-reference.

## Out of scope (follow-ups)

- Phase 3 observability + decay (`mnemon standing list` with age + recent contradiction-win count + last-injection event count) — separate PR
- Auto-promotion: ROADMAP explicitly says "operator-approved, not auto-promoted (auto-promotion risks crowding the capped tier with whatever memory happens to be on a hot streak)." This PR honors that.