### PR TITLE
chore(version): bump 0.7.0rc5 → 0.7.0rc6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,104 @@
 # Changelog
 
+## [0.7.0rc6] - 2026-05-27
+
+### Phase 2 / 3 salience tier + Phase B / C capture-attention substrate
+
+Substantial roadmap-closure release consolidating the 2026-05-27 sweep.
+Every change is gated default-off or operator-explicit — Phase A
+capture-attention auto-firing stays default-off pending the re-soak
+gate (see "Re-soak prereq" below).
+
+**Salience tier**
+- **Phase 2 promotion signals** (#178): new `documents.correction_count`
+  + `documents.contradiction_win_count` columns + `Store.salience_report`
+  + `mnemon salience-report` CLI. Bumps on operator `correction_of=`
+  gestures and NLI contradiction-win events respectively.
+- **Phase 3 observability** (#179): new `documents.last_injected_at`
+  column; `Store.list_standing` bumps it on every injection event;
+  `mnemon standing list` renders aging table with ⚠ stale marker
+  for members not injected in ≥90d.
+- **Vault-derived auto-exemplars** in `scripts/build_standing_set.py`
+  (#168): `--exemplar-source {hybrid, vault, hand-tuned}`. Default
+  hybrid; samples high-confidence preference/decision/antipattern
+  as positives and recent handoffs as negatives.
+- **LLM-judge opt-in** (#175): `--judge anthropic`, requires
+  `ANTHROPIC_API_KEY` + `pip install anthropic`. 4-dim rubric.
+  Default `--judge embedding` unchanged.
+- **`memory_promote` coherence check** (#173): post-promote NLI
+  bidirectional classification against existing standing-tier
+  members; conflicts surface as a warning (not blocking — NLI
+  false-neg on numeric updates is a known limitation).
+
+**Capture attention**
+- **Phase B access-count feedback loop** (#177):
+  `documents.access_count` now increments on every `memory_search`
+  hit; new `Store.attention_report` ranks by access × recency;
+  `mnemon attention-report` CLI.
+- **Phase C operator-reviewed consolidation** (#183):
+  `Store.find_clusters` + `mnemon consolidate [--apply <idx>]` with
+  y/N confirmation gate. Operator-review only per plan invariant.
+- **Retroactive contradiction sweep** (#180):
+  `contradiction.sweep_contradictions` + `mnemon sweep-contradictions
+  [--max-pairs N] [--dry-run]`. Closes the save-time miss gap.
+
+**`memory_save` / explicit supersession**
+- **`correction_of` is now a structural relation** (#171). When set,
+  `Store.save` inserts `'supersedes'` (new → target) + bumps the
+  target's `correction_count`. Raises `ValueError` on missing target.
+  `memory_save` MCP tool exposes the parameter.
+
+**`mnemon` CLI**
+- **`status` / `search` / `save` honor remote mode** (#176). When
+  `MNEMON_REMOTE_URL` is set, routes through `call_tool_sync` to
+  the remote vault. Closes the 2026-05-21 Layer-3 silent-fallback gap.
+- **`attention-status --strict`** (#167) exits 1 when boost-rate >
+  ceiling — for periodic health-check wiring.
+
+**Operator tooling**
+- **`scripts/mnemon_ops.sh`** (#172): `cleanup-test-apps`,
+  `recover-token`, `restart-machine`, `vault-stats`,
+  `changelog-extract`.
+- **`scripts/` smoke-test CI** (#170): pytest parametrized over
+  `scripts/*.py --help`.
+
+**Release engineering**
+- **TestPyPI integration** (#181): `mnemon upgrade web --testpypi`
+  + `promote_stable.sh testpublish` subcommand. Enables true
+  pre-publish validation of candidate code rather than the
+  latest-published proxy.
+- **`promote_stable.sh` harness expansion** (#182):
+  `MNEMON_VENV_BIN` env-var override; trap destroy retries + stderr
+  capture; step-2 `remote_url` isolation regression test.
+- **Drop `_fly_dump_vault` inline-Python script** (#169) —
+  `mnemon sync push` is now the canonical primitive.
+
+**Polish + fixes**
+- `context_surfacing` balances dangling `**` mid-bold truncation
+  (#167).
+- `scripts/calibrate_capture_threshold.py --use-fixture` falls back
+  to `.example.json` on fresh clones (#167).
+- NLI cache resolution docs in Dockerfile + nli.py (#167).
+- `cli.py` coverage 62% → 85% (#174).
+- README cross-client recall guidance (#163).
+
+### Re-soak prereq
+
+`CAPTURE_ATTENTION_ENABLED` stays default-off in this rc. Operator-
+side workflow to start the Phase A re-soak:
+
+1. Publish rc6 to PyPI (`twine upload`).
+2. `mnemon upgrade web --app-name mnemon-memory --mnemon-version 0.7.0rc6`.
+3. Verify `mnemon doctor` 7/7 green.
+4. `flyctl ssh console -a mnemon-memory -C 'mnemon attention-status'`
+   — confirm `Flag enabled: False`, baseline boost-rate.
+5. `flyctl secrets set MNEMON_CAPTURE_ATTENTION_ENABLED=true` —
+   starts the re-soak clock.
+6. Soak ≥1 week; pass condition `boost_rate ≤ 0.25` per the ROADMAP
+   gate.
+
+Suite 875 → 996 across the sweep (+121 tests).
+
 ## [0.7.0rc5] - 2026-05-27
 
 ### Salience tier — Phase 1 default-on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.7.0rc5"
+version = "0.7.0rc6"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.0rc5"
+__version__ = "0.7.0rc6"


### PR DESCRIPTION
## Summary

Consolidates the 2026-05-27 ROADMAP sweep into a single rc for operator-driven PyPI publish + Fly redeploy. Ships everything from PRs #167 through #183 (17 PRs across batches A + B + C, +121 net tests, suite 875 → 996).

3-line bump per the established pattern:
- `pyproject.toml`: `0.7.0rc5` → `0.7.0rc6`
- `src/mnemon/__init__.py`: `__version__ = "0.7.0rc6"`
- `CHANGELOG.md`: new `[0.7.0rc6]` section with the full release notes

## Why now (Phase A re-soak gate)

Fly is currently still on **rc4**. PR #165 (capture-attention hook-source filter — the fix for the 0.714 boost-rate from the 2026-05-27 morning soak failure) has been merged on `main` since this morning but **isn't live on Fly** — the Phase A re-soak can't safely start until it is. rc5 was the original bump for that fix but wasn't twine-uploaded.

rc6 consolidates rc5's work + everything since (Phase 2/3 salience, Phase B/C capture-attention, TestPyPI integration, etc.) so a single operator deploy unblocks the re-soak AND ships the full sweep.

## `CAPTURE_ATTENTION_ENABLED` stays default-off in this rc

Per the ROADMAP Phase A re-soak gate. Operator workflow to start the re-soak post-deploy is in the CHANGELOG entry — quoted here:

1. `twine upload` rc6 to PyPI
2. `mnemon upgrade web --app-name mnemon-memory --mnemon-version 0.7.0rc6`
3. `mnemon doctor` 7/7 green
4. `flyctl ssh console -a mnemon-memory -C 'mnemon attention-status'` — confirm `Flag enabled: False`, baseline boost-rate
5. `flyctl secrets set MNEMON_CAPTURE_ATTENTION_ENABLED=true` — starts the re-soak clock
6. Soak ≥1 week; pass condition `boost_rate ≤ 0.25` per the ROADMAP gate

## Test plan

- [x] Suite: **999 passed** (was 996 → +3 from a few late additions earlier this session that hadn't been counted)
- [x] `mnemon --version` returns `0.7.0rc6`
- [ ] Post-merge (user-only): `twine upload`, `mnemon upgrade web`, `mnemon doctor`, `flyctl secrets set`
- [ ] Tag `v0.7.0rc6` + GitHub Release post-publish