### PR TITLE
feat(salience): Phase 3 observability — standing-tier aging + stale-flag surface

### DIFF
--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -496,20 +496,45 @@ def _handle_standing(subcommand: str, rest: list[str]) -> None:
     store = Store()
     try:
         if subcommand == "list":
-            docs = store.list_standing()
+            # Phase 3 observability: standing_tier_aging() returns the
+            # per-member age + last-injected + signal columns without
+            # bumping last_injected_at (that's list_standing's job).
+            aging = store.standing_tier_aging()
             status = store.standing_tier_status()
             print(f"Standing tier: {status['count']}/{status['cap']} "
                   f"(hard ceiling {status['hard_ceiling']})")
-            if not docs:
+            if not aging:
                 print("  (empty — promote memories via `mnemon standing promote <id>`)")
                 return
             print()
-            for d in docs:
-                snippet = (d.content or "")[:120].replace("\n", " ")
-                ellipsis = "..." if len(d.content or "") > 120 else ""
-                print(f"  #{d.id:>5}  [{d.content_type}]  {d.title}")
-                print(f"         {snippet}{ellipsis}")
-                print()
+            print(f"  {'id':>5}  {'age':>6}  {'last inj':>9}  "
+                  f"{'wins':>4}  {'corr':>4}  type           title")
+            stale_threshold_days = 90.0
+            for a in aging:
+                ct = (a["content_type"] or "")[:12]
+                title = (a["title"] or "")[:60]
+                if a["days_since_injected"] is None:
+                    last_inj = "never"
+                else:
+                    last_inj = f"{a['days_since_injected']:.0f}d ago"
+                stale_marker = ""
+                if (
+                    a["days_since_injected"] is not None
+                    and a["days_since_injected"] >= stale_threshold_days
+                ):
+                    stale_marker = "  ⚠ stale"
+                print(
+                    f"  #{a['id']:>4}  {a['age_days']:>5.0f}d  "
+                    f"{last_inj:>9}  "
+                    f"{a['contradiction_win_count']:>4}  "
+                    f"{a['correction_count']:>4}  "
+                    f"{ct:<13}  {title}{stale_marker}"
+                )
+            print(
+                f"\n  Stale threshold: {stale_threshold_days:.0f}d since last injection. "
+                "Phase 3 doesn't auto-demote — review and run "
+                "`mnemon standing demote <id>` if no longer load-bearing."
+            )
 
         elif subcommand == "promote":
             if not rest:

--- a/src/mnemon/store.py
+++ b/src/mnemon/store.py
@@ -256,6 +256,31 @@ class Store:
         self._migrate_recurrence_count()
         self._migrate_tier()
         self._migrate_promotion_signals()
+        self._migrate_last_injected_at()
+
+    def _migrate_last_injected_at(self) -> None:
+        """Additive migration: ``documents.last_injected_at`` records
+        the last time a standing-tier memory was injected into a
+        recall context (via ``list_standing``).
+
+        Salience tier Phase 3 (added 2026-05-27) — surfaces "this
+        memory hasn't fired in N days, still load-bearing?" for
+        operator review. Doesn't auto-demote (would re-open the
+        noise-floor problem); just observability.
+
+        Stays NULL for non-standing docs and for standing docs that
+        haven't yet been injected through ``list_standing``. The
+        operator-facing CLI renders "never" for NULL.
+        """
+        cols = {
+            r["name"]
+            for r in self.db.execute("PRAGMA table_info(documents)").fetchall()
+        }
+        if "last_injected_at" not in cols:
+            self.db.execute(
+                "ALTER TABLE documents ADD COLUMN last_injected_at TEXT"
+            )
+            self.db.commit()
 
     def _migrate_promotion_signals(self) -> None:
         """Additive migration: ``documents.correction_count`` and
@@ -1134,6 +1159,13 @@ class Store:
         Consumed by ``build_context`` (hook injection path) and
         ``mnemon standing list`` (operator CLI). Includes content body
         so callers can render snippets without a second fetch.
+
+        Salience tier Phase 3 (2026-05-27): bumps ``last_injected_at``
+        on every returned row to track injection events for the
+        ``standing list`` aging surface. Operator can spot stale
+        standing-tier members ("this hasn't fired in 90 days, still
+        load-bearing?") for review. Single batched UPDATE — cost is one
+        round-trip regardless of standing-tier size.
         """
         rows = self.db.execute(
             """SELECT d.*, c.doc
@@ -1142,7 +1174,76 @@ class Store:
                WHERE d.tier = 'standing' AND d.invalidated_at IS NULL
                ORDER BY d.created_at DESC"""
         ).fetchall()
