### PR TITLE
feat(contradiction): retroactive sweep — close the save-time miss gap

### DIFF
--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -186,6 +186,41 @@ def main() -> None:
             sys.exit(1)
         store.close()
 
+    elif command == "sweep-contradictions":
+        # Retroactive contradiction sweep — walks the vault, classifies
+        # pair-wise NLI on cosine-overlapping candidates, applies decays +
+        # relations. Closes the gap for memories that landed before
+        # check_contradictions was wired in or that slipped past the
+        # save-time vector window.
+        from .store import Store
+        from .contradiction import sweep_contradictions
+        max_pairs = 50
+        dry_run = "--dry-run" in args[1:]
+        for i, a in enumerate(args[1:], start=1):
+            if a == "--max-pairs" and i + 1 < len(args):
+                try:
+                    max_pairs = int(args[i + 1])
+                except ValueError:
+                    print("Error: --max-pairs must be an integer", file=sys.stderr)
+                    sys.exit(2)
+        store = Store()
+        try:
+            result = sweep_contradictions(
+                store, max_pairs=max_pairs, dry_run=dry_run,
+            )
+        finally:
+            store.close()
+        print(f"Sweep complete{' (dry-run)' if dry_run else ''}:")
+        print(f"  pairs examined  : {result['pairs_examined']}")
+        print(f"  pairs classified: {result['pairs_classified']}")
+        print(f"  pairs skipped   : {result['pairs_skipped']}  (already had classification relation)")
+        print(f"  decayed         : {result['decayed']}  (update + contradiction outcomes)")
+        print(f"  relations added : {result['relations_added']}")
+        if result["nli_unavailable"]:
+            print("\n  ⚠ NLI unavailable — sweep aborted early. See server logs.",
+                  file=sys.stderr)
+            sys.exit(1)
+
     elif command == "sync":
         subcommand = args[1] if len(args) > 1 else ""
         if subcommand == "push":
@@ -869,6 +904,11 @@ Local vault (development/server-side only):
   mnemon salience-report    Phase 2 promotion-signal candidates — rank
                             situational memories by correction_count +
                             contradiction_win_count [--limit N]
+  mnemon sweep-contradictions
+                            Retroactive NLI sweep — classify cosine-
+                            overlapping memory pairs that bypassed the
+                            save-time check; non-destructive (decay +
+                            relations only). [--max-pairs N] [--dry-run]
 
 Salience tier (standing-context recall):
   mnemon standing list      Show all standing-tier memories + count vs cap

--- a/src/mnemon/contradiction.py
+++ b/src/mnemon/contradiction.py
@@ -231,6 +231,199 @@ def check_contradictions(
     }
 
 
