### PR TITLE
feat(upgrade): `--testpypi` flag + `promote_stable.sh testpublish`

### DIFF
--- a/scripts/promote_stable.sh
+++ b/scripts/promote_stable.sh
@@ -224,7 +224,7 @@ _layer3_cleanup() {
 }
 
 cmd_layer3() {
-    # Parse layer3-specific flags. Currently:
+    # Parse layer3-specific flags:
     #   --exercise-all-tools  After upgrade, iterate every registered
     #                         MCP tool against the test Fly app and
     #                         assert each returns cleanly. Catches
@@ -233,11 +233,24 @@ cmd_layer3() {
     #                         local-process integration canary
     #                         tests/test_tools_integration.py can't
     #                         see. Added 2026-05-22.
+    #   --testpypi            Pass through to `mnemon upgrade web
+    #                         --testpypi` so the Docker build resolves
+    #                         mnemon-memory from test.pypi.org. Pinned
+    #                         to TARGET_VERSION (must be on TestPyPI
+    #                         already — `cmd_testpublish` is the canonical
+    #                         producer). Added 2026-05-27 for true
+    #                         pre-publish validation per the C24 ROADMAP
+    #                         follow-up.
     local EXERCISE_ALL_TOOLS=0
+    local USE_TESTPYPI=0
     while [ $# -gt 0 ]; do
         case "$1" in
             --exercise-all-tools)
                 EXERCISE_ALL_TOOLS=1
+                shift
+                ;;
+            --testpypi)
+                USE_TESTPYPI=1
                 shift
                 ;;
             *)
