### PR TITLE
feat(phase-a-resoak): release-and-activate — single-command publish + activate

### DIFF
--- a/scripts/phase_a_resoak.sh
+++ b/scripts/phase_a_resoak.sh
@@ -7,12 +7,21 @@
 # filter to Fly + activate the re-soak + monitor + close.
 #
 # Subcommands:
+#   release-and-activate
+#               — ALL-IN-ONE: invoke promote_stable.sh publish (build →
+#                 twine upload → wait for PyPI → mnemon upgrade web →
+#                 doctor → tag → GH Release), then activate the Phase A
+#                 re-soak. The single-command operator path. Each
+#                 destructive step inside the chain has its own confirm
+#                 prompt so the gates remain.
 #   preflight   — read-only: confirm Fly version matches local
-#                 __version__ + hook-source filter is in the deployed
-#                 contradiction.py + secret is currently OFF.
+#                 __version__ + hook-source filter (rc5+) is live +
+#                 secret is currently OFF.
 #   activate    — confirm + `flyctl secrets set
 #                 MNEMON_CAPTURE_ATTENTION_ENABLED=true` + verify the
-#                 flip via `mnemon attention-status` on Fly.
+#                 flip via `mnemon attention-status` on Fly. Assumes
+#                 release already happened (use release-and-activate
+#                 to fold both).
 #   status      — print current Fly `mnemon attention-status` + soak
 #                 elapsed-days from the activation timestamp file.
 #   close       — read attention-status; if boost-rate ≤ ceiling +
@@ -23,19 +32,20 @@
 #                 MNEMON_CAPTURE_ATTENTION_ENABLED`. Use if the live
 #                 boost-rate spikes mid-soak.
 #
-# Operator workflow (assumes the rc has been merged + twine-uploaded +
-# `mnemon upgrade web` deployed against Fly):
+# Recommended operator workflow (single command):
 #
-#   scripts/phase_a_resoak.sh preflight   # confirm ready
-#   scripts/phase_a_resoak.sh activate    # start the soak clock
+#   scripts/phase_a_resoak.sh release-and-activate
 #   # ... wait ≥ MIN_SOAK_DAYS, periodically:
 #   scripts/phase_a_resoak.sh status
 #   # at soak end:
-#   scripts/phase_a_resoak.sh close       # surface pass/fail + next-step PR
+#   scripts/phase_a_resoak.sh close
 #
-# `twine upload` + `mnemon upgrade web` are NOT driven from here —
-# those are the operator's responsibility (credentials + the existing
-# promote_stable.sh / mnemon upgrade web entry points).
+# Decomposed workflow (when you want finer-grained control or already
+# released):
+#
+#   bash scripts/promote_stable.sh publish        # release chain only
+#   scripts/phase_a_resoak.sh preflight           # confirm ready
+#   scripts/phase_a_resoak.sh activate            # start the soak clock
 
 set -euo pipefail
 
@@ -293,6 +303,36 @@ print(f'{(now - started).total_seconds() / 86400:.1f}')
     fi
 }
 
