### PR TITLE
fix(serve): honor remote-vault mode so the local vault is inaccessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.7.0rc7] - 2026-06-04
+
+### Fix: `mnemon serve` honors remote-vault mode (two-vaults bug)
+
+When a remote vault was configured (`MNEMON_REMOTE_URL` env or
+`~/.mnemon/remote_url` file), the CLI read/write commands (`status`,
+`search`, `save`) routed to the remote — but `mnemon serve` did not: it
+unconditionally opened the local SQLite store. A machine pointed at a
+cloud vault therefore exposed **two** connected MCP servers backed by
+**different** data, the local one a stale near-empty vault. Reads/writes
+through it silently diverged from the source of truth.
+
+- **New `mnemon.server_proxy`** — a stdio MCP server that mirrors the
+  exact tool surface of `mnemon.server` (every tool wrapped via
+  `functools.wraps`, so names/docstrings/schemas are identical and can't
+  drift) and forwards each call to the remote vault via
+  `hooks._remote_client.call_tool_sync`. The local store is never opened
+  in remote mode. Fail-loud: remote/network/auth errors propagate to the
+  MCP client rather than degrading to the local vault.
+- **`serve` dispatch** now checks `_remote_mode_active()` and runs the
+  proxy in remote mode, `run_stdio` (local) otherwise — mirroring the
+  existing read/write routing.
+- `tests/test_server_proxy.py` asserts tool name/schema/description
+  parity between the two servers + forwarding + fail-loud behavior.
+
 ## [0.7.0rc6] - 2026-05-27
 
 ### Phase 2 / 3 salience tier + Phase B / C capture-attention substrate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.7.0rc6"
+version = "0.7.0rc7"
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.0rc6"
+__version__ = "0.7.0rc7"

