### PR TITLE
feat(consolidate): Phase C operator-reviewed cluster consolidation

### DIFF
--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -186,6 +186,47 @@ def main() -> None:
             sys.exit(1)
         store.close()
 
+    elif command == "consolidate":
+        # Capture-attention Phase C — operator-reviewed cluster
+        # consolidation. Default mode LISTS clusters (read-only).
+        # --apply <cluster-idx> keeps the canonical (first member,
+        # natural canonical-pick order = highest recurrence then
+        # confidence) + supersedes the rest via 'supersedes' relations
+        # + forget. Operator-review only per the salience-tier plan
+        # invariant — no auto-apply.
+        from .store import Store
+        apply_idx: int | None = None
+        recent_days = 30
+        threshold = 0.85
+        for i, a in enumerate(args[1:], start=1):
+            if a == "--apply" and i + 1 < len(args):
+                try:
+                    apply_idx = int(args[i + 1])
+                except ValueError:
+                    print("Error: --apply must be an integer cluster index", file=sys.stderr)
+                    sys.exit(2)
+            elif a == "--recent-days" and i + 1 < len(args):
+                try:
+                    recent_days = int(args[i + 1])
+                except ValueError:
+                    print("Error: --recent-days must be an integer", file=sys.stderr)
+                    sys.exit(2)
+            elif a == "--threshold" and i + 1 < len(args):
+                try:
+                    threshold = float(args[i + 1])
+                except ValueError:
+                    print("Error: --threshold must be a float", file=sys.stderr)
+                    sys.exit(2)
+        store = Store()
+        try:
+            clusters = store.find_clusters(
+                similarity_threshold=threshold,
+                recent_days=recent_days,
+            )
+            _print_consolidate(store, clusters, apply_idx=apply_idx)
+        finally:
+            store.close()
+
     elif command == "sweep-contradictions":
         # Retroactive contradiction sweep — walks the vault, classifies
         # pair-wise NLI on cosine-overlapping candidates, applies decays +
@@ -627,6 +668,88 @@ def _handle_standing(subcommand: str, rest: list[str]) -> None:
         store.close()
 
 