+# ── Retroactive sweep ────────────────────────────────────────────────────────
+
+
+def sweep_contradictions(
+    store: "Store",
+    *,
+    max_pairs: int = 50,
+    dry_run: bool = False,
+) -> dict:
+    """Retroactive contradiction sweep over the live vault.
+
+    ``check_contradictions`` only fires at save-time, so memory pairs
+    that landed before the classifier was wired in — or that slipped
+    past the at-save vector window because they arrived in different
+    sessions — never get classified. This sweep closes the gap by
+    walking the vault, finding pairs above
+    ``CONTRADICTION_OVERLAP_THRESHOLD``, and running the same NLI
+    classifier + decay/relation side effects as the save-time path.
+
+    Bounded by ``max_pairs`` (default 50) per invocation so a periodic
+    runner doesn't churn through the entire vault every tick. The
+    sweep is **non-destructive** — only adjusts confidence (decay) +
+    adds relations + bumps contradiction_win_count on winners. Mirrors
+    the `apply_confidence_decay` operational shape so it can be wired
+    into the same periodic cadence (see ``persistent_sessions``-style
+    background task).
+
+    Skips pairs that already carry a 'same'/'update'/'contradiction'
+    relation — those have been classified at some point and re-running
+    NLI on them produces no new signal.
+
+    Returns::
+
+        {
+          "pairs_examined": int,
+          "pairs_classified": int,   # NLI was actually invoked
+          "pairs_skipped": int,      # already had a classification relation
+          "decayed": int,            # update + contradiction outcomes
+          "relations_added": int,    # related + supersedes + contradicts
+          "nli_unavailable": bool,
+          "dry_run": bool,
+        }
+    """
+    summary = {
+        "pairs_examined": 0, "pairs_classified": 0, "pairs_skipped": 0,
+        "decayed": 0, "relations_added": 0,
+        "nli_unavailable": False, "dry_run": dry_run,
+    }
+
+    if max_pairs <= 0:
+        return summary
+
+    try:
+        from .nli import classify_pair_bidirectional, NLIUnavailableError
+    except ImportError:
+        summary["nli_unavailable"] = True
+        return summary
+
+    rows = store.db.execute(
+        """SELECT d.id, d.title, c.doc AS content, d.hash
+           FROM documents d
+           JOIN content c ON d.hash = c.hash
+           WHERE d.invalidated_at IS NULL
+           ORDER BY d.id"""
+    ).fetchall()
+    if len(rows) < 2:
+        return summary
+
+    docs_by_id = {r["id"]: r for r in rows}
+
+    # Pre-compute the set of (a, b) pairs that already carry a
+    # classification relation — symmetric, so check both directions.
+    classified_pairs: set[tuple[int, int]] = set()
+    for r in store.db.execute(
+        "SELECT source_id, target_id FROM relations "
+        "WHERE relation_type IN ('same', 'related', 'update', "
+        "'supersedes', 'contradicts')"
+    ).fetchall():
+        a, b = sorted([r["source_id"], r["target_id"]])
+        classified_pairs.add((a, b))
+
+    try:
+        from .embedder import embed
+    except ImportError:
+        summary["nli_unavailable"] = True
+        return summary
+
+    examined = 0
+    for doc_id, row in docs_by_id.items():
+        if summary["pairs_classified"] >= max_pairs:
+            break
+        try:
+            query_emb = embed(
+                f"title: {row['title']} | text: {row['content']}"
+            )
+            neighbors = store.search_vector(query_emb, 5)
+        except Exception as exc:
+            logger.warning(
+                "sweep_contradictions: embed/search failed for #%d (%s); "
+                "skipping that doc", doc_id, exc,
+            )
+            continue
+
+        for cand in neighbors:
+            if cand.doc_id == doc_id:
+                continue
+            if cand.score < CONTRADICTION_OVERLAP_THRESHOLD:
+                continue
+            pair = tuple(sorted([doc_id, cand.doc_id]))
+            if pair in classified_pairs:
+                summary["pairs_skipped"] += 1
+                continue
+            examined += 1
+            summary["pairs_examined"] = examined
+
+            cand_row = docs_by_id.get(cand.doc_id)
+            if cand_row is None:
+                continue
+            try:
+                result = classify_pair_bidirectional(
+                    f"title: {cand_row['title']} | text: {cand_row['content']}",
+                    f"title: {row['title']} | text: {row['content']}",
+                )
+            except NLIUnavailableError:
+                summary["nli_unavailable"] = True
+                return summary
+            except Exception as exc:
+                logger.warning(
+                    "sweep_contradictions: classify failed for pair "
+                    "(#%d, #%d): %s", doc_id, cand.doc_id, exc,
+                )
+                continue
+
+            summary["pairs_classified"] += 1
+            classified_pairs.add(pair)  # avoid re-classifying within this run
+
+            label = result.mnemon_label
+            if dry_run:
+                continue
+
+            # The "winner" / "loser" framing mirrors check_contradictions:
+            # the new save was the winner against the existing
+            # candidate. In a retroactive sweep there's no "new" doc —
+            # the higher-id doc (more recent) is treated as the winner
+            # by convention, since later memories typically reflect
+            # corrected understanding.
+            winner, loser = (doc_id, cand.doc_id) if doc_id > cand.doc_id else (cand.doc_id, doc_id)
+            loser_doc = store.get(loser)
+            if loser_doc is None:
+                continue
+
+            if label == "update":
+                new_conf = max(CONFIDENCE_FLOOR, loser_doc.confidence - UPDATE_DECAY)
+                store.db.execute(
+                    "UPDATE documents SET confidence = ?, "
+                    "updated_at = datetime('now') WHERE id = ?",
+                    (new_conf, loser),
+                )
+                store.db.execute(
+                    "UPDATE documents SET contradiction_win_count = "
+                    "contradiction_win_count + 1 WHERE id = ?",
+                    (winner,),
+                )
+                store.add_relation(winner, loser, "supersedes", 0.8)
+                summary["decayed"] += 1
+                summary["relations_added"] += 1
+            elif label == "contradiction":
+                new_conf = max(CONFIDENCE_FLOOR, loser_doc.confidence - CONTRADICTION_DECAY)
+                store.db.execute(
+                    "UPDATE documents SET confidence = ?, "
+                    "updated_at = datetime('now') WHERE id = ?",
+                    (new_conf, loser),
+                )
+                store.db.execute(
+                    "UPDATE documents SET contradiction_win_count = "
+                    "contradiction_win_count + 1 WHERE id = ?",
+                    (winner,),
+                )
+                store.add_relation(winner, loser, "contradicts", 0.9)
+                summary["decayed"] += 1
+                summary["relations_added"] += 1
+            elif label == "same":
+                store.add_relation(winner, loser, "related", 1.0)
+                summary["relations_added"] += 1
+            # 'unrelated' = no action
+            store.db.commit()
+
+            if summary["pairs_classified"] >= max_pairs:
+                break
+
+    return summary
+
+
 # ── Confidence Decay ────────────────────────────────────────────────────────
 
 