--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -1,9 +1,11 @@
 """CLI entry point for mnemon.
 
 Setup commands configure clients to use a remote vault. Read/write
-commands (``status``, ``search``, ``save``) auto-route to the live
-remote vault when ``MNEMON_REMOTE_URL`` is set (env var or
-``~/.mnemon/remote_url`` file). Otherwise they hit the local
+commands (``status``, ``search``, ``save``) and the MCP server
+(``serve``) auto-route to the live remote vault when ``MNEMON_REMOTE_URL``
+is set (env var or ``~/.mnemon/remote_url`` file) — in remote mode
+``serve`` runs the stdio proxy in :mod:`mnemon.server_proxy`, never
+opening the local store. Otherwise they hit the local
 ``~/.mnemon/default.sqlite``. Local-only commands (``sync``,
 ``rebuild``, ``forget``, ``standing``, ``attention-status``,
 ``doctor``) intentionally stay on the local path — they're either
@@ -50,8 +52,17 @@ def main() -> None:
         return
 
     if command == "serve":
-        from .server import run_stdio
-        run_stdio()
+        # In remote mode the stdio MCP server must proxy to the remote
+        # vault, NOT open the local SQLite — otherwise a machine pointed
+        # at a cloud vault exposes a second, stale local vault over MCP
+        # (the 2026-06-04 two-vaults bug). Mirrors the read/write CLI
+        # routing above.
+        if _remote_mode_active():
+            from .server_proxy import run_remote_proxy
+            run_remote_proxy()
+        else:
+            from .server import run_stdio
+            run_stdio()
 
     elif command == "serve-remote":
         from .server_remote import run_remote

--- a/src/mnemon/server_proxy.py
+++ b/src/mnemon/server_proxy.py
@@ -1,0 +1,110 @@
+"""Remote-proxy MCP server (stdio transport).
+
+When a remote vault is configured (``MNEMON_REMOTE_URL`` env var or
+``~/.mnemon/remote_url`` file), ``mnemon serve`` runs THIS server instead
+of the local-SQLite :func:`mnemon.server.run_stdio`. Every tool call is
+forwarded to the remote vault via
+:func:`mnemon.hooks._remote_client.call_tool_sync` — the local SQLite
+vault is never opened.
+
+Why this exists
+---------------
+Before 2026-06-04, ``mnemon serve`` always opened the local vault even
+when a remote was configured, so a machine pointed at a cloud vault
+exposed TWO connected MCP servers backed by DIFFERENT data — the local
+one a stale, near-empty vault. Reads/writes through it silently diverged
+from the source of truth (a stale ``memory_status``/``memory_timeline``
+answered as if authoritative). The CLI read/write commands already
+routed to the remote via ``cli._remote_mode_active()``; ``serve`` was the
+one command that didn't. This module closes that gap: in remote mode the
+local vault is structurally inaccessible over MCP.
+
+Design — no drift
+-----------------
+The proxy mirrors the EXACT tool surface of :mod:`mnemon.server` by
+wrapping each registered tool function with :func:`functools.wraps`
+(which copies name, docstring, signature, and annotations → an identical
+MCP input schema) and swapping the body to forward remotely. The tool
+set is enumerated from the local server's own tool manager, so adding a
+tool to ``server.py`` automatically adds its proxy. ``tests/
+test_server_proxy.py`` asserts schema + description parity as a
+belt-and-suspenders guard.
+
+Fail-loud
+---------
+A remote / network / auth / config failure propagates out of the tool
+call (surfaced to the MCP client as a tool error) rather than degrading
+to the local vault. Per the project no-silent-fails rule, the proxy must
+never silently answer from the wrong store.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from . import server as _local
+from .hooks._remote_client import call_tool_sync
+from .server import _build_transport_security
+
+# Generous timeout for interactive tool calls proxied to the remote.
+# Larger than the hooks' 8s budget: operations like memory_rebuild /
+# memory_sweep / memory_export_vectors do real work on the remote and a
+# human is waiting on the MCP client, not a fire-and-forget hook.
+PROXY_TIMEOUT_SEC = 60.0
+_CLIENT_LABEL = "claude-code-proxy"
+
+
+def _forward(tool_name: str, arguments: dict[str, Any]) -> str:
+    """Forward one tool call to the configured remote vault.
+
+    Drops ``None``-valued optional arguments so the remote applies its
+    own defaults (mirrors how the bare MCP client would omit them).
+    Raises on any failure — the caller (FastMCP) surfaces it to the MCP
+    client as a tool error. Never falls back to the local vault.
+    """
+    args = {k: v for k, v in arguments.items() if v is not None}
+    text, _elapsed = call_tool_sync(
+        tool_name,
+        args,
+        timeout=PROXY_TIMEOUT_SEC,
+        client_label=_CLIENT_LABEL,
+    )
+    return text
+
+
+def _make_proxy(local_fn):
+    """Build a remote-forwarding wrapper with ``local_fn``'s exact
+    signature/docstring so FastMCP derives an identical tool schema."""
+    name = local_fn.__name__
+    sig = inspect.signature(local_fn)
+
+    @functools.wraps(local_fn)
+    def wrapper(*args, **kwargs):
+        bound = sig.bind(*args, **kwargs)
+        bound.apply_defaults()
+        return _forward(name, dict(bound.arguments))
+
+    return wrapper
+
+
+def build_proxy() -> FastMCP:
+    """Construct the remote-proxy FastMCP instance.
+
+    Enumerates every tool registered on the local server and registers a
+    remote-forwarding twin under the same name/schema. Returns a fresh
+    instance per call (cheap; FastMCP construction is in-process) so
+    tests can build in isolation.
+    """
+    mcp = FastMCP("mnemon", transport_security=_build_transport_security())
+    for tool in _local.mcp._tool_manager.list_tools():
+        mcp.tool()(_make_proxy(tool.fn))
+    return mcp
+
+
+def run_remote_proxy() -> None:
+    """Start the remote-proxy MCP server on stdio transport."""
+    build_proxy().run(transport="stdio")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -77,11 +77,26 @@ class TestVersionAndHelp:
 
 
 class TestServe:
+    @patch("mnemon.cli._remote_mode_active", return_value=False)
     @patch("mnemon.server.run_stdio")
