### PR TITLE
chore(promote-stable): harness expansion — venv-bin override + trap retry + isolation regression

### DIFF
--- a/scripts/promote_stable.sh
+++ b/scripts/promote_stable.sh
@@ -66,8 +66,12 @@ confirm() {
 TARGET_VERSION="$(awk -F'"' '/^__version__ = /{print $2; exit}' src/mnemon/__init__.py)"
 [ -n "$TARGET_VERSION" ] || die "could not read __version__ from src/mnemon/__init__.py"
 
-MNEMON_VENV_BIN="$REPO_ROOT/.venv/bin"
-[ -x "$MNEMON_VENV_BIN/mnemon" ] || die "mnemon CLI not found at $MNEMON_VENV_BIN/mnemon — activate / install editable venv first"
+# Operator-overridable so CI / non-.venv setups can point at the
+# interpreter dir GitHub Actions actually provisioned (no virtualenv
+# created in default ci.yml). Same pattern as scripts/mnemon_ops.sh +
+# tests/test_mnemon_ops.py — sys.executable's parent works everywhere.
+MNEMON_VENV_BIN="${MNEMON_VENV_BIN:-$REPO_ROOT/.venv/bin}"
+[ -x "$MNEMON_VENV_BIN/mnemon" ] || die "mnemon CLI not found at $MNEMON_VENV_BIN/mnemon — activate / install editable venv first (or override MNEMON_VENV_BIN)"
 [ -x "$MNEMON_VENV_BIN/twine" ] || die "twine not found at $MNEMON_VENV_BIN/twine — pip install -e .[dev]"
 [ -x "$MNEMON_VENV_BIN/python" ] || die "venv python not found at $MNEMON_VENV_BIN/python"
 
@@ -187,9 +191,44 @@ _layer3_cleanup() {
 
     # 1. Destroy any lingering test Fly app first — frees the namespace + stops
     #    cost accumulation before doing anything else.
+    #
+    # Surfaced 2026-05-21 (during Layer-3 attempt-4): a previous trap
+    # invocation reported `destroying lingering test app ...` but the
+    # destroy didn't actually succeed (app survived 44 minutes in
+    # suspended state, blocked the next layer3 invocation's
+    # "dangling apps" preflight). The original silent `>/dev/null 2>&1`
+    # masked the cause — could be a machine still draining, a transient
+    # API error, or auth expiry.
+    #
+    # Fix: capture stderr to a temp log, retry once after a brief
+    # sleep, and on persistent failure surface the captured error so
+    # the operator knows what to recover by hand. Cleanup-side
+    # failures stay tolerated (don't override `rc`), but their cause
+    # is now visible.
     if [ -n "${TEST_APP_NAME:-}" ] && flyctl apps list 2>/dev/null | grep -q "$TEST_APP_NAME"; then
         echo_warn "cleanup: destroying lingering test app $TEST_APP_NAME"
-        flyctl apps destroy "$TEST_APP_NAME" -y >/dev/null 2>&1 || echo_warn "cleanup: flyctl destroy failed for $TEST_APP_NAME"
+        local _destroy_log
+        _destroy_log="$(mktemp -t mnemon-layer3-destroy-XXXXXX.log)"
+        if flyctl apps destroy "$TEST_APP_NAME" -y >/dev/null 2>"$_destroy_log"; then
+            rm -f "$_destroy_log"
+        else
+            # First attempt failed — pause briefly + retry. Most common
+            # causes (machine still draining, transient flyctl 5xx)
+            # resolve in a few seconds.
+            echo_warn "cleanup: flyctl destroy attempt 1 failed, retrying in 5s"
+            sleep 5
+            if flyctl apps destroy "$TEST_APP_NAME" -y >/dev/null 2>"$_destroy_log"; then
+                echo_ok "cleanup: destroy succeeded on retry"
+                rm -f "$_destroy_log"
+            else
+                echo_err "cleanup: flyctl destroy FAILED twice for $TEST_APP_NAME"
+                echo_err "cleanup: captured stderr — recover by hand:"
+                sed 's/^/    /' "$_destroy_log" >&2
+                echo_err "cleanup: \`flyctl apps destroy $TEST_APP_NAME -y\` is the manual recovery"
+                # Don't unlink the log — operator may want it for support.
+                echo_warn "cleanup: stderr log retained at $_destroy_log"
+            fi
+        fi
     fi
     if [ -n "${MNEMON_S3_PREFIX:-}" ]; then
         aws s3 rm "s3://${MNEMON_S3_BUCKET:-mnemon-memory}/$MNEMON_S3_PREFIX/" --recursive >/dev/null 2>&1 || echo_warn "cleanup: s3 rm failed for prefix $MNEMON_S3_PREFIX"

--- a/tests/test_promote_stable.sh
+++ b/tests/test_promote_stable.sh
@@ -390,6 +390,61 @@ PY
     [ -n "$result" ] || { echo "    extraction returned empty" >&2; return 1; }
 }
 
+test_step2_removes_remote_url_before_seed() {
+    # Surfaced 2026-05-21 (Layer-3 attempt). `mnemon save` honors
+    # ~/.mnemon/remote_url even from inside layer3, so seed saves
+    # routed to PROD instead of the local test vault. The fix in
+    # cmd_layer3 moves the file aside before running the three saves.
+    # Regression-lock the rm + unset by grepping the script source.
+    local script_path
+    script_path="$REPO_ROOT/scripts/promote_stable.sh"
+
+    grep -q 'unset MNEMON_REMOTE_URL' "$script_path" \
+        || { echo "    script missing 'unset MNEMON_REMOTE_URL'" >&2; return 1; }
+    grep -qF 'rm -f "$HOME/.mnemon/remote_url"' "$script_path" \
+        || { echo "    script missing 'rm -f \$HOME/.mnemon/remote_url'" >&2; return 1; }
+
+    # Ordering: the unset/rm must precede the Step 2 banner.
+    local unset_line rm_line step2_line
+    unset_line="$(grep -n 'unset MNEMON_REMOTE_URL' "$script_path" | head -1 | cut -d: -f1)"
+    rm_line="$(grep -nF 'rm -f "$HOME/.mnemon/remote_url"' "$script_path" | head -1 | cut -d: -f1)"
+    step2_line="$(grep -n 'echo_step "Step 2 — seed local test vault"' "$script_path" | head -1 | cut -d: -f1)"
+    [ -n "$step2_line" ] || { echo "    no 'echo_step Step 2' line in script" >&2; return 1; }
+    [ "$unset_line" -lt "$step2_line" ] && [ "$rm_line" -lt "$step2_line" ] \
+        || { echo "    unset/rm must precede Step 2 (got unset=$unset_line rm=$rm_line step2=$step2_line)" >&2; return 1; }
+}
+
+test_mnemon_venv_bin_env_var_is_honored() {
+    # Sub-item 1 of C25: MNEMON_VENV_BIN must be overridable so CI /
+    # non-.venv operators can run the script. The script's bootstrap
+    # uses ${MNEMON_VENV_BIN:-...} to default to .venv/bin only when
+    # the env var is unset. Regression-lock the parameter expansion
+    # pattern.
+    local script_path
+    script_path="$REPO_ROOT/scripts/promote_stable.sh"
+    grep -qE 'MNEMON_VENV_BIN="\$\{MNEMON_VENV_BIN:-\$REPO_ROOT/\.venv/bin\}"' "$script_path" \
+        || { echo "    MNEMON_VENV_BIN not using \${VAR:-default} pattern" >&2; return 1; }
+}
+
+test_cleanup_destroy_retries_on_failure() {
+    # Sub-item 4 of C25: trap destroy now retries once on failure +
+    # captures stderr. Grep the script source for the retry pattern.
+    local script_path
+    script_path="$REPO_ROOT/scripts/promote_stable.sh"
+    local body
+    body="$(awk '/^_layer3_cleanup\(\)/,/^}/' "$script_path")"
+
+    # Must capture stderr to a file (not >/dev/null).
+    grep -q '2>"\$_destroy_log"' <<<"$body" \
+        || { echo "    cleanup must capture flyctl destroy stderr" >&2; return 1; }
+    # Must retry on failure ('attempt 1 failed' marker).
+    grep -q 'attempt 1 failed' <<<"$body" \
+        || { echo "    cleanup must announce retry on first failure" >&2; return 1; }
+    # On persistent failure, must surface the captured stderr to operator.
+    grep -q 'FAILED twice' <<<"$body" \
+        || { echo "    cleanup must surface persistent-failure path" >&2; return 1; }
+}
+
 test_step2_seed_contents_are_unique() {
     # mnemon's store.save() does content-hash dedup (rc15+). The original
     # runbook passed the same content to all three Step-2 saves, which
@@ -442,6 +497,9 @@ run_test test_awk_handles_zero_count
 run_test test_awk_returns_empty_when_field_missing
 run_test test_sourcing_does_not_dispatch
 run_test test_step2_seed_contents_are_unique
+run_test test_step2_removes_remote_url_before_seed
+run_test test_mnemon_venv_bin_env_var_is_honored
+run_test test_cleanup_destroy_retries_on_failure
 run_test test_remote_helper_exists_and_is_invokable
 run_test test_layer3_uses_remote_helper_not_mnemon_status
 run_test test_helper_exposes_exercise_all_tools_subcommand


### PR DESCRIPTION
## Summary

Closes 3 of 4 sub-items in the 2026-05-21 C25 ROADMAP follow-up ("`promote_stable.sh` sandbox harness — expand coverage").

The fourth sub-item (stub `mnemon upgrade web` / `downgrade local` end-to-end via PATH-shim) is **scoped-down**: that path duplicates `tests/test_upgrade.py`'s mocked `_fly_deploy` assertions, so the coverage already exists at the right layer. The bash harness should regression-lock the script's own behavior, not re-prove the Python module's contract.

## Sub-item 1 — `MNEMON_VENV_BIN` env-var override

`promote_stable.sh` now resolves `MNEMON_VENV_BIN` via the `${VAR:-default}` pattern. CI runners + non-`.venv` operators can point at `sys.executable`'s parent rather than the repo's `.venv/bin`. Same shape as `scripts/mnemon_ops.sh` + the fix in `tests/test_mnemon_ops.py`.

**Regression-lock:** `test_mnemon_venv_bin_env_var_is_honored` greps for the parameter-expansion pattern.

## Sub-item 3 — Step-2 `remote_url` isolation

**Surfaced 2026-05-21:** `mnemon save` honored `~/.mnemon/remote_url` even from inside layer3, so seed saves routed to PROD instead of the local test vault. The fix moves the file aside before Step 2.

**Regression-lock:** `test_step2_removes_remote_url_before_seed` asserts both `unset MNEMON_REMOTE_URL` AND `rm -f $HOME/.mnemon/remote_url` appear in the script, AND that both precede the Step 2 banner.

## Sub-item 4 — trap destroy retries + stderr capture

**Surfaced 2026-05-21 (Layer-3 attempt-4):** trap reported `destroying lingering test app ...` but `flyctl destroy` didn't actually succeed (app survived 44min in suspended state, blocked next layer3's preflight). Original `>/dev/null 2>&1` masked the cause.

**Fix:** capture stderr to a `mktemp` log, sleep 5s + retry once on failure, on persistent failure surface the captured stderr and retain the log file path for operator support. Cleanup-side failures still tolerated (don't override the script's exit code), but their cause is now visible.

**Regression-lock:** `test_cleanup_destroy_retries_on_failure` asserts the stderr-capture pattern, the "attempt 1 failed" retry marker, and the "FAILED twice" surfacing path are all present.

## Test plan

- Harness: **15 → 18 tests**; all pass against current main
- Python suite: 979 passing (unchanged — bash-only branch)
- Visual smoke: harness output shows all three new tests green