+cmd_release_and_activate() {
+    # All-in-one: invoke promote_stable.sh publish (full release chain
+    # — build → twine upload → wait → mnemon upgrade web → doctor →
+    # tag → GH Release), then activate the Phase A re-soak. Folds the
+    # 5-command operator sequence into a single invocation. Each
+    # destructive step inside promote_stable.sh has its own confirm
+    # prompt (twine upload, etc.), so the operator gates remain.
+    #
+    # Use this when: you've merged the rc bump PR + want to ship the
+    # rc to Fly AND start the Phase A re-soak in one shot.
+    #
+    # If a step fails, the script aborts at the failure point and the
+    # operator can hand-resume from there. After fixing, re-invoke
+    # this subcommand — promote_stable.sh's preflight + the activate
+    # step are both idempotent.
+    echo_step "Release + activate Phase A re-soak — single-command path"
+    echo "  Phase 1: promote_stable.sh publish (build → twine → deploy → tag → release)"
+    echo "  Phase 2: phase_a_resoak.sh activate (preflight → flyctl secrets set → verify)"
+
+    confirm "Run the full release + activate chain for $LOCAL_VERSION?"
+
+    echo_step "Phase 1 of 2 — promote_stable.sh publish"
+    bash "$SCRIPT_DIR/promote_stable.sh" publish
+
+    echo_step "Phase 2 of 2 — phase_a_resoak.sh activate"
+    # cmd_activate already runs cmd_preflight as its first step, which
+    # validates Fly is at the just-deployed version.
+    cmd_activate
+}
+
 cmd_deactivate() {
     echo_step "Phase A re-soak DEACTIVATE — emergency off-switch"
 
@@ -319,11 +359,12 @@ main() {
     local sub="${1:-help}"
     shift || true
     case "$sub" in
-        preflight)   cmd_preflight ;;
-        activate)    cmd_activate ;;
-        status)      cmd_status ;;
-        close)       cmd_close ;;
-        deactivate)  cmd_deactivate ;;
+        preflight)             cmd_preflight ;;
+        activate)              cmd_activate ;;
+        release-and-activate)  cmd_release_and_activate ;;
+        status)                cmd_status ;;
+        close)                 cmd_close ;;
+        deactivate)            cmd_deactivate ;;
         help|-h|--help|"") usage ;;
         *)
             echo "unknown subcommand: $sub" >&2

--- a/tests/test_phase_a_resoak.py
+++ b/tests/test_phase_a_resoak.py
@@ -63,7 +63,14 @@ class TestHelp:
             capture_output=True, text=True,
             cwd=str(REPO_ROOT), env=_env_with_venv_bin(),
         )
-        for sub in ("preflight", "activate", "status", "close", "deactivate"):
+        for sub in (
+            "preflight",
+            "activate",
+            "release-and-activate",
+            "status",
+            "close",
+            "deactivate",
+        ):
             assert sub in result.stdout, f"help text missing {sub}"
 
 


### PR DESCRIPTION
## Summary

Folds the publish chain + Phase A re-soak activation into a single operator command. Direct answer to "why can't we fold all commands into a script."

**Before** (5+ commands across two scripts):
```bash
bash scripts/promote_stable.sh publish
# (hand-resume on failure: mnemon upgrade web, mnemon doctor, git tag, gh release create)
bash scripts/phase_a_resoak.sh preflight
bash scripts/phase_a_resoak.sh activate
```

**After** (one command):
```bash
bash scripts/phase_a_resoak.sh release-and-activate
```

## What it does

Phase 1 invokes `bash scripts/promote_stable.sh publish` — full release chain (build → twine check → twine upload → wait for PyPI → mnemon upgrade web → mnemon doctor → tag → GH Release → post-publish smoke).

Phase 2 invokes `cmd_activate`, which preflights (confirms Fly is now at the just-released version + hook-source filter is live) and then sets the Fly secret + verifies via attention-status.

## Gates preserved

- `twine upload` still prompts inside `cmd_publish` (confirm)
- `flyctl secrets set` still prompts inside `cmd_activate` (confirm)
- The chain short-circuits cleanly on any step failure (`set -e`); operator hand-resumes from the failure point
- Both subscripts are idempotent where possible, so re-invoking `release-and-activate` after a fix is safe

## Help block

Header updated:
- **"Recommended operator workflow (single command)"** leads with `release-and-activate`
- **"Decomposed workflow"** preserved for finer-grained control
- `activate`'s docstring notes it assumes release already happened (pointing operators at `release-and-activate`)

## Test plan

- `test_help_lists_every_subcommand` extended to require the new subcommand appears — catches future drift where the name changes without updating help
- Full suite: 1004 passed (unchanged — bash-only change)
- Smoke: `bash scripts/phase_a_resoak.sh help` renders the new subcommand at the top of the list

## Composes with

- PR #186 (PyPI poll → JSON API): once #186 merges, the publish phase no longer dies on the polling step, and `release-and-activate` runs end-to-end
- Existing `promote_stable.sh publish` (no changes needed there — this PR just calls it)