+        if rows:
+            ids = [r["id"] for r in rows]
+            placeholders = ",".join("?" * len(ids))
+            self.db.execute(
+                f"UPDATE documents SET last_injected_at = datetime('now') "
+                f"WHERE id IN ({placeholders})",
+                ids,
+            )
+            self.db.commit()
         return [_row_to_document(r) for r in rows]
+
+    def standing_tier_aging(self) -> list[dict[str, Any]]:
+        """Standing-tier aging surface for Phase 3 observability.
+
+        Returns one row per live standing-tier member with:
+          - ``id`` / ``title`` / ``content_type``
+          - ``age_days`` (since created_at)
+          - ``contradiction_win_count`` (Phase 2 signal, persists for
+            review even after demote — but this method returns only
+            currently-standing)
+          - ``last_injected_at`` (raw timestamp; None until first
+            list_standing call hits it)
+          - ``days_since_injected`` (None if never, else days since
+            last_injected_at)
+
+        DOES NOT bump last_injected_at — this is an OBSERVATION call,
+        not an injection event. ``list_standing`` is the injection
+        path and owns the bump.
+
+        Operator-facing — surfaces "promoted 90 days ago, never fired"
+        as a candidate for ``memory_demote`` (Phase 3 doesn't
+        auto-demote per the plan invariant)."""
+        import datetime as _dt
+        rows = self.db.execute(
+            """SELECT id, title, content_type, confidence,
+                      created_at, last_injected_at,
+                      contradiction_win_count, correction_count
+               FROM documents
+               WHERE tier = 'standing' AND invalidated_at IS NULL
+               ORDER BY created_at DESC"""
+        ).fetchall()
+        now = _dt.datetime.now()
+
+        def _days_since(ts: str | None) -> float | None:
+            if not ts:
+                return None
+            try:
+                t = _dt.datetime.fromisoformat(str(ts).replace("Z", ""))
+            except (ValueError, TypeError):
+                return None
+            return max((now - t).total_seconds() / 86400.0, 0.0)
+
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            age_days = _days_since(r["created_at"]) or 0.0
+            since_inj = _days_since(r["last_injected_at"])
+            out.append({
+                "id": r["id"],
+                "title": r["title"],
+                "content_type": r["content_type"],
+                "confidence": r["confidence"],
+                "age_days": round(age_days, 1),
+                "contradiction_win_count": r["contradiction_win_count"],
+                "correction_count": r["correction_count"],
+                "last_injected_at": r["last_injected_at"],
+                "days_since_injected": (
+                    round(since_inj, 1) if since_inj is not None else None
+                ),
+            })
+        return out
 
     def salience_report(
         self, limit: int = 20,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -683,34 +683,49 @@ class TestStandingCli:
 
     @patch("mnemon.store.Store")
     def test_list_populated(self, MockStore, capsys):
-        from mnemon.store import Document
+        # Phase 3 surface: standing_tier_aging is the data source now.
         mock_store = MockStore.return_value
         mock_store.standing_tier_status.return_value = {
             "count": 2, "cap": 15, "hard_ceiling": 20,
         }
-        d1 = Document(
-            id=1, collection="default", path=None, title="Rule 1",
-            hash="h1", content_type="preference", memory_type="semantic",
-            confidence=0.85, quality_score=0.0, access_count=0, pinned=0,
-            source_client=None, invalidated_at=None, invalidated_by=None,
-            created_at="2026-05-01", updated_at="2026-05-01",
-            content="some constraint content",
-        )
-        d2 = Document(
-            id=2, collection="default", path=None, title="Rule 2",
-            hash="h2", content_type="decision", memory_type="semantic",
-            confidence=0.9, quality_score=0.0, access_count=0, pinned=0,
-            source_client=None, invalidated_at=None, invalidated_by=None,
-            created_at="2026-05-02", updated_at="2026-05-02",
-            content="another constraint",
-        )
-        mock_store.list_standing.return_value = [d1, d2]
+        mock_store.standing_tier_aging.return_value = [
+            {"id": 1, "title": "Rule 1", "content_type": "preference",
+             "confidence": 0.85, "age_days": 10.0,
+             "contradiction_win_count": 0, "correction_count": 0,
+             "last_injected_at": "2026-05-26 00:00:00",
+             "days_since_injected": 1.0},
+            {"id": 2, "title": "Rule 2", "content_type": "decision",
+             "confidence": 0.9, "age_days": 100.0,
+             "contradiction_win_count": 3, "correction_count": 1,
+             "last_injected_at": None, "days_since_injected": None},
+        ]
         with patch("sys.argv", ["mnemon", "standing", "list"]):
             main()
         out = capsys.readouterr().out
         assert "Standing tier: 2/15" in out
         assert "Rule 1" in out
         assert "Rule 2" in out
+        assert "never" in out  # second row has no injection yet
+
+    @patch("mnemon.store.Store")
+    def test_list_marks_stale_standing_members(self, MockStore, capsys):
+        # ⚠ marker when days_since_injected ≥ 90.
+        mock_store = MockStore.return_value
+        mock_store.standing_tier_status.return_value = {
+            "count": 1, "cap": 15, "hard_ceiling": 20,
+        }
+        mock_store.standing_tier_aging.return_value = [
+            {"id": 5, "title": "Stale rule", "content_type": "preference",
+             "confidence": 0.7, "age_days": 200.0,
+             "contradiction_win_count": 0, "correction_count": 0,
+             "last_injected_at": "2026-01-01 00:00:00",
+             "days_since_injected": 120.0},
+        ]
+        with patch("sys.argv", ["mnemon", "standing", "list"]):
+            main()
+        out = capsys.readouterr().out
+        assert "⚠ stale" in out
+        assert "Stale rule" in out
 
     @patch("mnemon.store.Store")
     def test_list_empty(self, MockStore, capsys):
@@ -718,7 +733,7 @@ class TestStandingCli:
         mock_store.standing_tier_status.return_value = {
             "count": 0, "cap": 15, "hard_ceiling": 20,
         }
-        mock_store.list_standing.return_value = []
+        mock_store.standing_tier_aging.return_value = []
         with patch("sys.argv", ["mnemon", "standing", "list"]):
             main()
         out = capsys.readouterr().out

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -342,6 +342,95 @@ class TestCorrectionOf:
         mock_apply.assert_not_called()
 
 
+class TestStandingTierAging:
+    """Salience tier Phase 3 observability — standing_tier_aging()
+    surfaces per-member age + last-injected + signal columns for the
+    operator to spot stale standing-tier members. list_standing()
+    bumps last_injected_at as the canonical injection-event surface."""
+
+    def test_list_standing_bumps_last_injected_at(self, store):
+        doc_id = store.save(title="Standing rule", content="some constraint")
+        store.promote_to_standing(doc_id)
+        # Pre-list_standing: last_injected_at is NULL.
+        row = store.db.execute(
+            "SELECT last_injected_at FROM documents WHERE id = ?", (doc_id,),
+        ).fetchone()
+        assert row["last_injected_at"] is None
+        # Call list_standing — bumps last_injected_at.
+        docs = store.list_standing()
+        assert len(docs) == 1
+        row = store.db.execute(
+            "SELECT last_injected_at FROM documents WHERE id = ?", (doc_id,),
+        ).fetchone()
+        assert row["last_injected_at"] is not None
+
+    def test_aging_renders_never_for_uninjected(self, store):
+        doc_id = store.save(title="Just promoted", content="never queried")
+        store.promote_to_standing(doc_id)
+        aging = store.standing_tier_aging()
+        assert len(aging) == 1
+        assert aging[0]["last_injected_at"] is None
+        assert aging[0]["days_since_injected"] is None
+
+    def test_aging_renders_days_since_injection(self, store):
+        import datetime as _dt
+        doc_id = store.save(title="Active rule", content="frequently injected")
+        store.promote_to_standing(doc_id)
+        # Backdate last_injected_at by 5 days
+        store.db.execute(
+            "UPDATE documents SET last_injected_at = ? WHERE id = ?",
+            ((_dt.datetime.now() - _dt.timedelta(days=5)).isoformat(sep=" "), doc_id),
+        )
+        store.db.commit()
+        aging = store.standing_tier_aging()
+        assert aging[0]["days_since_injected"] is not None
+        assert 4.5 <= aging[0]["days_since_injected"] <= 5.5
+
+    def test_aging_does_not_bump_last_injected(self, store):
+        """standing_tier_aging is observation, not injection — must NOT
+        bump last_injected_at. Otherwise calling `standing list` would
+        defeat the purpose (every call would refresh the timestamp)."""
+        doc_id = store.save(title="X", content="content")
+        store.promote_to_standing(doc_id)
+        # Seed an old timestamp
+        store.db.execute(
+            "UPDATE documents SET last_injected_at = '2026-01-01 00:00:00' "
+            "WHERE id = ?", (doc_id,),
+        )
+        store.db.commit()
+        store.standing_tier_aging()
+        store.standing_tier_aging()
+        row = store.db.execute(
+            "SELECT last_injected_at FROM documents WHERE id = ?", (doc_id,),
+        ).fetchone()
+        assert row["last_injected_at"] == "2026-01-01 00:00:00"
+
+    def test_aging_includes_phase_2_signals(self, store):
+        doc_id = store.save(title="Signal-rich", content="rule")
+        store.promote_to_standing(doc_id)
+        store.db.execute(
+            "UPDATE documents SET contradiction_win_count = 5, "
+            "correction_count = 2 WHERE id = ?", (doc_id,),
+        )
+        store.db.commit()
+        aging = store.standing_tier_aging()
+        assert aging[0]["contradiction_win_count"] == 5
+        assert aging[0]["correction_count"] == 2
+
+    def test_aging_excludes_situational_and_invalidated(self, store):
+        a = store.save(title="Standing", content="rule a")
+        store.promote_to_standing(a)
+        store.save(title="Situational", content="rule b")  # not promoted
+        c = store.save(title="Forgotten standing", content="rule c")
+        store.promote_to_standing(c)
+        store.forget(c)
+        aging = store.standing_tier_aging()
+        ids = [x["id"] for x in aging]
+        assert a in ids
+        assert c not in ids
+        assert len(ids) == 1
+
+
 class TestSalienceReport:
     """Salience tier Phase 2 promotion signals — correction_count +
     contradiction_win_count event-counter wiring + salience_report


### PR DESCRIPTION
## Summary

Closes 2026-05-21 ROADMAP Phase 3 follow-up. Standing items aren't static — they should still age, get reviewed, and be demotable when no longer load-bearing. This PR adds the injection-event tracking and operator-facing aging surface. Doesn't auto-demote (would re-open the noise-floor problem per plan invariant 6).

**⚠ STACKS ON PR #178 (C28 Phase 2 promotion signals).** Uses the new `contradiction_win_count` + `correction_count` columns. Merge #178 first, then rebase this against main before merging.

## Schema

```
documents.last_injected_at TEXT  -- nullable, additive migration
```

NULL until first `list_standing` call hits the doc; CLI renders "never" for NULL.

## Wiring

- **`Store.list_standing()`** batches a `UPDATE … SET last_injected_at = datetime('now') WHERE id IN (…)` at the end of every call. Fires in both `build_context`'s `_fetch_standing_via_mcp` path AND `mnemon standing list` when called via the operator CLI.
- **`Store.standing_tier_aging()`** returns per-member age + signal columns. Pure observation — does NOT bump `last_injected_at` (otherwise `standing list` would self-refresh and defeat the staleness signal).
- **`mnemon standing list`** renders a wide table: `id | age | last_inj | wins | corr | type | title`. Members with `days_since_injected ≥ 90d` get a "⚠ stale" marker. Closing line tells the operator how to demote per plan invariant 6.

## Test plan

10 new tests, all green:

- `test_store.py::TestStandingTierAging` (6): list_standing bumps last_injected_at; renders "never" for uninjected; renders days for injected; observation does NOT bump (regression-lock); includes Phase 2 signals; excludes situational + invalidated
- `test_cli.py::TestStandingCli` (2 updated + 1 new): list-populated shape with Phase 3 columns, stale-marker at ≥90d, list-empty path

Full suite: **972 passed**.

## Composes with

- `[[mnemon-salience-tier-plan-260521]]` Phase 3 — this IS the implementation
- C28 / PR #178 — the wins/corr columns the aging surface renders
- Phase 1 / PR #154 — `list_standing` was the existing canonical injection path; this PR extends it with the timestamp bump