--- a/tests/test_contradiction.py
+++ b/tests/test_contradiction.py
@@ -17,6 +17,7 @@ from mnemon.contradiction import (
     UPDATE_DECAY,
     check_contradictions,
     apply_confidence_decay,
+    sweep_contradictions,
 )
 from mnemon.nli import BidirectionalResult, NLIResult, NLIUnavailableError
 
@@ -400,3 +401,145 @@ class TestConfidenceDecay:
         doc2 = store.get(id2)
         # High-access memory should retain more confidence than low-access at same age
         assert doc2.confidence > doc1.confidence
+
+
+class TestSweepContradictions:
+    """Retroactive sweep — closes the gap for pairs that bypassed
+    save-time check_contradictions. Mirrors the same NLI classifier +
+    decay/relation side effects but bounded by --max-pairs."""
+
+    def test_empty_vault_returns_zero(self, store):
+        result = sweep_contradictions(store)
+        assert result["pairs_examined"] == 0
+        assert result["pairs_classified"] == 0
+        assert result["decayed"] == 0
+        assert result["relations_added"] == 0
+
+    def test_single_doc_vault_returns_zero(self, store):
+        store.save(title="Only one", content="lonely memory")
+        result = sweep_contradictions(store)
+        assert result["pairs_classified"] == 0
+
+    def test_classifies_overlapping_pair_and_decays_loser(self, store):
+        id_a = store.save(title="Old framing", content="old phrasing")
+        id_b = store.save(title="New framing", content="new phrasing")
+        # Force search_vector to return id_a as a candidate for id_b
+        # and vice versa, both above OVERLAP_THRESHOLD.
+        results_for_a = [SearchResult(
+            doc_id=id_b, title="New framing", content="new phrasing",
+            content_type="note", memory_type="semantic", confidence=0.8,
+            created_at="2026-01-01", score=0.95, source="vector",
+        )]
+        results_for_b = [SearchResult(
+            doc_id=id_a, title="Old framing", content="old phrasing",
+            content_type="note", memory_type="semantic", confidence=0.8,
+            created_at="2026-01-01", score=0.95, source="vector",
+        )]
+        loser_conf_before = store.get(id_a).confidence
+
+        def _search_side_effect(emb, k):
+            # Cheap: same neighbor list both directions for the test
+            return results_for_a
+        with patch.object(store, "search_vector", side_effect=_search_side_effect), \
+             patch("mnemon.embedder.embed", return_value=_mock_embedding()), \
+             patch("mnemon.nli.classify_pair_bidirectional",
+                   return_value=_bidir("update")):
+            result = sweep_contradictions(store, max_pairs=10)
+
+        assert result["pairs_classified"] >= 1
+        assert result["decayed"] >= 1
+        # id_b is the higher id → winner per the sweep's convention.
+        winner_after = store.db.execute(
+            "SELECT contradiction_win_count FROM documents WHERE id = ?",
+            (id_b,),
+        ).fetchone()
+        assert winner_after["contradiction_win_count"] >= 1
+        loser_doc = store.get(id_a)
+        assert loser_doc.confidence < loser_conf_before
+
+    def test_skips_already_classified_pairs(self, store):
+        id_a = store.save(title="A", content="first")
+        id_b = store.save(title="B", content="second")
+        # Pre-seed a 'related' relation so the pair is already classified
+        store.add_relation(id_a, id_b, "related", 1.0)
+        neighbors = [SearchResult(
+            doc_id=id_b, title="B", content="second",
+            content_type="note", memory_type="semantic", confidence=0.8,
+            created_at="2026-01-01", score=0.95, source="vector",
+        )]
+        with patch.object(store, "search_vector", return_value=neighbors), \
+             patch("mnemon.embedder.embed", return_value=_mock_embedding()), \
+             patch("mnemon.nli.classify_pair_bidirectional",
+                   return_value=_bidir("contradiction")) as mock_nli:
+            result = sweep_contradictions(store, max_pairs=10)
+
+        # No classification should have been attempted — the pre-existing
+        # 'related' relation means the pair has been classified.
+        mock_nli.assert_not_called()
+        assert result["pairs_skipped"] >= 1
+        assert result["pairs_classified"] == 0
+
+    def test_dry_run_classifies_but_does_not_mutate(self, store):
+        id_a = store.save(title="A", content="first")
+        id_b = store.save(title="B", content="second")
+        loser_conf = store.get(id_a).confidence
+        neighbors = [SearchResult(
+            doc_id=id_b, title="B", content="second",
+            content_type="note", memory_type="semantic", confidence=0.8,
+            created_at="2026-01-01", score=0.95, source="vector",
+        )]
+        with patch.object(store, "search_vector", return_value=neighbors), \
+             patch("mnemon.embedder.embed", return_value=_mock_embedding()), \
+             patch("mnemon.nli.classify_pair_bidirectional",
+                   return_value=_bidir("contradiction")):
+            result = sweep_contradictions(store, max_pairs=10, dry_run=True)
+
+        assert result["pairs_classified"] >= 1
+        # No mutation — confidence unchanged, no relations added.
+        assert store.get(id_a).confidence == loser_conf
+        rels = store.db.execute(
+            "SELECT COUNT(*) AS c FROM relations "
+            "WHERE relation_type IN ('contradicts', 'supersedes', 'related')"
+        ).fetchone()["c"]
+        assert rels == 0
+
+    def test_max_pairs_caps_work(self, store):
+        # 4 docs → 12 directed pair-classifications possible, but we cap at 2.
+        for i in range(4):
+            store.save(title=f"M{i}", content=f"content {i}")
+        # Each doc's "neighbors" includes the others above threshold
+        all_docs = store.timeline(10)
+        def _neighbors(emb, k):
+            return [
+                SearchResult(
+                    doc_id=d.id, title=d.title, content="",
+                    content_type="note", memory_type="semantic",
+                    confidence=0.8, created_at="2026-01-01",
+                    score=0.95, source="vector",
+                ) for d in all_docs
+            ]
+        with patch.object(store, "search_vector", side_effect=_neighbors), \
+             patch("mnemon.embedder.embed", return_value=_mock_embedding()), \
+             patch("mnemon.nli.classify_pair_bidirectional",
+                   return_value=_bidir("unrelated")):
+            result = sweep_contradictions(store, max_pairs=2)
+
+        assert result["pairs_classified"] <= 2
+
+    def test_nli_unavailable_aborts_early(self, store):
+        store.save(title="A", content="first")
+        store.save(title="B", content="second")
+        neighbors = [SearchResult(
+            doc_id=2, title="B", content="second",
+            content_type="note", memory_type="semantic", confidence=0.8,
+            created_at="2026-01-01", score=0.95, source="vector",
+        )]
+        with patch.object(store, "search_vector", return_value=neighbors), \
+             patch("mnemon.embedder.embed", return_value=_mock_embedding()), \
+             patch("mnemon.nli.classify_pair_bidirectional",
+                   side_effect=NLIUnavailableError("model missing")):
+            result = sweep_contradictions(store, max_pairs=10)
+
+        assert result["nli_unavailable"] is True
+        # No decays since we aborted before applying side effects.
+        assert result["decayed"] == 0


