### PR TITLE
docs: OSS-readiness — MCP-tool accuracy, ARCHITECTURE, community infra

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Something isn't working as expected
+title: ''
+labels: bug
+assignees: ''
+---
+
+**What happened**
+A clear description of the bug.
+
+**What you expected**
+What you expected to happen instead.
+
+**Steps to reproduce**
+1.
+2.
+3.
+
+**Environment**
+- mnemon version: <!-- `mnemon --version` or the pip version -->
+- Python version: <!-- `python --version` -->
+- OS: <!-- macOS / Linux / Windows + version -->
+- Mode: <!-- local (stdio) or web (remote/Fly) -->
+- MCP client: <!-- Claude Code / Claude Desktop / Cursor / Gemini / claude.ai / other -->
+
+**Logs / output**
+```
+paste any error output, traceback, or `mnemon doctor` results here
+```
+
+**Does it reproduce on a fresh `pip install`?**
+<!-- These get prioritized. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea or enhancement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**The problem**
+What are you trying to do that mnemon doesn't support today?
+
+**Proposed solution**
+What you'd like to see.
+
+**Alternatives considered**
+Other approaches you've thought about.
+
+**Scope note**
+mnemon's interface is intentionally narrow (17 MCP tools) and adding to it has compounding cost — please open this issue to align on shape before writing code. See `CONTRIBUTING.md`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## What & why
+
+<!-- What does this change and why? Link any related issue. -->
+
+## Checklist
+
+- [ ] Tests added/updated for the behavior change
+- [ ] `pytest` passes locally and coverage stays ≥ 80%
+- [ ] `ruff check src/ tests/` is clean for files I touched
+- [ ] `CHANGELOG.md` updated (under `[Unreleased]`)
+- [ ] Schema changes (if any) are **additive** — new nullable columns + migration, never rename/drop
+- [ ] No secrets, vault data, or `private/` content committed
+- [ ] Fail-loud preserved — no new silent `except: pass` swallows
+
+## Test plan
+
+<!-- How you verified this works. -->

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,108 @@
+# mnemon — Architecture
+
+A map of the codebase for readers and contributors. mnemon is **two products in one codebase**: a simple **local** memory vault (zero accounts, single SQLite file, stdio MCP) and an optional **hosted web** layer (Fly-deployed remote MCP with OAuth, multi-device). The most important thing to understand:
+
+> **You can read and understand the entire local memory engine without ever touching the hosted-web code.** The core is `store → embedder → vecstore → search → server`. Everything OAuth / session / dashboard / migration is an *optional layer* on top.
+
+If you're here to understand how memory works, read the **Core** table. If you're deploying or hacking on the hosted server, read **Hosted layer**.
+
+---
+
+## The two modes
+
+| | Local (default) | Hosted web (optional) |
+|---|---|---|
+| Storage | Single SQLite file `~/.mnemon/default.sqlite` + `default.vec.npz` | Same engine, on Fly + S3 vault backup |
+| Transport | stdio MCP (`mnemon serve`) | Streamable HTTP MCP (`mnemon serve-remote`) |
+| Accounts | None | OAuth (self-hosted AS) |
+| Install | `pip install mnemon-memory` | `pip install "mnemon-memory[server]"` + deploy |
+| Invariant | — | **Single source of truth at all times** — never both local and remote active; no sync daemon. In remote mode the local vault is *inaccessible* (fails loud). |
+
+---
+
+## Core (local engine — always present, read this first)
+
+The memory engine. A local-only user exercises exactly this set.
+
+| Module | Purpose |
+|---|---|
+| `store.py` | SQLite + FTS5 storage — `documents` / `content` / `relations`, supersession chain (`invalidated_by`), the standing **`tier`** column, capture-attention **`recurrence_count`**. The heart of the system. |
+| `vecstore.py` | In-process vector store — brute-force cosine over numpy arrays (`default.vec.npz`). |
+| `embedder.py` | FastEmbed `bge-small-en-v1.5` wrapper (384-d ONNX, ~13 MB, lazy singleton). |
+| `search.py` | Retrieval — BM25 ⊕ vector via RRF fusion → composite score (relevance / recency / confidence) → MMR diversity. Optional LLM query expansion. |
+| `config.py` | Content types, decay half-lives, scoring constants — the tunables. |
+| `safety.py` | Stored-injection defense — `defang_control_markup` (recall boundary) + `contains_control_markup` (capture-boundary reject). See `SECURITY.md` / the 5-layer model. |
+| `contradiction.py` + `nli.py` | Contradiction detection via NLI (`cross-encoder/nli-deberta-v3-xsmall`) + confidence decay. |
+| `llm.py` | **Optional** (`[llm]` extra) — QMD-1.7B GGUF via llama-cpp-python, used by `search.py` for query expansion. Not required. |
+| `server.py` | The MCP server (stdio) — registers the **17 tools**. Imports only `store`, `search`, `safety`. This is the local entry point. |
+| `api.py` | In-process tool surface (same shapes as `server.py`) so local hooks / `doctor` / setup work without any HTTP endpoint. |
+| `server_proxy.py` | When a remote vault is configured, `mnemon serve` forwards stdio → remote (fail-loud, never opens local). |
+| `cli.py` | CLI dispatcher (`serve`, `status`, `search`, `save`, `setup`, `sync`, `standing`, …). |
+| `setup.py` | Auto-configure MCP clients (Claude Code / Desktop / Cursor / Gemini) + hooks. |
+| `doctor.py` | Health checks (`mnemon doctor`). |
+| `mirror.py` | Mirror local memory files (upsert by slug) for the `auto_mirror` hook. |
+| `sync.py` | S3 vault backup (push/pull). |
+
+### Hooks (`hooks/` — Claude Code integration, all best-effort, never block the session, exit 0)
+| Hook | Trigger | Purpose |
+|---|---|---|
+| `context_surfacing.py` | UserPromptSubmit | `memory_search` → inject the `<mnemon-context>` spotlight envelope |
+| `session_extractor.py` | Stop | LLM-or-regex observation extraction → `memory_save` (Layer-0 control-markup reject) |
+| `handoff_generator.py` | Stop | Session-summary memory |
+| `auto_mirror.py` | PostToolUse | Mirror local memory files (`mirror.py`) |
+| `framework.py` | (shared) | stdin/stdout, SHA-256 dedup, noise filtering |
+| `_client.py` / `_remote_client.py` | (shared) | Local (via `api.py`) vs remote tool-call clients |
+
+---
+
+## Hosted layer (optional — only for the web product; `[server]` extra)
+
+A **local-only user never imports any of these.** They exist for the Fly-deployed multi-device product. (Verified: `server.py` does not import any module in this table.)
+
+| Module | Purpose |
+|---|---|
+| `server_remote.py` | Remote HTTP MCP (Streamable HTTP) — reuses `server.mcp`; persistent sessions + warm-keeper. |
+| `oauth_as.py` | Self-hosted OAuth Authorization Server (DCR, refresh-token rotation grace). |
+| `auth.py` | OAuth config + middleware for the remote server. |
+| `persistent_sessions.py` | Session store + warm-keeper for the remote transport (single uvicorn worker). |
+| `dashboard/` | Streamlit vault dashboard (`[ui]` extra). |
+
+### Migration tooling (advanced, not core-path)
+| Module | Purpose |
+|---|---|
+| `upgrade.py` | `mnemon upgrade web` — local → hosted migration + Fly deploy. |
+| `downgrade.py` | `mnemon downgrade local` — hosted → local. |
+| `uninstall.py` | `mnemon uninstall`. |
+
+---
+
+## How to extend
+
+Common extension points and where to start:
+
+- **Add an MCP tool** → `server.py` (register with `@mcp.tool()`) + mirror the shape in `api.py` so local hooks can call it. Add a test.
+- **Add a content type / change a half-life or scoring weight** → `config.py`.
+- **Change retrieval behavior** (fusion, recency decay, MMR) → `search.py`.
+- **Swap the embedding model** → `embedder.py` (then `mnemon rebuild` to re-embed).
+- **Add a storage backend** → `store.py` is SQLite-specific; the `Store` interface is the seam.
+- **Add an MCP client to auto-setup** → `setup.py`.
+
+Hard rules for contributions: the full `pytest` suite must stay green (coverage gate ≥ 80%); storage stays **lossless** (only the model-facing copy is defanged); schema changes are **additive** (new nullable columns + migrations, never rename/drop); the fail-loud posture (raise, don't silently swallow) holds. See `CONTRIBUTING.md`.
+
+---
+
+## Request flow (local)
+
+```
+Claude Code prompt
+  └─ hooks/context_surfacing.py (UserPromptSubmit)
+       └─ api.py / server.py: memory_search
+            └─ search.py  → store.py (BM25/FTS5) ⊕ vecstore.py (cosine)
+                          → RRF fuse → composite score → MMR
+            └─ safety.defang_control_markup (recall boundary)
+       └─ inject <mnemon-context>
+
+Claude Code Stop
+  └─ hooks/session_extractor.py → memory_save
+       └─ safety.contains_control_markup (capture reject)  → store.py
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ src/mnemon/
   llm.py                # QMD-1.7B via llama-cpp-python (optional)
   contradiction.py      # Contradiction detection + confidence decay
   config.py             # Content types, half-lives, scoring constants
-  server.py             # MCP server (stdio) — 13 tools
+  server.py             # MCP server (stdio) — 17 tools
   server_remote.py      # Remote HTTP server (Streamable HTTP)
   sync.py               # S3 vault sync (push/pull via AWS CLI)
   setup.py              # Auto-configure Claude Code, Cursor, Gemini

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at `conduct@nousergon.ai` (or open a private report via GitHub Security Advisories). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,13 +12,13 @@ pip install -e ".[dev]"
 pytest -m "not integration"
 ```
 
-You should see ~635 tests pass in under 15 seconds. The 4 integration tests are excluded from this run because they bind a local socket — run them separately with `pytest -m integration` if you're touching `serve-remote` or auth.
+You should see ~1010 tests pass in a few seconds. The 4 integration tests are excluded from this run because they bind a local socket — run them separately with `pytest -m integration` if you're touching `serve-remote` or auth.
 
 ## What to work on
 
 - **Roadmap / open scope:** see [`README.md`](README.md) for the user-facing pitch and the public roadmap; design discussions happen in [GitHub Issues](https://github.com/cipher813/mnemon/issues).
 - **Good first issues:** anything tagged [`good first issue`](https://github.com/cipher813/mnemon/labels/good%20first%20issue) — usually doc fixes, test coverage, or minor CLI polish.
-- **New features:** open an issue first to align on shape before writing code. mnemon's interface is intentionally narrow (13 MCP tools) and adding to it has compounding cost.
+- **New features:** open an issue first to align on shape before writing code. mnemon's interface is intentionally narrow (17 MCP tools) and adding to it has compounding cost.
 
 ## Style
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ mnemon status
 | `memory_pin` | Pin a memory to boost confidence and prevent archival |
 | `memory_forget` | Soft-delete a memory (marked as invalidated, not physically removed) |
 
+### Standing tier (salience)
+
+| Tool | Description |
+|------|-------------|
+| `memory_promote` | Promote a memory to the standing tier — always-on context, injected regardless of query |
+| `memory_demote` | Demote a standing memory back to situational (relevance-ranked) recall |
+| `memory_list_standing` | List the current standing-tier memories |
+
 ### Lifecycle
 
 | Tool | Description |
@@ -150,12 +158,13 @@ mnemon status
 | `memory_status` | Vault health stats — counts by type, vectors, pinned/invalidated |
 | `memory_sweep` | Archive stale memories past their half-life (dry-run by default) |
 | `memory_rebuild` | Re-embed all documents (use after upgrading embedding model) |
+| `memory_export_vectors` | Export stored embeddings (e.g. for analysis or visualization) |
 
 ### Intelligence
 
 | Tool | Description |
 |------|-------------|
-| `memory_check_contradictions` | Check a memory for conflicts using vector similarity + LLM classification |
+| `memory_check_contradictions` | Check a memory for conflicts using vector similarity + NLI classification (`cross-encoder/nli-deberta-v3-xsmall`) |
 | `profile_get` | Synthesized user profile from stored preferences and decisions |
 | `profile_update` | Manually add a fact to the user profile |
 


### PR DESCRIPTION
Open-source-release-readiness docs pass (bundled per solo-repo convention; 3 commits, all low-risk/docs-only).

## 1. Correct public-facing doc drift
- README MCP Tools table **13 → 17** (adds standing-tier tools + `memory_export_vectors`); contradiction relabeled **LLM → NLI** (`cross-encoder/nli-deberta-v3-xsmall`).
- CLAUDE.md `server.py` "13 tools" → "17 tools".

## 2. ARCHITECTURE.md (new)
Core-vs-hosted map so outside readers can navigate the ~14.3K-LOC codebase: the local engine (`store → embedder → vecstore → search → server`) is understandable without the hosted-web layer (`oauth_as`/`server_remote`/`persistent_sessions`/`auth`/`dashboard`) — **verified** via import graph. Module tables, hook map, "how to extend" seams, request flow.

## 3. Community infrastructure (new)
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1 (canonical text).
- `.github/ISSUE_TEMPLATE/` (bug + feature) + `PULL_REQUEST_TEMPLATE.md`.
- `CONTRIBUTING.md` — fixed stale counts (~635 → ~1010 non-integration tests; 13 → 17 tools).

## Test plan
Docs-only — CI (pytest matrix / coverage / gitleaks) unchanged; gitleaks clean on all pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)