-    def test_serve_calls_run_stdio(self, mock_run):
+    def test_serve_local_mode_calls_run_stdio(self, mock_run, _mode):
+        """No remote configured → serve opens the local stdio server."""
         with patch("sys.argv", ["mnemon", "serve"]):
             main()
         mock_run.assert_called_once()
+
+    @patch("mnemon.cli._remote_mode_active", return_value=True)
+    @patch("mnemon.server_proxy.run_remote_proxy")
+    @patch("mnemon.server.run_stdio")
+    def test_serve_remote_mode_calls_proxy_not_local(
+        self, mock_local, mock_proxy, _mode,
+    ):
+        """Remote configured → serve runs the remote proxy, NEVER the
+        local store (the 2026-06-04 two-vaults fix)."""
+        with patch("sys.argv", ["mnemon", "serve"]):
+            main()
+        mock_proxy.assert_called_once()
+        mock_local.assert_not_called()
 
     @patch("mnemon.server_remote.run_remote")
     def test_serve_remote_calls_run_remote(self, mock_run):

--- a/tests/test_server_proxy.py
+++ b/tests/test_server_proxy.py
@@ -1,0 +1,119 @@
+"""Tests for the remote-proxy MCP server (``mnemon.server_proxy``).
+
+The proxy must expose the EXACT same tool surface as the local
+``mnemon.server`` (so a client can't tell which backend it's talking to)
+while forwarding every call to the remote vault and never touching the
+local SQLite store.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from mnemon import server as local_server
+from mnemon import server_proxy
+
+
+def _tools(mcp):
+    """name -> Tool, via the sync tool-manager listing."""
+    return {t.name: t for t in mcp._tool_manager.list_tools()}
+
+
+class TestToolParity:
+    """The proxy can't drift from the real server — same names, schemas,
+    and descriptions, derived structurally via functools.wraps."""
+
+    def test_same_tool_names(self):
+        proxy = server_proxy.build_proxy()
+        assert set(_tools(proxy)) == set(_tools(local_server.mcp))
+
+    def test_same_input_schemas(self):
+        proxy_tools = _tools(server_proxy.build_proxy())
+        local_tools = _tools(local_server.mcp)
+        # ``.parameters`` is the JSON input schema on the tool-manager's
+        # internal Tool objects (the async protocol listing calls it
+        # ``inputSchema``).
+        mismatches = {
+            name
+            for name, lt in local_tools.items()
+            if proxy_tools[name].parameters != lt.parameters
+        }
+        assert not mismatches, f"schema drift in: {mismatches}"
+
+    def test_same_descriptions(self):
+        proxy_tools = _tools(server_proxy.build_proxy())
+        local_tools = _tools(local_server.mcp)
+        mismatches = {
+            name
+            for name, lt in local_tools.items()
+            if (proxy_tools[name].description or "") != (lt.description or "")
+        }
+        assert not mismatches, f"description drift in: {mismatches}"
+
+
+class TestForwarding:
+    """Every tool body forwards to the remote via call_tool_sync and
+    returns its text verbatim — the local Store is never constructed."""
+
+    def test_forward_passes_args_and_drops_none(self):
+        captured = {}
+
+        def fake_call(tool_name, arguments, *, timeout, client_label):
+            captured["tool_name"] = tool_name
+            captured["arguments"] = arguments
+            captured["timeout"] = timeout
+            captured["client_label"] = client_label
+            return ("REMOTE_RESULT", 0.01)
+
+        with patch.object(server_proxy, "call_tool_sync", fake_call):
+            proxy = server_proxy.build_proxy()
+            fn = _tools(proxy)["memory_search"].fn
+            out = fn(query="hello", limit=5, content_type=None)
+
+        assert out == "REMOTE_RESULT"
+        assert captured["tool_name"] == "memory_search"
+        # None-valued optionals are dropped so the remote uses its default
+        assert captured["arguments"] == {"query": "hello", "limit": 5}
+        assert captured["client_label"] == "claude-code-proxy"
+        assert captured["timeout"] == server_proxy.PROXY_TIMEOUT_SEC
+
+    def test_forward_keeps_explicit_non_none_optionals(self):
+        captured = {}
+
+        def fake_call(tool_name, arguments, *, timeout, client_label):
+            captured["arguments"] = arguments
+            return ("ok", 0.0)
+
+        with patch.object(server_proxy, "call_tool_sync", fake_call):
+            proxy = server_proxy.build_proxy()
+            fn = _tools(proxy)["memory_search"].fn
+            fn(query="q", content_type="note")
+
+        assert captured["arguments"] == {
+            "query": "q",
+            "limit": 10,
+            "content_type": "note",
+        }
+
+    def test_forward_never_opens_local_store(self):
+        """A proxy tool call must not construct a local Store."""
+        with patch.object(
+            server_proxy, "call_tool_sync", lambda *a, **k: ("ok", 0.0)
+        ), patch("mnemon.store.Store") as store_cls:
+            proxy = server_proxy.build_proxy()
+            _tools(proxy)["memory_status"].fn()
+            store_cls.assert_not_called()
+
+    def test_failure_propagates_not_swallowed(self):
+        """Fail-loud: a remote error raises out of the tool call rather
+        than degrading to the local vault."""
+        def boom(*a, **k):
+            raise RuntimeError("remote unreachable")
+
+        with patch.object(server_proxy, "call_tool_sync", boom):
+            proxy = server_proxy.build_proxy()
+            fn = _tools(proxy)["memory_status"].fn
+            with pytest.raises(RuntimeError, match="remote unreachable"):
+                fn()


### PR DESCRIPTION
## Problem

When a remote vault is configured (`MNEMON_REMOTE_URL` env or `~/.mnemon/remote_url` file), the CLI read/write commands (`status`, `search`, `save`) route to the remote — but **`mnemon serve` did not**. `serve` called `run_stdio()` unconditionally, which opens the local `~/.mnemon/default.sqlite`.

Consequence: a machine pointed at a cloud vault exposes **two** connected MCP servers backed by **different** data — `claude.ai mnemon` (remote, authoritative) and the stdio `mnemon` server (stale local SQLite). Reads/writes through the local one silently diverge from the source of truth. This caused a real wrong-vault incident on 2026-06-04 (a stale `memory_timeline` answered as if current).

## Fix

`serve` now honors `_remote_mode_active()`, mirroring the existing read/write routing — in remote mode the local store is **never opened over MCP**.

- **New `mnemon/server_proxy.py`** — a stdio MCP server that mirrors `server.py`'s exact tool surface and forwards every call to the remote vault via `hooks._remote_client.call_tool_sync`.
  - Drift-proof: each tool is wrapped with `functools.wraps`, so name / docstring / input schema are **byte-identical** to the real tool, and the tool set is enumerated from the local tool manager — adding a tool to `server.py` auto-adds its proxy.
  - **Fail-loud**: remote / network / auth / config errors propagate to the MCP client (surfaced as a tool error) rather than degrading to the local vault — never silently answer from the wrong store.
- `serve` dispatch branches on `_remote_mode_active()`; `run_stdio` (local) only when no remote is configured.
- `tests/test_server_proxy.py`: asserts name + schema + description parity between the two servers, plus forwarding semantics (drops `None` optionals, passes timeout/label, never constructs a local `Store`) and fail-loud propagation.
- Bumps `0.7.0rc6` → `0.7.0rc7` + CHANGELOG.

## Testing

- Full suite: **1012 passed**, coverage **87.95%** (gate 80%); `server_proxy.py` at 97%.
- No CI lint step affected; new files are ruff-clean.

## Notes

- This is a **client-side** fix (the local `mnemon serve`). The Fly remote server is unchanged — no remote redeploy required. Brian runs `serve` from the editable git checkout, so it takes effect on `git pull` + MCP server restart.
- Keeps headless/cron coverage: the stdio `mnemon` MCP server stays available (claude.ai OAuth connectors can be absent in headless runs), but now always reaches the cloud vault.
- Follow-up (separate, operational): archive `~/.mnemon/default.sqlite*` on this machine so the stale local data is physically out of commission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)