### PR DESCRIPTION
## Summary

Closes the 2026-05-07 "Retroactive vector-near-duplicate sweep" ROADMAP item. `check_contradictions` only fires at save-time, so memory pairs that landed before the classifier was wired in — or that slipped past the at-save vector window because they arrived in different sessions — never get classified. This PR adds the non-destructive sweep that closes the gap.

## API

**`contradiction.sweep_contradictions(store, max_pairs=50, dry_run=False)`**

- Walks the live vault. For each doc, finds top-K vector neighbors above `CONTRADICTION_OVERLAP_THRESHOLD`.
- Skips pairs that already carry a `'same'`/`'related'`/`'update'`/`'supersedes'`/`'contradicts'` relation — those have been classified at some point (save-time or earlier sweep); no new signal from re-running.
- For unclassified pairs, runs the same `classify_pair_bidirectional` NLI primitive as `check_contradictions`.
- Applies the same side effects: `update` / `contradiction` → confidence decay (`UPDATE_DECAY` / `CONTRADICTION_DECAY`) on the loser + `'supersedes'`/`'contradicts'` relation; `same` → `'related'` relation; `unrelated` → no-op.
- **Winner-side convention:** higher doc id is the winner (more recent = typically corrected understanding). Bumps the winner's `contradiction_win_count` (Salience Phase 2 signal — composes with #178).
- **Bounded** by `max_pairs` (default 50) per invocation so a periodic runner doesn't churn the entire vault every tick.
- `dry_run=True` still classifies but skips all mutations — operator preview before committing.

## CLI

`mnemon sweep-contradictions [--max-pairs N] [--dry-run]` — prints the summary (pairs_examined / classified / skipped / decayed / relations_added). Exits 1 with a warning when NLI is unavailable on the host.

## Test plan

7 new tests in `TestSweepContradictions`:
- empty / single-doc vault returns zero
- overlapping pair classified, loser decayed, winner `contradiction_win_count` bumped
- already-classified pair skipped (regression-locks the dedup)
- `dry_run` classifies but doesn't mutate (no confidence change, no new relations)
- `max_pairs` caps work
- `NLIUnavailableError` aborts early with `nli_unavailable=True`

Full suite: **979 passed** (was 972 → +7).

## Composes with

- `check_contradictions` (save-time path) — same NLI primitive, same decay constants, same relation types, same winner-side counter
- Salience Phase 2 / PR #178 — bumps `contradiction_win_count` on winners, feeding the `salience-report` promotion candidate ranking
- `apply_confidence_decay` — sibling periodic-sweep pattern, both non-destructive, both bounded per-invocation. Future operator follow-up: wire `sweep_contradictions` into the same `persistent_sessions`-style background task at a weekly cadence.