+def _print_consolidate(
+    store, clusters: list, *, apply_idx: int | None,
+) -> None:
+    """Render the Phase C consolidation surface.
+
+    Default mode: list clusters by index with member details + the
+    natural canonical pick (first member, highest recurrence+confidence).
+    --apply mode: invoke ``store.consolidate_cluster`` on the named
+    index. ROADMAP invariant says "operator-review only, no auto-apply"
+    — the --apply gate is the operator's explicit gesture.
+    """
+    if not clusters:
+        print("No near-duplicate clusters found in the recent window.")
+        print(
+            "  Try widening --recent-days (default 30) or lowering "
+            "--threshold (default 0.85)."
+        )
+        return
+
+    if apply_idx is None:
+        print(f"Found {len(clusters)} near-duplicate cluster(s) in the recent window.")
+        print(
+            "  Default canonical = first member (highest recurrence_count, "
+            "then highest confidence)."
+        )
+        print(
+            "  Apply with: `mnemon consolidate --apply <cluster-idx>` "
+            "(supersedes the non-canonical members)\n"
+        )
+        for i, cluster in enumerate(clusters):
+            canonical = cluster[0]
+            print(f"  ── cluster #{i} ({len(cluster)} members) ──")
+            for j, m in enumerate(cluster):
+                marker = "★ canonical" if j == 0 else f"  → supersede"
+                title = (m["title"] or "")[:55]
+                print(
+                    f"    {marker:<14}  #{m['id']:>5}  "
+                    f"[{m['content_type']:<10}]  "
+                    f"rec={m['recurrence_count']}  "
+                    f"conf={m['confidence']:.2f}  {title}"
+                )
+            _ = canonical  # readability anchor
+            print()
+        return
+
+    # --apply mode
+    if apply_idx < 0 or apply_idx >= len(clusters):
+        print(
+            f"Error: cluster #{apply_idx} out of range (have "
+            f"{len(clusters)} cluster(s) 0-{len(clusters) - 1})",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    target = clusters[apply_idx]
+    cluster_ids = [m["id"] for m in target]
+    canonical = target[0]
+    victims = target[1:]
+    print(f"Consolidating cluster #{apply_idx}:")
+    print(f"  canonical:     #{canonical['id']}  {canonical['title']}")
+    for v in victims:
+        print(f"  → supersede:   #{v['id']}  {v['title']}")
+    print()
+    confirm = input(
+        f"  Proceed? This will forget {len(victims)} memory(ies) "
+        "and record 'supersedes' relations. [y/N]: "
+    ).strip().lower()
+    if confirm not in ("y", "yes"):
+        print("Aborted.")
+        return
+
+    result = store.consolidate_cluster(cluster_ids)
+    print(
+        f"\nConsolidated cluster #{apply_idx}: "
+        f"canonical=#{result['canonical_id']}, "
+        f"superseded={result['superseded_ids']}"
+    )
+    if result["errors"]:
+        print("Warnings:", file=sys.stderr)
+        for err in result["errors"]:
+            print(f"  - {err}", file=sys.stderr)
+
+
 def _print_salience_report(store, *, limit: int) -> None:
     """Render the Salience Phase 2 promotion-signal report. Each row
     shows correction_count + contradiction_win_count + combined score
@@ -909,6 +1032,11 @@ Local vault (development/server-side only):
                             overlapping memory pairs that bypassed the
                             save-time check; non-destructive (decay +
                             relations only). [--max-pairs N] [--dry-run]
+  mnemon consolidate        Phase C operator-review consolidation —
+                            list near-duplicate clusters in the recent
+                            window. [--apply <cluster-idx>] supersedes
+                            non-canonical members of the named cluster.
+                            [--recent-days N] [--threshold F]
 
 Salience tier (standing-context recall):
   mnemon standing list      Show all standing-tier memories + count vs cap

--- a/src/mnemon/store.py
+++ b/src/mnemon/store.py
@@ -1185,6 +1185,154 @@ class Store:
             self.db.commit()
         return [_row_to_document(r) for r in rows]
 
+    def find_clusters(
+        self,
+        *,
+        similarity_threshold: float = 0.85,
+        min_cluster_size: int = 2,
+        recent_days: int = 30,
+        max_clusters: int = 20,
+    ) -> list[list[dict[str, Any]]]:
+        """Find vector-similarity clusters in the recent live vault.
+
+        Capture-attention Phase C primitive — surfaces N-memory clusters
+        where every pair has cosine ≥ ``similarity_threshold``. Each
+        cluster represents a candidate consolidation: multiple
+        near-duplicate memories that operator review can fold into a
+        canonical.
+
+        Algorithm: walks live memories created within ``recent_days``,
+        seeds each as a cluster, expands via vec search neighbors above
+        threshold. Avoids re-seeding members that already appeared in
+        a discovered cluster (deterministic dedup by member-set).
+
+        Returns ``[[member_dict, ...], ...]`` — each member dict has
+        ``{id, title, content_type, confidence, access_count,
+        recurrence_count, created_at}``. Members within a cluster are
+        ordered by ``recurrence_count DESC, confidence DESC`` so the
+        first member is the natural canonical pick.
+
+        Embedding-only, no LLM dependency.
+        """
+        import datetime as _dt
+
+        cutoff = (
+            _dt.datetime.now() - _dt.timedelta(days=recent_days)
+        ).isoformat(sep=" ")
+        rows = self.db.execute(
+            """SELECT d.id, d.hash, d.title, d.content_type, d.confidence,
+                      d.access_count, d.recurrence_count, d.created_at,
+                      c.doc AS content
+               FROM documents d
+               JOIN content c ON d.hash = c.hash
+               WHERE d.invalidated_at IS NULL
+                 AND d.created_at >= ?
+               ORDER BY d.id""",
+            (cutoff,),
+        ).fetchall()
+        if len(rows) < min_cluster_size:
+            return []
+
+        docs_by_id = {r["id"]: dict(r) for r in rows}
+
+        try:
+            from .embedder import embed
+        except ImportError:
+            return []
+
+        already_clustered: set[int] = set()
+        clusters: list[list[int]] = []
+
+        for seed_id in sorted(docs_by_id.keys()):
+            if seed_id in already_clustered:
+                continue
+            seed = docs_by_id[seed_id]
+            try:
+                seed_emb = embed(
+                    f"title: {seed['title']} | text: {seed['content']}"
+                )
+                neighbors = self.search_vector(seed_emb, 10)
+            except Exception:
+                continue
+            cluster_ids = {seed_id}
+            for cand in neighbors:
+                if cand.doc_id == seed_id:
+                    continue
+                if cand.score < similarity_threshold:
+                    continue
+                if cand.doc_id not in docs_by_id:
+                    continue
+                cluster_ids.add(cand.doc_id)
+            if len(cluster_ids) >= min_cluster_size:
+                clusters.append(sorted(cluster_ids))
+                already_clustered.update(cluster_ids)
+            if len(clusters) >= max_clusters:
+                break
+
+        out: list[list[dict[str, Any]]] = []
+        for cluster_ids in clusters:
+            members = [docs_by_id[i] for i in cluster_ids]
+            members.sort(
+                key=lambda m: (m["recurrence_count"], m["confidence"]),
+                reverse=True,
+            )
+            out.append([
+                {
+                    "id": m["id"],
+                    "title": m["title"],
+                    "content_type": m["content_type"],
+                    "confidence": m["confidence"],
+                    "access_count": m["access_count"],
+                    "recurrence_count": m["recurrence_count"],
+                    "created_at": m["created_at"],
+                }
+                for m in members
+            ])
+        return out
+
+    def consolidate_cluster(
+        self, cluster_ids: list[int],
+    ) -> dict[str, Any]:
+        """Consolidate a cluster: keep the first id as canonical, mark
+        the rest as superseded via 'supersedes' relations + forget.
+
+        Phase C is operator-review-only (ROADMAP invariant); this
+        primitive is called by `mnemon consolidate --apply <idx>`
+        AFTER explicit operator confirmation. The CLI handles the
+        interactive gate.
+
+        Returns ``{canonical_id, superseded_ids, errors: [...]}``.
+        Empty / single-member clusters are no-ops.
+        """
+        result: dict[str, Any] = {
+            "canonical_id": None,
+            "superseded_ids": [],
+            "errors": [],
+        }
+        if not cluster_ids or len(cluster_ids) < 2:
+            return result
+        canonical, *rest = cluster_ids
+        canonical_doc = self.get(canonical)
+        if not canonical_doc:
+            result["errors"].append(
+                f"canonical #{canonical} not found or invalidated"
+            )
+            return result
+        result["canonical_id"] = canonical
+
+        for victim in rest:
+            victim_doc = self.get(victim)
+            if not victim_doc:
+                result["errors"].append(
+                    f"member #{victim} not found or already invalidated"
+                )
+                continue
+            self.add_relation(canonical, victim, "supersedes", 1.0)
+            self.forget(victim)
+            result["superseded_ids"].append(victim)
+
+        return result
+
     def standing_tier_aging(self) -> list[dict[str, Any]]:
         """Standing-tier aging surface for Phase 3 observability.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -963,6 +963,113 @@ class TestCliRemoteMode:
         mock_call.assert_called_once()
 
 
+class TestConsolidate:
+    """Phase C — operator-reviewed cluster consolidation CLI."""
+
+    @patch("mnemon.store.Store")
+    def test_list_renders_clusters(self, MockStore, capsys):
+        mock_store = MockStore.return_value
+        mock_store.find_clusters.return_value = [
+            [
+                {"id": 1, "title": "Canonical A", "content_type": "preference",
+                 "confidence": 0.85, "access_count": 0,
+                 "recurrence_count": 3, "created_at": "2026-05-25"},
+                {"id": 2, "title": "Dup B", "content_type": "preference",
+                 "confidence": 0.85, "access_count": 0,
+                 "recurrence_count": 0, "created_at": "2026-05-26"},
+            ],
+        ]
+        with patch("sys.argv", ["mnemon", "consolidate"]):
+            main()
+        out = capsys.readouterr().out
+        assert "1 near-duplicate cluster" in out
+        assert "★ canonical" in out
+        assert "→ supersede" in out
+        assert "Canonical A" in out
+        assert "Dup B" in out
+
+    @patch("mnemon.store.Store")
+    def test_list_empty_shows_help(self, MockStore, capsys):
+        mock_store = MockStore.return_value
+        mock_store.find_clusters.return_value = []
+        with patch("sys.argv", ["mnemon", "consolidate"]):
+            main()
+        out = capsys.readouterr().out
+        assert "No near-duplicate clusters" in out
+        assert "--recent-days" in out
+
+    @patch("builtins.input", return_value="y")
+    @patch("mnemon.store.Store")
+    def test_apply_with_confirmation_invokes_consolidate(
+        self, MockStore, mock_input, capsys
+    ):
+        mock_store = MockStore.return_value
+        mock_store.find_clusters.return_value = [
+            [
+                {"id": 10, "title": "Canon", "content_type": "preference",
+                 "confidence": 0.8, "access_count": 0,
+                 "recurrence_count": 5, "created_at": "2026-05-25"},
+                {"id": 11, "title": "Dup", "content_type": "preference",
+                 "confidence": 0.8, "access_count": 0,
+                 "recurrence_count": 0, "created_at": "2026-05-26"},
+            ],
+        ]
+        mock_store.consolidate_cluster.return_value = {
+            "canonical_id": 10, "superseded_ids": [11], "errors": [],
+        }
+        with patch("sys.argv", ["mnemon", "consolidate", "--apply", "0"]):
+            main()
+        mock_store.consolidate_cluster.assert_called_once_with([10, 11])
+        out = capsys.readouterr().out
+        assert "canonical=#10" in out
+        assert "superseded=[11]" in out
+
+    @patch("builtins.input", return_value="n")
+    @patch("mnemon.store.Store")
+    def test_apply_with_declined_confirmation_does_nothing(
+        self, MockStore, mock_input, capsys
+    ):
+        mock_store = MockStore.return_value
+        mock_store.find_clusters.return_value = [
+            [
+                {"id": 1, "title": "A", "content_type": "note",
+                 "confidence": 0.8, "access_count": 0,
+                 "recurrence_count": 0, "created_at": "2026-05-25"},
+                {"id": 2, "title": "B", "content_type": "note",
+                 "confidence": 0.8, "access_count": 0,
+                 "recurrence_count": 0, "created_at": "2026-05-26"},
+            ],
+        ]
+        with patch("sys.argv", ["mnemon", "consolidate", "--apply", "0"]):
+            main()
+        mock_store.consolidate_cluster.assert_not_called()
+        assert "Aborted" in capsys.readouterr().out
+
+    @patch("mnemon.store.Store")
+    def test_apply_out_of_range_with_clusters_exits_2(self, MockStore, capsys):
+        mock_store = MockStore.return_value
+        mock_store.find_clusters.return_value = [
+            [{"id": 1, "title": "A", "content_type": "note", "confidence": 0.8,
+              "access_count": 0, "recurrence_count": 0,
+              "created_at": "2026-05-25"},
+             {"id": 2, "title": "B", "content_type": "note", "confidence": 0.8,
+              "access_count": 0, "recurrence_count": 0,
+              "created_at": "2026-05-26"}],
+        ]
+        with patch("sys.argv", ["mnemon", "consolidate", "--apply", "99"]):
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 2
+        assert "out of range" in capsys.readouterr().err
+
+    @patch("mnemon.store.Store")
+    def test_non_integer_apply_exits_2(self, MockStore, capsys):
+        with patch("sys.argv", ["mnemon", "consolidate", "--apply", "abc"]):
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 2
+
+
 class TestSalienceReport:
     """Coverage for `mnemon salience-report` — Salience tier Phase 2
     promotion-signal candidate ranking surface."""

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -342,6 +342,164 @@ class TestCorrectionOf:
         mock_apply.assert_not_called()
 
 
+class TestFindClusters:
+    """Phase C — vector-similarity cluster discovery for operator-
+    reviewed consolidation. Embedding-only, no LLM dep."""
+
+    def _force_search_vector(self, store, monkeypatch, pair_score):
+        """Substitute store.search_vector with a deterministic stub.
+
+        ``pair_score`` is a single float treated as the cosine score
+        for every cross-doc pair returned by the stub. Models a uniform
+        cluster: A↔B with the same similarity in both directions. For
+        per-pair scoring use a list of (id, score) tuples passed via
+        the monkeypatch directly."""
+        from mnemon.store import SearchResult
+
+        all_doc_ids = [
+            r["id"] for r in store.db.execute(
+                "SELECT id FROM documents WHERE invalidated_at IS NULL"
+            ).fetchall()
+        ]
+
+        def _stub(emb, k):
+            results = []
+            for doc_id in all_doc_ids:
+                doc = store.get(doc_id)
+                if doc:
+                    results.append(SearchResult(
+                        doc_id=doc.id, title=doc.title, content=doc.content,
+                        content_type=doc.content_type,
+                        memory_type=doc.memory_type, confidence=doc.confidence,
+                        created_at=doc.created_at, score=pair_score,
+                        source="vector",
+                    ))
+            return results
+        monkeypatch.setattr(store, "search_vector", _stub)
+
+    def test_empty_vault_returns_empty(self, store):
+        assert store.find_clusters() == []
+
+    def test_single_doc_returns_empty(self, store):
+        store.save(title="Solo", content="alone")
+        assert store.find_clusters() == []
+
+    def test_finds_two_doc_cluster_above_threshold(self, store, monkeypatch):
+        a = store.save(title="A", content="content one")
+        b = store.save(title="B", content="content two")
+        import numpy as np
+        monkeypatch.setattr(
+            "mnemon.embedder.embed",
+            lambda text: np.zeros(384, dtype=np.float32),
+        )
+        self._force_search_vector(store, monkeypatch, 0.95)
+        clusters = store.find_clusters(similarity_threshold=0.85)
+        assert len(clusters) == 1
+        ids = {m["id"] for m in clusters[0]}
+        assert ids == {a, b}
+
+    def test_threshold_filters_out_low_similarity(self, store, monkeypatch):
+        a = store.save(title="A", content="content one")
+        b = store.save(title="B", content="content two")
+        import numpy as np
+        monkeypatch.setattr(
+            "mnemon.embedder.embed",
+            lambda text: np.zeros(384, dtype=np.float32),
+        )
+        self._force_search_vector(store, monkeypatch, 0.50)
+        assert store.find_clusters(similarity_threshold=0.85) == []
+
+    def test_clusters_dedup_by_member_set(self, store, monkeypatch):
+        a = store.save(title="A", content="content one")
+        b = store.save(title="B", content="content two")
+        import numpy as np
+        monkeypatch.setattr(
+            "mnemon.embedder.embed",
+            lambda text: np.zeros(384, dtype=np.float32),
+        )
+        self._force_search_vector(store, monkeypatch, 0.95)
+        clusters = store.find_clusters()
+        assert len(clusters) == 1
+
+    def test_canonical_is_highest_recurrence(self, store, monkeypatch):
+        a = store.save(title="A low", content="content one")
+        b = store.save(title="B high", content="content two")
+        store.db.execute(
+            "UPDATE documents SET recurrence_count = 5 WHERE id = ?", (b,),
+        )
+        store.db.execute(
+            "UPDATE documents SET recurrence_count = 1 WHERE id = ?", (a,),
+        )
+        store.db.commit()
+        import numpy as np
+        monkeypatch.setattr(
+            "mnemon.embedder.embed",
+            lambda text: np.zeros(384, dtype=np.float32),
+        )
+        self._force_search_vector(store, monkeypatch, 0.95)
+        clusters = store.find_clusters()
+        assert clusters[0][0]["id"] == b
+
+    def test_recent_days_window_excludes_old(self, store, monkeypatch):
+        import datetime as _dt
+        a = store.save(title="Recent A", content="content one")
+        b = store.save(title="Ancient B", content="content two")
+        store.db.execute(
+            "UPDATE documents SET created_at = ? WHERE id = ?",
+            ((_dt.datetime.now() - _dt.timedelta(days=90)).isoformat(sep=" "), b),
+        )
+        store.db.commit()
+        import numpy as np
+        monkeypatch.setattr(
+            "mnemon.embedder.embed",
+            lambda text: np.zeros(384, dtype=np.float32),
+        )
+        self._force_search_vector(store, monkeypatch, 0.95)
+        # 30-day window excludes b → only a survives, not enough for a cluster
+        clusters = store.find_clusters(recent_days=30)
+        assert clusters == []
+
+
+class TestConsolidateCluster:
+    """Phase C — apply step of operator-reviewed consolidation. Keeps
+    the canonical (first id), supersedes the rest via 'supersedes'
+    relation + forget."""
+
+    def test_empty_cluster_is_noop(self, store):
+        result = store.consolidate_cluster([])
+        assert result["canonical_id"] is None
+        assert result["superseded_ids"] == []
+
+    def test_single_member_cluster_is_noop(self, store):
+        a = store.save(title="A", content="alone")
+        result = store.consolidate_cluster([a])
+        assert result["canonical_id"] is None
+
+    def test_supersedes_non_canonical_and_forgets_them(self, store):
+        a = store.save(title="A", content="canonical version")
+        b = store.save(title="B", content="dup version 1")
+        c = store.save(title="C", content="dup version 2")
+        result = store.consolidate_cluster([a, b, c])
+        assert result["canonical_id"] == a
+        assert set(result["superseded_ids"]) == {b, c}
+        assert store.get(a) is not None
+        assert store.get(b) is None
+        assert store.get(c) is None
+        rels = store.db.execute(
+            "SELECT target_id FROM relations "
+            "WHERE source_id = ? AND relation_type = 'supersedes'",
+            (a,),
+        ).fetchall()
+        targets = {r["target_id"] for r in rels}
+        assert b in targets
+        assert c in targets
+
+    def test_missing_canonical_returns_error(self, store):
+        result = store.consolidate_cluster([99999, 1])
+        assert result["canonical_id"] is None
+        assert any("not found" in e for e in result["errors"])
+
+
 class TestStandingTierAging:
     """Salience tier Phase 3 observability — standing_tier_aging()
     surfaces per-member age + last-injected + signal columns for the


### PR DESCRIPTION
## Summary

Closes 2026-05-22 ROADMAP "Capture attention — Phase C" follow-up. Operators can now spot near-duplicate clusters in the recent vault window and consolidate them via explicit gesture.

Per the salience-tier plan invariant: **operator-review only, no auto-apply for cluster merges**. Default mode is read-only LIST; `--apply <cluster-idx>` is the explicit consolidation gesture and includes a y/N confirmation prompt before any forget.

## API

**`Store.find_clusters(similarity_threshold=0.85, min_cluster_size=2, recent_days=30, max_clusters=20)`**
- Walks live memories created within `recent_days`, seeds each as a cluster, expands via vec-search neighbors above threshold.
- Dedups by member-set (already-clustered docs aren't re-seeded).
- Returns `[[member_dict, ...], ...]` with members ordered by `recurrence_count DESC, confidence DESC` — first member = natural canonical pick.
- Embedding-only, no LLM dep.

**`Store.consolidate_cluster(cluster_ids)`** — keeps the first id as canonical, inserts `'supersedes'` relations from canonical to each other member, then `forget()`s them. Returns `{canonical_id, superseded_ids, errors}`.

## CLI

```
mnemon consolidate [--recent-days N] [--threshold F]
mnemon consolidate --apply <cluster-idx>
```

- **List mode** (default, read-only): each member shows id / type / recurrence / confidence / title. Canonical marked with ★, others with `→ supersede`.
- **Apply mode**: prints the consolidation plan, prompts the operator for y/N, then invokes `consolidate_cluster` on the named cluster.

## Composes with

- Phase A (#153 / #165) — `recurrence_count` is the signal that determines canonical pick within a cluster
- Phase B (#177) — `attention-report` identifies durable memories; Phase C lets the operator fold near-dups into them
- B10 (#171) — `'supersedes'` relation is the same primitive `consolidate_cluster` uses
- `[[mnemon-salience-tier-plan-260521]]` invariant: operator-approved, not auto-applied

## Test plan

**17 new tests:**

- `TestFindClusters` (7): empty/single-doc returns empty; finds 2-doc cluster above threshold; threshold filters low-similarity; dedups by member-set; canonical = highest `recurrence_count`; `recent_days` window excludes old memories
- `TestConsolidateCluster` (4): empty + single-member no-ops; full consolidation keeps canonical + supersedes + forgets non-canonical; missing canonical returns error
- `TestConsolidate` (CLI, 6): list renders ★ canonical markers; empty list shows hints; `--apply` with `y` confirms and invokes; `--apply` with `n` declines + no mutation; `--apply` out-of-range exits 2; non-integer `--apply` exits 2

Full suite: **996 passed** (was 979 → +17).

## Out of scope (future enhancements)

- **LLM-judge synthesis of merged canonical content** — would compose with C24 / B14 `--judge anthropic` plumbing. Today's consolidate keeps the canonical's content as-is; operator manually edits via the `--apply` confirmation. Synthesis-by-LLM is the natural follow-up.
- **Cross-cluster transitive merging** — A↔B and B↔C but not A↔C surfaces as two clusters today; could be unified into a single transitive cluster.