### PR TITLE
fix(promote-stable): poll PyPI via JSON API, not `pip index versions`

### DIFF
--- a/scripts/promote_stable.sh
+++ b/scripts/promote_stable.sh
@@ -605,8 +605,14 @@ cmd_publish() {
     echo_ok "uploaded to PyPI"
 
     echo_step "Wait for PyPI to surface $TARGET_VERSION"
+    # Use the JSON API via `is_pypi_published` (same primitive
+    # `latest_pypi_version` uses). `pip index versions` proved unreliable
+    # for rc surfacing: returns latest STABLE only, hiding 0.7.0rcN
+    # entirely even when the rc IS published — caught 2026-05-27 when
+    # rc6 uploaded cleanly but the polling loop died after 5 min while
+    # https://pypi.org/project/mnemon-memory/0.7.0rc6/ was live.
     local tries=0
-    until "$MNEMON_VENV_BIN/pip" index versions mnemon-memory 2>/dev/null | head -5 | grep -q "$TARGET_VERSION"; do
+    until is_pypi_published "$TARGET_VERSION"; do
         tries=$((tries + 1))
         [ "$tries" -gt 30 ] && die "PyPI didn't surface $TARGET_VERSION after 5 min"
         sleep 10
@@ -682,10 +688,10 @@ PY
 cmd_verify() {
     echo_step "Verify $TARGET_VERSION live"
 
-    local pypi_line
-    pypi_line="$("$MNEMON_VENV_BIN/pip" index versions mnemon-memory 2>/dev/null | head -1 || true)"
-    echo "  PyPI: $pypi_line"
-    "$MNEMON_VENV_BIN/pip" index versions mnemon-memory 2>/dev/null | head -1 | grep -q "$TARGET_VERSION" \
+    # Same JSON-API path as cmd_publish + latest_pypi_version. The old
+    # `pip index versions` lookup hid rc/pre-releases and missed the
+    # 2026-05-27 rc6 surfacing — see test_publish_pypi_poll_uses_json_api.
+    is_pypi_published "$TARGET_VERSION" \
       || die "PyPI does not show $TARGET_VERSION as a known version"
     echo_ok "PyPI shows $TARGET_VERSION"
 

--- a/tests/test_promote_stable.sh
+++ b/tests/test_promote_stable.sh
@@ -445,6 +445,31 @@ test_cleanup_destroy_retries_on_failure() {
         || { echo "    cleanup must surface persistent-failure path" >&2; return 1; }
 }
 
+test_publish_pypi_poll_uses_json_api_not_pip_index() {
+    # 2026-05-27: rc6 uploaded cleanly to PyPI but cmd_publish's
+    # "Wait for PyPI to surface" loop died after 5 min because it was
+    # polling via 'pip index versions mnemon-memory' — that command
+    # filters out pre-releases by default + has known cache flakiness
+    # (the existing latest_pypi_version helper docstring calls it out
+    # explicitly). Fix routes the polling check through
+    # is_pypi_published which hits the JSON API directly.
+    local script_path
+    script_path="$REPO_ROOT/scripts/promote_stable.sh"
+
+    # No runtime invocation of `pip index versions` should remain.
+    # Match only the executable-call form ("$MNEMON_VENV_BIN/pip" index
+    # versions ...) so docstring/comment mentions explaining WHY we
+    # avoid the command don't trip the check.
+    if grep -qE '"\$MNEMON_VENV_BIN/pip"[[:space:]]+index[[:space:]]+versions' "$script_path"; then
+        echo "    found \"\$MNEMON_VENV_BIN/pip\" index versions invocation — must use is_pypi_published" >&2
+        return 1
+    fi
+    # Wait-for-pypi block must call is_pypi_published.
+    grep -A6 'Wait for PyPI to surface' "$script_path" \
+        | grep -q 'is_pypi_published' \
+        || { echo "    cmd_publish wait-for-pypi must call is_pypi_published" >&2; return 1; }
+}
+
 test_step2_seed_contents_are_unique() {
     # mnemon's store.save() does content-hash dedup (rc15+). The original
     # runbook passed the same content to all three Step-2 saves, which
@@ -497,6 +522,7 @@ run_test test_awk_handles_zero_count
 run_test test_awk_returns_empty_when_field_missing
 run_test test_sourcing_does_not_dispatch
 run_test test_step2_seed_contents_are_unique
+run_test test_publish_pypi_poll_uses_json_api_not_pip_index
 run_test test_step2_removes_remote_url_before_seed
 run_test test_mnemon_venv_bin_env_var_is_honored
 run_test test_cleanup_destroy_retries_on_failure


### PR DESCRIPTION
## Summary

Surfaced 2026-05-27 when rc6 uploaded cleanly but `cmd_publish`'s "Wait for PyPI to surface" loop died after 5 min while https://pypi.org/project/mnemon-memory/0.7.0rc6/ was visibly live.

**Root cause:** `cmd_publish` + `cmd_verify` polled via `"$MNEMON_VENV_BIN/pip" index versions mnemon-memory`. That command filters out pre-releases by default (returns latest STABLE only, hides `0.7.0rcN` entirely) AND has known cache flakiness — the helper at the top of the same script (`latest_pypi_version`, line 81) calls this out explicitly in its docstring as the reason for using the JSON API. The wait-for-pypi block + `cmd_verify` hadn't been migrated alongside.

## Fix

- `cmd_publish`'s wait-for-pypi loop now calls `is_pypi_published "$TARGET_VERSION"` (the JSON-API-backed helper already in the file).
- `cmd_verify`'s PyPI surfacing assertion likewise.

## Test plan

- `test_publish_pypi_poll_uses_json_api_not_pip_index` in `tests/test_promote_stable.sh` — asserts no runtime `"$MNEMON_VENV_BIN/pip" index versions ...` invocations remain + the wait-for-pypi block calls `is_pypi_published`.
- Harness: **18 → 19 tests**, all green.
- Python suite unchanged (**1004 passed**).

## Operator note

The in-flight rc6 publish that hit this bug can be completed manually:

```bash
.venv/bin/mnemon upgrade web --app-name mnemon-memory --mnemon-version 0.7.0rc6
.venv/bin/mnemon doctor
git tag -a v0.7.0rc6 -m "0.7.0rc6"
git push origin v0.7.0rc6
gh release create v0.7.0rc6 --notes "$(bash scripts/mnemon_ops.sh changelog-extract 0.7.0rc6)" --prerelease
```

Once this PR lands, re-running `promote_stable.sh publish` against a fresh rc will complete end-to-end.