@@ -279,6 +292,14 @@ cmd_layer3() {
     if [ -n "${LAYER3_VERSION_OVERRIDE:-}" ]; then
         LAYER3_VERSION="$LAYER3_VERSION_OVERRIDE"
         echo_ok "Layer-3 pinning mnemon-memory==$LAYER3_VERSION (operator override)"
+    elif [ "$USE_TESTPYPI" = "1" ]; then
+        # --testpypi mode: TARGET_VERSION must be on TestPyPI (produced
+        # by `cmd_testpublish` upstream). This is the true pre-publish
+        # validation path — Docker resolves mnemon-memory from
+        # test.pypi.org so the candidate's actual code runs in the test
+        # Fly app, not a published-proxy stand-in.
+        LAYER3_VERSION="$TARGET_VERSION"
+        echo_ok "Layer-3 pinning mnemon-memory==$LAYER3_VERSION (TestPyPI mode)"
     elif is_pypi_published "$TARGET_VERSION"; then
         LAYER3_VERSION="$TARGET_VERSION"
         echo_ok "Layer-3 pinning mnemon-memory==$LAYER3_VERSION (candidate already on PyPI)"
@@ -287,7 +308,7 @@ cmd_layer3() {
         [ -n "$LAYER3_VERSION" ] || die "could not resolve mnemon-memory latest from PyPI JSON API"
         echo_warn "candidate $TARGET_VERSION isn't on PyPI yet"
         echo_warn "Layer-3 will deploy mnemon-memory==$LAYER3_VERSION (latest published) as a proxy"
-        echo_warn "for true pre-publish validation of $TARGET_VERSION's code: file TestPyPI integration as ROADMAP follow-up"
+        echo_warn "for true pre-publish validation of $TARGET_VERSION's code, use: $0 testpublish then $0 layer3 --testpypi"
     fi
     confirm "proceed with Layer-3 deploying mnemon-memory==$LAYER3_VERSION?"
 
@@ -364,7 +385,12 @@ cmd_layer3() {
     echo_ok "3 docs seeded in local test vault"
 
     echo_step "Step 3 — upgrade web to $TEST_APP_NAME (pinned to mnemon-memory==$LAYER3_VERSION)"
-    "$M" upgrade web --app-name "$TEST_APP_NAME" --mnemon-version "$LAYER3_VERSION"
+    local UPGRADE_EXTRA_ARGS=()
+    if [ "$USE_TESTPYPI" = "1" ]; then
+        UPGRADE_EXTRA_ARGS+=("--testpypi")
+        echo "  (--testpypi: Docker resolves from test.pypi.org)"
+    fi
+    "$M" upgrade web --app-name "$TEST_APP_NAME" --mnemon-version "$LAYER3_VERSION" "${UPGRADE_EXTRA_ARGS[@]}"
     ls "$MNEMON_VAULT_DIR/archive/" | grep -q "pre-web-" || die "expected pre-web-*.sqlite archive missing"
     ! [ -f "$MNEMON_VAULT_DIR/default.sqlite" ] || die "local vault should be archived; default.sqlite still present"
 
@@ -427,6 +453,69 @@ cmd_layer3() {
 # ============================================================
 # publish — POST-MERGE: build, twine upload, tag, GH Release, Fly redeploy
 # ============================================================
+cmd_testpublish() {
+    # Pre-publish: upload candidate to TestPyPI so Layer-3 can deploy
+    # the actual candidate code (rather than the latest-published-as-
+    # proxy). Closes the 2026-05-21 chicken-and-egg gap where
+    # `mnemon upgrade web` needs the candidate already on a pip index
+    # but real PyPI publication is one-way.
+    #
+    # Operator workflow (per the C24 ROADMAP follow-up):
+    #   1. preflight             — read-only checks
+    #   2. testpublish           — build → twine upload --repository testpypi
+    #   3. layer3 --testpypi     — Docker resolves from test.pypi.org
+    #   ── merge promote PR ──
+    #   4. publish               — twine upload to prod PyPI + tag + Fly redeploy
+    #   5. verify                — post-publish sanity check
+    #
+    # Prereqs:
+    #   - ~/.pypirc has a [testpypi] section with an API token, OR
+    #     TWINE_USERNAME=__token__ + TWINE_PASSWORD=<testpypi-token> set
+    #   - dist/ either fresh-built here or pre-built from a prior preflight
+    echo_step "TestPyPI publish — $TARGET_VERSION pre-publish validation"
+
+    echo_step "Build — sdist + wheel"
+    rm -rf dist/
+    "$MNEMON_VENV_BIN/python" -m build
+    "$MNEMON_VENV_BIN/twine" check dist/*
+    echo_ok "build clean, twine check passed"
+
+    # Same sdist hygiene check the prod publish step runs — TestPyPI
+    # is public, same forbidden-path rules apply.
+    local sdist
+    sdist="$(ls dist/mnemon_memory-*.tar.gz | head -1)"
+    [ -n "$sdist" ] || die "no sdist found in dist/"
+    local leaks
+    leaks="$(tar tzf "$sdist" | grep -E "(^|/)(\.env|fly\.toml|default\.sqlite)$|(^|/)(private|\.mnemon)/" || true)"
+    if [ -n "$leaks" ]; then
+        echo_err "sdist contains forbidden paths:"
+        printf "%s\n" "$leaks" >&2
+        die "abort before twine upload"
+    fi
+    echo_ok "no forbidden files in sdist"
+
+    confirm "Upload dist/* to TestPyPI? (test.pypi.org — separate index from real PyPI)"
+    echo_step "twine upload --repository testpypi"
+    "$MNEMON_VENV_BIN/twine" upload --repository testpypi dist/*
+    echo_ok "uploaded to TestPyPI"
+
+    echo_step "Wait for TestPyPI to surface $TARGET_VERSION"
+    local tries=0
+    until curl -fsS "https://test.pypi.org/pypi/mnemon-memory/json" 2>/dev/null \
+        | "$MNEMON_VENV_BIN/python" -c \
+            "import json,sys; data=json.load(sys.stdin); sys.exit(0 if '$TARGET_VERSION' in data.get('releases', {}) else 1)"; do
+        tries=$((tries + 1))
+        [ "$tries" -gt 30 ] && die "TestPyPI didn't surface $TARGET_VERSION after 5 min"
+        sleep 10
+    done
+    echo_ok "TestPyPI surfacing mnemon-memory==$TARGET_VERSION"
+
+    echo
+    echo "Next: $0 layer3 --testpypi"
+    echo "  (Docker build will resolve mnemon-memory==$TARGET_VERSION from test.pypi.org)"
+}
+
+
 cmd_publish() {
     echo_step "Publish $TARGET_VERSION — post-merge sequence"
 
@@ -583,20 +672,23 @@ if [ "${BASH_SOURCE[0]}" != "$0" ]; then
 fi
 
 case "${1:-}" in
-    preflight) cmd_preflight ;;
-    layer3)    shift; cmd_layer3 "$@" ;;
-    publish)   cmd_publish ;;
-    verify)    cmd_verify ;;
+    preflight)    cmd_preflight ;;
+    testpublish)  cmd_testpublish ;;
+    layer3)       shift; cmd_layer3 "$@" ;;
+    publish)      cmd_publish ;;
+    verify)       cmd_verify ;;
     *)
         cat >&2 <<EOF
 usage: $0 <subcommand>
 
 Subcommands (run in this order around the promote PR merge):
-  preflight   — read-only: branch/version/CHANGELOG/tests/auth all check out
-  layer3      — E2E web test (test-scoped Fly app, ~15 min)
+  preflight    — read-only: branch/version/CHANGELOG/tests/auth all check out
+  testpublish  — (optional) upload candidate to TestPyPI for true pre-publish validation
+  layer3       — E2E web test (test-scoped Fly app, ~15 min)
+                 [--testpypi: deploy candidate from TestPyPI rather than latest-published proxy]
   ── MERGE THE PROMOTE PR ON GITHUB HERE ──
-  publish     — post-merge: build → twine upload → tag → GH Release → Fly redeploy
-  verify      — post-publish sanity check
+  publish      — post-merge: build → twine upload → tag → GH Release → Fly redeploy
+  verify       — post-publish sanity check
 
 Target version read from src/mnemon/__init__.py (currently: $TARGET_VERSION).
 

--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -297,7 +297,7 @@ def main() -> None:
             print(
                 "Usage: mnemon upgrade web --app-name <name> "
                 "[--s3-bucket NAME] [--token TOKEN] [--region REGION] "
-                "[--mnemon-version VER] [--skip-doctor]",
+                "[--mnemon-version VER] [--skip-doctor] [--testpypi]",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -319,6 +319,7 @@ def main() -> None:
                     region=parsed["region"] or "sjc",
                     mnemon_version=parsed["mnemon_version"],
                     skip_doctor=parsed["skip_doctor"],
+                    use_testpypi=parsed["use_testpypi"],
                 )
             )
         except UpgradeError as exc:
@@ -778,6 +779,7 @@ def _parse_upgrade_args(args: list[str]) -> dict:
         "region": None,
         "mnemon_version": None,
         "skip_doctor": False,
+        "use_testpypi": False,
     }
     i = 0
     while i < len(args):
@@ -805,6 +807,9 @@ def _parse_upgrade_args(args: list[str]) -> dict:
             i += 2
         elif flag == "--skip-doctor":
             result["skip_doctor"] = True
+            i += 1
+        elif flag == "--testpypi":
+            result["use_testpypi"] = True
             i += 1
         else:
             i += 1
@@ -859,7 +864,7 @@ Idempotent: rerun to redeploy an existing app with the current mnemon
 version (clients keep their URL + token):
   mnemon upgrade web --app-name <name> [--s3-bucket NAME] [--token TOKEN]
                              [--region REGION] [--mnemon-version VER]
-                             [--skip-doctor]
+                             [--skip-doctor] [--testpypi]
                              First-time deploy requires: flyctl, aws CLI
                              with credentials, and an S3 bucket
                              (MNEMON_S3_BUCKET or --s3-bucket). Redeploy
@@ -867,6 +872,10 @@ version (clients keep their URL + token):
                              --mnemon-version pins a specific PyPI version
                              in the deployed Dockerfile (defaults to the
                              locally-installed __version__).
+                             --testpypi resolves mnemon-memory from
+                             test.pypi.org (transitive deps stay on
+                             prod PyPI); for true pre-publish validation
+                             via promote_stable.sh testpublish.
 
 Downgrade web → local (pull remote vault back, reconfigure clients to stdio):
   mnemon downgrade local    [--destroy-fly-app] [--yes] [--app-name NAME]

--- a/src/mnemon/upgrade.py
+++ b/src/mnemon/upgrade.py
@@ -108,8 +108,12 @@ WORKDIR /app
 
 # Install mnemon with server deps from PyPI. Pinning the version keeps
 # the deployed image reproducible even if PyPI state changes between
-# deploys.
-RUN pip install --no-cache-dir 'mnemon-memory[server]=={mnemon_version}'
+# deploys. {pip_index_args} is empty for prod PyPI; for --testpypi
+# resolution it expands to `--index-url https://test.pypi.org/simple/
+# --extra-index-url https://pypi.org/simple/` so the mnemon-memory
+# artifact comes from TestPyPI but its transitive deps (fastembed,
+# numpy, etc.) still resolve from real PyPI.
+RUN pip install --no-cache-dir {pip_index_args}'mnemon-memory[server]=={mnemon_version}'
 
 # Bake the FastEmbed bge-small-en-v1.5 ONNX model into the image so cold
 # starts don't trigger a 5-15s download from HuggingFace Hub.
@@ -499,12 +503,33 @@ def _fly_app_exists(app_name: str) -> bool:
 # ── Redeploy (existing app, version bump) ────────────────────────────────────
 
 
+def _pip_index_args(use_testpypi: bool) -> str:
+    """Pip args to thread into the Dockerfile RUN line.
+
+    Empty string for prod PyPI (default). For TestPyPI, returns the
+    flag set that points at test.pypi.org as the primary index while
+    keeping prod PyPI as the fallback for transitive deps — TestPyPI
+    only hosts mnemon-memory artifacts, every other dep (fastembed,
+    numpy, etc.) still lives on prod PyPI.
+
+    Trailing space matters: `--index-url X --extra-index-url Y` then
+    a space before the package spec.
+    """
+    if not use_testpypi:
+        return ""
+    return (
+        "--index-url https://test.pypi.org/simple/ "
+        "--extra-index-url https://pypi.org/simple/ "
+    )
+
+
 def _redeploy_web(
     *,
     app_name: str,
     region: str,
     mnemon_version: str,
     skip_doctor: bool,
+    use_testpypi: bool = False,
 ) -> str:
     """Redeploy an existing Fly mnemon app pinned to ``mnemon_version``.
 
@@ -522,7 +547,10 @@ def _redeploy_web(
     with tempfile.TemporaryDirectory(prefix="mnemon-redeploy-") as tdir:
         workdir = Path(tdir)
         (workdir / "Dockerfile").write_text(
-            _DOCKERFILE_TEMPLATE.format(mnemon_version=mnemon_version)
+            _DOCKERFILE_TEMPLATE.format(
+                mnemon_version=mnemon_version,
+                pip_index_args=_pip_index_args(use_testpypi),
+            )
         )
         (workdir / "fly.toml").write_text(
             _FLY_TOML_TEMPLATE.format(app_name=app_name, region=region)
@@ -583,6 +611,7 @@ def upgrade_web(
     region: str = "sjc",
     mnemon_version: str | None = None,
     skip_doctor: bool = False,
+    use_testpypi: bool = False,
 ) -> str:
     """Upgrade a local mnemon install to a web (Fly-hosted) deployment.
 
@@ -632,6 +661,7 @@ def upgrade_web(
             region=region,
             mnemon_version=mnemon_version,
             skip_doctor=skip_doctor,
+            use_testpypi=use_testpypi,
         )
 
     _require_aws()
@@ -676,7 +706,10 @@ def upgrade_web(
         with tempfile.TemporaryDirectory(prefix="mnemon-upgrade-") as tdir:
             workdir = Path(tdir)
             (workdir / "Dockerfile").write_text(
-                _DOCKERFILE_TEMPLATE.format(mnemon_version=mnemon_version)
+                _DOCKERFILE_TEMPLATE.format(
+                    mnemon_version=mnemon_version,
+                    pip_index_args=_pip_index_args(use_testpypi),
+                )
             )
             (workdir / "fly.toml").write_text(
                 _FLY_TOML_TEMPLATE.format(app_name=app_name, region=region)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -425,8 +425,27 @@ class TestUpgradeCli:
             region="sjc",
             mnemon_version=None,
             skip_doctor=True,
+            use_testpypi=False,
         )
         assert "upgrade output" in capsys.readouterr().out
+
+    @patch("mnemon.upgrade.upgrade_web")
+    def test_testpypi_flag_passes_through(self, mock_upgrade, capsys):
+        """C24 ROADMAP follow-up: --testpypi routes the Docker build's
+        pip install through test.pypi.org for true pre-publish
+        validation."""
+        mock_upgrade.return_value = "ok"
+        with patch(
+            "sys.argv",
+            [
+                "mnemon", "upgrade", "web",
+                "--app-name", "mnemon-test-cli",
+                "--testpypi",
+                "--skip-doctor",
+            ],
+        ):
+            main()
+        assert mock_upgrade.call_args.kwargs["use_testpypi"] is True
 
     @patch("mnemon.upgrade.upgrade_web")
     def test_mnemon_version_flag_passes_through(self, mock_upgrade, capsys):

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -505,6 +505,67 @@ class TestUpgradeWebRedeploy:
         assert 'app = "mnemon-test-existing"' in captured["fly_toml"]
         assert 'primary_region = "iad"' in captured["fly_toml"]
 
+    def test_redeploy_without_testpypi_uses_prod_pypi(self, tmp_path, monkeypatch):
+        """Default: Dockerfile pip install has no --index-url flags, so
+        pip resolves from prod PyPI as before. Regression-lock that the
+        --testpypi opt-in doesn't accidentally flip default behavior."""
+        monkeypatch.setattr(
+            "mnemon.config.vault_dir", lambda: tmp_path / ".mnemon"
+        )
+        captured: dict[str, str] = {}
+
+        def _capture(workdir: Path, app_name: str) -> None:
+            captured["dockerfile"] = (workdir / "Dockerfile").read_text()
+
+        with patch("mnemon.upgrade._require_flyctl"), \
+            patch("mnemon.upgrade._fly_app_exists", return_value=True), \
+            patch("mnemon.upgrade._fly_deploy", side_effect=_capture):
+            upgrade_web(
+                app_name="mnemon-test-existing",
+                mnemon_version="0.7.0rc5",
+                skip_doctor=True,
+            )
+
+        # The Dockerfile contains explanatory comment text about
+        # --index-url and test.pypi.org, so search the actual RUN line.
+        run_line = next(
+            ln for ln in captured["dockerfile"].splitlines()
+            if ln.startswith("RUN pip install")
+        )
+        assert "test.pypi.org" not in run_line
+        assert "--index-url" not in run_line
+
+    def test_redeploy_with_testpypi_flag_threads_index_urls(
+        self, tmp_path, monkeypatch
+    ):
+        """C24 ROADMAP follow-up: --testpypi makes the Docker build
+        resolve mnemon-memory from test.pypi.org while keeping prod
+        PyPI as the fallback for transitive deps."""
+        monkeypatch.setattr(
+            "mnemon.config.vault_dir", lambda: tmp_path / ".mnemon"
+        )
+        captured: dict[str, str] = {}
+
+        def _capture(workdir: Path, app_name: str) -> None:
+            captured["dockerfile"] = (workdir / "Dockerfile").read_text()
+
+        with patch("mnemon.upgrade._require_flyctl"), \
+            patch("mnemon.upgrade._fly_app_exists", return_value=True), \
+            patch("mnemon.upgrade._fly_deploy", side_effect=_capture):
+            upgrade_web(
+                app_name="mnemon-test-existing",
+                mnemon_version="0.7.0rc5",
+                skip_doctor=True,
+                use_testpypi=True,
+            )
+
+        # Primary index = TestPyPI (for mnemon-memory)
+        assert "--index-url https://test.pypi.org/simple/" in captured["dockerfile"]
+        # Fallback = prod PyPI (for FastEmbed, numpy, etc. transitive deps)
+        assert "--extra-index-url https://pypi.org/simple/" in captured["dockerfile"]
+        # Version pin still threads through
+        assert "mnemon-memory[server]==0.7.0rc5" in captured["dockerfile"]
+
     def test_redeploy_ignores_missing_aws_and_bucket(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## Summary

Closes 2026-05-21 ROADMAP "TestPyPI integration for true pre-publish validation" follow-up.

**Today:** `mnemon upgrade web` pins `pip install mnemon-memory[server]==<ver>` inside Docker, so the candidate must already be on a pip index when Layer-3 runs. The current workaround pins to the **latest published** version as a proxy — valid for byte-identical rc→stable promotion (e.g., 0.6.0rc18 ↔ 0.6.0 source-identical), but **incomplete validation** for rc bumps with real code changes.

**TestPyPI is the institutional answer:** upload candidate → TestPyPI → Docker build resolves the candidate's actual code → real Layer-3 validation → merge promote PR → twine upload to prod.

## Operator workflow

```
preflight  →  testpublish  →  layer3 --testpypi  →  MERGE PR  →  publish  →  verify
```

## Changes

**`src/mnemon/upgrade.py`**
- New `_pip_index_args(use_testpypi)` helper. Empty for prod (default). For TestPyPI: `--index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/` — mnemon-memory from TestPyPI, transitive deps (fastembed / numpy / etc.) from prod.
- `_DOCKERFILE_TEMPLATE` has a new `{pip_index_args}` placeholder. Both `_redeploy_web` and `upgrade_web` plumb `use_testpypi` to the formatter.
- `upgrade_web` + `_redeploy_web` signatures gained `use_testpypi: bool = False`.

**`src/mnemon/cli.py`**
- `_parse_upgrade_args` learns `--testpypi`.
- Invocation forwards the flag.
- Help text updated.

**`scripts/promote_stable.sh`**
- **New `cmd_testpublish`**: build dist → `twine upload --repository testpypi dist/*` → poll TestPyPI's JSON API until the candidate surfaces. Same sdist hygiene check as `cmd_publish`.
- **`cmd_layer3` learns `--testpypi`**: pins `LAYER3_VERSION=TARGET_VERSION` and threads `--testpypi` to `mnemon upgrade web`. The latest-published-proxy fallback now explicitly points operators at the SOTA path.
- Dispatcher + usage banner updated.

## Test plan

3 new tests:
- `TestUpgradeWebRedeploy::test_redeploy_without_testpypi_uses_prod_pypi` — regression-lock that default behavior is unchanged (RUN pip line has no `--index-url`)
- `TestUpgradeWebRedeploy::test_redeploy_with_testpypi_flag_threads_index_urls` — Dockerfile picks up both `--index-url` + `--extra-index-url`
- `TestUpgradeCli::test_testpypi_flag_passes_through` — flag parsing routes `use_testpypi=True`

All pre-existing tests updated to include `use_testpypi=False` in expected kwargs.

Full suite: **982 passed** (was 979 → +3).

Bash script: `bash -n` clean; smoke-tested the help-text rendering.

## Prereq for operators

Using `testpublish` requires either a `[testpypi]` section in `~/.pypirc` with an API token (separate from prod PyPI), or `TWINE_USERNAME=__token__` + `TWINE_PASSWORD=<testpypi-token>` exported.