### PR TITLE
test: comprehensive tool/capability coverage + raise gate to 88%

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-compatible-blueviolet.svg)](https://modelcontextprotocol.io)
 [![PyPI](https://img.shields.io/pypi/v/mnemon-memory.svg)](https://pypi.org/project/mnemon-memory/)
-[![Coverage](https://img.shields.io/badge/coverage-86%25-brightgreen.svg)]()
+[![Coverage](https://img.shields.io/badge/coverage-90%25-brightgreen.svg)]()
 
 > One memory vault. Every MCP client. Self-hosted.
 >

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,12 +92,12 @@ omit = [
     "src/mnemon/dashboard/*",
     # __main__ entry-point shim — 4 lines, no logic
     "src/mnemon/__main__.py",
-    # Release-engineering operations on Fly + AWS — exercised by the
-    # Layer-3 web test ritual (scripts/promote_stable.sh), not unit
-    # tests. Mocking the full upgrade/downgrade path adds maintenance
-    # cost without surfacing real bugs (those surface in Layer-3).
-    "src/mnemon/upgrade.py",
-    "src/mnemon/downgrade.py",
+    # NOTE: upgrade.py / downgrade.py are now MEASURED (un-omitted
+    # 2026-06-07). Their Fly + AWS subprocess calls are mocked in
+    # test_upgrade.py / test_downgrade.py so the local↔web migration
+    # paths carry CI coverage rather than relying solely on the
+    # operator Layer-3 web ritual — this minimizes the manual-test
+    # surface for long-term maintenance.
     # Deprecated / optional LLM path — kept for local-mode operators
     # who explicitly install [llm] extras. The deployed product is
     # LLM-free by design (2026-05-22 decision); NLI replaced the only
@@ -107,7 +107,12 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 80
+# Raised 80 → 88 on 2026-06-07 after the comprehensive-tool-coverage pass
+# (downgrade 61→98, context_surfacing 74→99, server_remote 63→95,
+# upgrade 86→93, + upgrade/downgrade un-omitted). The gate locks in that
+# coverage so it can't silently regress — keeps the manual-test surface
+# small for long-term maintenance.
+fail_under = 88
 show_missing = true
 skip_empty = true
 exclude_lines = [

--- a/tests/test_downgrade.py
+++ b/tests/test_downgrade.py
@@ -16,7 +16,11 @@ import pytest
 from mnemon import downgrade as dg
 from mnemon.downgrade import (
     DowngradeError,
+    _client_config_root,
+    _confirm,
     _extract_app_name,
+    _reconfigure_clients_local,
+    _resolve_remote_url,
     downgrade_local,
 )
 
@@ -396,3 +400,177 @@ class TestFlyDumpVaultBeforePull:
         assert call_args[6] == "mnemon sync push", (
             f"expected `mnemon sync push`, got: {call_args[6]!r}"
         )
+
+
+# ── _resolve_remote_url ──────────────────────────────────────────────────────
+
+
+class TestResolveRemoteUrl:
+    def test_env_var_takes_precedence(self, monkeypatch):
+        monkeypatch.setenv("MNEMON_REMOTE_URL", "https://env-app.fly.dev/mcp")
+        assert _resolve_remote_url() == "https://env-app.fly.dev/mcp"
+
+    def test_falls_back_to_remote_url_file(self, tmp_path):
+        mnemon_dir = tmp_path / ".mnemon"
+        mnemon_dir.mkdir()
+        (mnemon_dir / "remote_url").write_text("https://file-app.fly.dev/mcp\n")
+        assert _resolve_remote_url() == "https://file-app.fly.dev/mcp"
+
+    def test_oserror_reading_file_falls_through_to_raise(self, monkeypatch):
+        # exists() True but read_text() raises OSError → the except OSError
+        # branch swallows it and we fall through to the "no remote" raise.
+        fake_file = MagicMock()
+        fake_file.exists.return_value = True
+        fake_file.read_text.side_effect = OSError("permission denied")
+        monkeypatch.setattr("mnemon.downgrade.REMOTE_URL_FILE", fake_file)
+        with pytest.raises(DowngradeError, match="nothing to downgrade"):
+            _resolve_remote_url()
+
+
+# ── _client_config_root ──────────────────────────────────────────────────────
+
+
+class TestClientConfigRoot:
+    def test_default_is_home(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MNEMON_CLIENT_CONFIG_ROOT", raising=False)
+        # _isolate_env patches Path.home → tmp_path
+        assert _client_config_root() == tmp_path
+
+    def test_override_env_wins(self, monkeypatch, tmp_path):
+        override = tmp_path / "custom-root"
+        monkeypatch.setenv("MNEMON_CLIENT_CONFIG_ROOT", str(override))
+        assert _client_config_root() == override
+
+
+# ── _reconfigure_clients_local ───────────────────────────────────────────────
+
+
+class TestReconfigureClientsLocalDirect:
+    """Exercise the real _reconfigure_clients_local (the downgrade_local
+    tests patch it out). Verifies it calls each detected client's setup
+    function in local (stdio) mode, skips the 'hooks' pseudo-target, and
+    restores setup.Path.home afterward."""
+
+    def test_iterates_targets_in_local_mode_and_restores_home(
+        self, monkeypatch, tmp_path
+    ):
+        from mnemon import setup as setup_mod
+
+        prior_home = setup_mod.Path.home
+        cc = MagicMock()
+        cursor = MagicMock()
+        fake_targets = {"claude-code": cc, "cursor": cursor}
+        monkeypatch.setattr(setup_mod, "TARGETS", fake_targets)
+        monkeypatch.setenv("MNEMON_CLIENT_CONFIG_ROOT", str(tmp_path / "root"))
+
+        # 'hooks' must be skipped even if it sneaks into the detected list.
+        result = _reconfigure_clients_local(["claude-code", "hooks", "cursor"])
+
+        assert result == ["claude-code", "cursor"]
+        cc.assert_called_once_with(remote_url=None, token=None)
+        cursor.assert_called_once_with(remote_url=None, token=None)
+        # Path.home restored to whatever it was on entry.
+        assert setup_mod.Path.home is prior_home
+
+    def test_restores_home_even_when_setup_raises(self, monkeypatch, tmp_path):
+        from mnemon import setup as setup_mod
+
+        prior_home = setup_mod.Path.home
+        boom = MagicMock(side_effect=RuntimeError("setup blew up"))
+        monkeypatch.setattr(setup_mod, "TARGETS", {"claude-code": boom})
+        monkeypatch.setenv("MNEMON_CLIENT_CONFIG_ROOT", str(tmp_path / "root"))
+
+        with pytest.raises(RuntimeError, match="setup blew up"):
+            _reconfigure_clients_local(["claude-code"])
+        # finally: block must restore Path.home despite the exception.
+        assert setup_mod.Path.home is prior_home
+
+
+# ── _confirm ─────────────────────────────────────────────────────────────────
+
+
+class TestConfirm:
+    def test_non_tty_returns_false(self, monkeypatch):
+        fake_stdin = MagicMock()
+        fake_stdin.isatty.return_value = False
+        monkeypatch.setattr("mnemon.downgrade.sys.stdin", fake_stdin)
+        assert _confirm("destroy? ") is False
+
+    def test_tty_yes_returns_true(self, monkeypatch):
+        fake_stdin = MagicMock()
+        fake_stdin.isatty.return_value = True
+        monkeypatch.setattr("mnemon.downgrade.sys.stdin", fake_stdin)
+        monkeypatch.setattr("builtins.input", lambda _prompt: "  YES  ")
+        assert _confirm("destroy? ") is True
+
+    def test_tty_no_returns_false(self, monkeypatch):
+        fake_stdin = MagicMock()
+        fake_stdin.isatty.return_value = True
+        monkeypatch.setattr("mnemon.downgrade.sys.stdin", fake_stdin)
+        monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+        assert _confirm("destroy? ") is False
+
+    def test_tty_eoferror_returns_false(self, monkeypatch):
+        fake_stdin = MagicMock()
+        fake_stdin.isatty.return_value = True
+        monkeypatch.setattr("mnemon.downgrade.sys.stdin", fake_stdin)
+
+        def _raise(_prompt):
+            raise EOFError
+
+        monkeypatch.setattr("builtins.input", _raise)
+        assert _confirm("destroy? ") is False
+
+
+# ── doctor step (skip_doctor=False) ──────────────────────────────────────────
+
+
+class TestDoctorStep:
+    """The existing downgrade_local tests all pass skip_doctor=True. These
+    exercise the Step-5 doctor block (run_doctor against the restored local
+    vault) including the clean, issues-found, and crash paths."""
+
+    def _seed_remote_config(self, tmp_path, url="https://mnemon-test.fly.dev/mcp"):
+        mnemon_dir = tmp_path / ".mnemon"
+        mnemon_dir.mkdir()
+        (mnemon_dir / "remote_url").write_text(url)
+
+    def _happy_path_patches(self):
+        return (
+            patch("mnemon.downgrade._fly_dump_vault"),
+            patch(
+                "mnemon.sync.pull",
+                return_value={"pulled": ["sqlite"], "errors": []},
+            ),
+            patch("mnemon.setup.detect_installed_clients", return_value=[]),
+            patch("mnemon.downgrade._reconfigure_clients_local", return_value=[]),
+        )
+
+    def test_doctor_clean_no_note(self, tmp_path):
+        self._seed_remote_config(tmp_path)
+        p1, p2, p3, p4 = self._happy_path_patches()
+        with p1, p2, p3, p4, patch(
+            "mnemon.doctor.run_doctor", return_value=0
+        ) as mock_doc:
+            result = downgrade_local(skip_doctor=False)
+        mock_doc.assert_called_once()
+        assert "Running mnemon doctor against the restored local vault" in result
+        assert "doctor reported issues" not in result
+
+    def test_doctor_issues_appends_note(self, tmp_path):
+        self._seed_remote_config(tmp_path)
+        p1, p2, p3, p4 = self._happy_path_patches()
+        with p1, p2, p3, p4, patch("mnemon.doctor.run_doctor", return_value=1):
+            result = downgrade_local(skip_doctor=False)
+        assert "doctor reported issues against the local vault" in result
+
+    def test_doctor_crash_is_caught(self, tmp_path):
+        self._seed_remote_config(tmp_path)
+        p1, p2, p3, p4 = self._happy_path_patches()
+        with p1, p2, p3, p4, patch(
+            "mnemon.doctor.run_doctor", side_effect=RuntimeError("doctor boom")
+        ):
+            result = downgrade_local(skip_doctor=False)
+        # Crash is captured into the summary, not propagated.
+        assert "doctor invocation crashed" in result
+        assert "RuntimeError" in result

--- a/tests/test_hooks_extended.py
+++ b/tests/test_hooks_extended.py
@@ -886,6 +886,152 @@ class TestContextSurfacingMain:
         assert "Fast" in injected
 
 
+# ── context_surfacing.py: standing-tier helpers (Phase 0/1) ──────────────────
+
+
+class TestStandingTierHelpers:
+    """The Phase-0 standing-tier helper functions (env-var driven ID list,
+    rendered-cache read, per-id HTTP fallback) and the Phase-1 MCP
+    import-guard. build_context exercises the success paths via
+    test_standing_tier.py; these cover the helpers directly incl. the
+    failure branches."""
+
+    def test_standing_tier_enabled_env_override_true(self, monkeypatch):
+        from mnemon.hooks import context_surfacing as cs
+
+        monkeypatch.setenv("MNEMON_STANDING_TIER_ENABLED", "true")
+        assert cs._standing_tier_enabled() is True
+
+    def test_standing_tier_enabled_env_override_false(self, monkeypatch):
+        from mnemon.hooks import context_surfacing as cs
+
+        monkeypatch.setenv("MNEMON_STANDING_TIER_ENABLED", "off")
+        assert cs._standing_tier_enabled() is False
+
+    def test_fetch_standing_via_mcp_import_error_returns_empty(self, monkeypatch):
+        from mnemon.hooks import context_surfacing as cs
+
+        # Make `from ._remote_client import call_tool_sync` raise ImportError.
+        monkeypatch.setitem(sys.modules, "mnemon.hooks._remote_client", None)
+        assert cs._fetch_standing_via_mcp() == ""
+
+    def test_load_standing_ids_reads_file(self, monkeypatch, tmp_path):
+        from mnemon.hooks import context_surfacing as cs
+
+        f = tmp_path / "standing.json"
+        f.write_text(json.dumps({"ids": [1, 2, 3]}))
+        monkeypatch.setenv("MNEMON_STANDING_TIER_FILE", str(f))
+        assert cs._load_standing_ids() == [1, 2, 3]
+
+    def test_load_standing_ids_malformed_returns_empty(self, monkeypatch, tmp_path, capsys):
+        from mnemon.hooks import context_surfacing as cs
+
+        f = tmp_path / "standing.json"
+        f.write_text("{ not valid json")
+        monkeypatch.setenv("MNEMON_STANDING_TIER_FILE", str(f))
+        assert cs._load_standing_ids() == []
+        assert "failed to load standing-tier IDs" in capsys.readouterr().err
+
+    def test_read_rendered_cache_returns_sibling_md(self, monkeypatch, tmp_path):
+        from mnemon.hooks import context_surfacing as cs
+
+        sj = tmp_path / "standing.json"
+        sj.write_text("{}")
+        (tmp_path / "standing-rendered.md").write_text("  rendered standing block  ")
+        monkeypatch.setenv("MNEMON_STANDING_TIER_FILE", str(sj))
+        assert cs._read_rendered_cache() == "rendered standing block"
+
+    def test_read_rendered_cache_missing_returns_empty(self, monkeypatch, tmp_path):
+        from mnemon.hooks import context_surfacing as cs
+
+        sj = tmp_path / "standing.json"  # no sibling .md created
+        monkeypatch.setenv("MNEMON_STANDING_TIER_FILE", str(sj))
+        assert cs._read_rendered_cache() == ""
+
+    def test_read_rendered_cache_oserror_returns_empty(self, monkeypatch, tmp_path):
+        from mnemon.hooks import context_surfacing as cs
+
+        sj = tmp_path / "standing.json"
+        (tmp_path / "standing-rendered.md").write_text("x")
+        monkeypatch.setenv("MNEMON_STANDING_TIER_FILE", str(sj))
+
+        def _boom(*_a, **_k):
+            raise OSError("read denied")
+
+        monkeypatch.setattr("builtins.open", _boom)
+        assert cs._read_rendered_cache() == ""
+
+    def test_fetch_standing_block_empty_ids(self):
+        from mnemon.hooks import context_surfacing as cs
+
+        assert cs._fetch_standing_block([]) == ""
+
+    def test_fetch_standing_block_renders_docs(self, monkeypatch):
+        from mnemon.hooks import context_surfacing as cs
+
+        doc = json.dumps({"title": "Standing T", "content": "C body", "content_type": "preference"})
+        monkeypatch.setattr(
+            "mnemon.hooks._remote_client.call_tool_sync",
+            lambda _name, _args, timeout=5.0: (doc, 0.01),
+        )
+        out = cs._fetch_standing_block([1])
+        assert "**Standing T**" in out and "C body" in out and "id=1" in out
+
+    def test_fetch_standing_block_skips_failed_ids(self, monkeypatch):
+        from mnemon.hooks import context_surfacing as cs
+
+        def _call(_name, args, timeout=5.0):
+            if args["id"] == 1:
+                raise RuntimeError("fetch boom")
+            return (json.dumps({"title": "OK", "content": "good", "content_type": "note"}), 0.01)
+
+        monkeypatch.setattr("mnemon.hooks._remote_client.call_tool_sync", _call)
+        out = cs._fetch_standing_block([1, 2])
+        assert "boom" not in out
+        assert "**OK**" in out
+
+    def test_fetch_standing_block_import_error_returns_empty(self, monkeypatch):
+        from mnemon.hooks import context_surfacing as cs
+
+        monkeypatch.setitem(sys.modules, "mnemon.hooks._remote_client", None)
+        assert cs._fetch_standing_block([1]) == ""
+
+
+class TestContextSurfacingMainErrorTail:
+    """The outer try/except in main() — the last line of defense so a hook
+    crash never propagates into Claude Code."""
+
+    def test_outer_exception_is_logged_not_raised(self, monkeypatch):
+        from mnemon.hooks.context_surfacing import main
+
+        monkeypatch.setattr(
+            "mnemon.hooks.framework.read_stdin",
+            MagicMock(side_effect=RuntimeError("stdin boom")),
+        )
+        hit = {}
+        monkeypatch.setattr(
+            "mnemon.hooks.framework.log_hook_error",
+            lambda *_a, **_k: hit.setdefault("logged", True),
+        )
+        main()  # must not raise
+        assert hit.get("logged")
+
+    def test_outer_exception_falls_back_to_stderr(self, monkeypatch, capsys):
+        from mnemon.hooks.context_surfacing import main
+
+        monkeypatch.setattr(
+            "mnemon.hooks.framework.read_stdin",
+            MagicMock(side_effect=RuntimeError("stdin boom")),
+        )
+        # The tail's own log_hook_error also fails → inner except → stderr.
+        monkeypatch.setattr(
+            "mnemon.hooks.framework.log_hook_error",
+            MagicMock(side_effect=RuntimeError("logger boom")),
+        )
+        main()  # must not raise
+        assert "context-surfacing error" in capsys.readouterr().err
+
+
 # ── session_extractor.py: extract_with_llm ───────────────────────────────────
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,9 +8,11 @@ import pytest
 import mnemon.server as server_mod
 from mnemon.server import (
     memory_check_contradictions,
+    memory_demote,
     memory_export_vectors,
     memory_forget,
     memory_get,
+    memory_list_standing,
     memory_pin,
     memory_promote,
     memory_rebuild,
@@ -444,6 +446,78 @@ class TestMemoryPromoteCoherenceCheck:
             result = memory_promote(1)
         assert "Promoted memory #1" in result
         assert "⚠" not in result
+
+
+# ── memory_demote ────────────────────────────────────────────────────────────
+
+
+class TestMemoryDemote:
+    """Server-surface tests for memory_demote (symmetry with
+    TestMemoryPromoteCoherenceCheck; the tool was unit-covered in
+    test_standing_tier.py + the all-tools integration test, but lacked a
+    direct server-surface test that locks its return-shape contract)."""
+
+    @patch("mnemon.server.Store")
+    def test_demote_success_reports_remaining_count(self, MockStore):
+        store = MockStore.return_value
+        store.demote_to_situational.return_value = True
+        store.standing_tier_status.return_value = {"count": 2, "cap": 15}
+        result = memory_demote(5)
+        assert "Demoted memory #5 to situational" in result
+        assert "2/15 remain standing" in result
+
+    @patch("mnemon.server.Store")
+    def test_demote_noop_when_not_on_tier(self, MockStore):
+        store = MockStore.return_value
+        store.demote_to_situational.return_value = False
+        store.standing_tier_status.return_value = {"count": 0, "cap": 15}
+        result = memory_demote(99)
+        assert result == "Memory #99 was not on the standing tier."
+
+    @patch("mnemon.server.Store")
+    def test_demote_standing_tier_error_returns_clean_message(self, MockStore):
+        from mnemon.store import StandingTierError
+        store = MockStore.return_value
+        store.demote_to_situational.side_effect = StandingTierError("boom")
+        result = memory_demote(5)
+        assert result == "Error: boom"
+
+
+# ── memory_list_standing ─────────────────────────────────────────────────────
+
+
+class TestMemoryListStanding:
+    """Server-surface tests for memory_list_standing — locks the JSON
+    array shape consumed by hooks/context_surfacing.py."""
+
+    @patch("mnemon.server.Store")
+    def test_returns_json_array_of_standing_docs(self, MockStore):
+        store = MockStore.return_value
+        store.list_standing.return_value = [
+            _make_document(
+                id=1, title="Runway", content="multi-year",
+                content_type="preference", confidence=0.9,
+                created_at="2026-05-01",
+            ),
+            _make_document(
+                id=2, title="Severance", content="lump sum",
+                content_type="preference", confidence=0.8,
+                created_at="2026-05-02",
+            ),
+        ]
+        parsed = json.loads(memory_list_standing())
+        assert [d["doc_id"] for d in parsed] == [1, 2]
+        assert parsed[0]["title"] == "Runway"
+        assert parsed[0]["content_type"] == "preference"
+        assert set(parsed[0].keys()) == {
+            "doc_id", "title", "content", "content_type",
+            "confidence", "created_at",
+        }
+
+    @patch("mnemon.server.Store")
+    def test_empty_when_nothing_promoted(self, MockStore):
+        MockStore.return_value.list_standing.return_value = []
+        assert json.loads(memory_list_standing()) == []
 
 
 # ── memory_status ────────────────────────────────────────────────────────────

--- a/tests/test_server_remote.py
+++ b/tests/test_server_remote.py
@@ -1,7 +1,8 @@
 """Tests for remote HTTP server configuration."""
 
 import os
-from unittest.mock import patch
+import sys
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -95,6 +96,122 @@ class TestSessionManagerConfig:
             f"PersistentSessionManager must be wired with json_response=True; "
             f"got {captured.get('json_response')!r}. See class docstring for why."
         )
+
+
+class TestRunRemoteBranches:
+    """Drive run_remote()'s startup branches with the heavy deps mocked.
+
+    run_remote() is an orchestrator that ends in a blocking uvicorn.run();
+    its real behavior is exercised end-to-end by test_integration_remote.py
+    (a subprocess), but coverage.py can't see subprocess lines. These unit
+    tests mock the model pre-loads + uvicorn so each branch is covered
+    deterministically and fast."""
+
+    def _base_env(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MNEMON_LOCAL_TOKEN", "x" * 32)
+        monkeypatch.setenv("MNEMON_VAULT_DIR", str(tmp_path))
+        monkeypatch.setenv("MNEMON_PUBLIC_URL", "http://127.0.0.1:8502")
+        monkeypatch.setenv("MNEMON_ALLOWED_HOSTS", "127.0.0.1,127.0.0.1:8502")
+        monkeypatch.delenv("MNEMON_AS_ENABLED", raising=False)
+
+    def _stub_models(self, monkeypatch):
+        monkeypatch.setattr("mnemon.embedder._get_model", lambda: object())
+        monkeypatch.setattr("mnemon.nli.prewarm", lambda: None)
+
+    def test_happy_path_calls_uvicorn_run(self, monkeypatch, tmp_path, capsys):
+        self._base_env(monkeypatch, tmp_path)
+        self._stub_models(monkeypatch)
+        fake_run = MagicMock()
+        monkeypatch.setattr("uvicorn.run", fake_run)
+
+        from mnemon.server_remote import run_remote
+        run_remote()
+
+        fake_run.assert_called_once()
+        # host/port forwarded; wrapped ASGI app passed positionally
+        assert fake_run.call_args.kwargs.get("port") == int(os.environ.get("PORT", "8502"))
+        assert "local static bearer token enabled" in capsys.readouterr().err
+
+    def test_embedder_preload_failure_warns_but_continues(self, monkeypatch, tmp_path, capsys):
+        self._base_env(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            "mnemon.embedder._get_model",
+            MagicMock(side_effect=RuntimeError("model boom")),
+        )
+        monkeypatch.setattr("mnemon.nli.prewarm", lambda: None)
+        monkeypatch.setattr("uvicorn.run", MagicMock())
+
+        from mnemon.server_remote import run_remote
+        run_remote()  # WARN, not fatal
+
+        assert "failed to pre-load embedding model" in capsys.readouterr().err
+
+    def test_nli_preload_failure_warns_but_continues(self, monkeypatch, tmp_path, capsys):
+        self._base_env(monkeypatch, tmp_path)
+        monkeypatch.setattr("mnemon.embedder._get_model", lambda: object())
+        monkeypatch.setattr(
+            "mnemon.nli.prewarm",
+            MagicMock(side_effect=RuntimeError("nli boom")),
+        )
+        monkeypatch.setattr("uvicorn.run", MagicMock())
+
+        from mnemon.server_remote import run_remote
+        run_remote()
+
+        assert "failed to pre-load NLI classifier" in capsys.readouterr().err
+
+    def test_as_misconfigured_exits(self, monkeypatch, tmp_path):
+        self._base_env(monkeypatch, tmp_path)
+        self._stub_models(monkeypatch)
+        # AS enabled but invalid → validate() returns problems → exit(1).
+        fake_as = MagicMock()
+        fake_as.enabled = True
+        fake_as.validate.return_value = ["MNEMON_AS_PASSPHRASE not set"]
+        monkeypatch.setattr(
+            "mnemon.oauth_as.AuthorizationServerConfig.from_env",
+            lambda: fake_as,
+        )
+
+        from mnemon.server_remote import run_remote
+        with pytest.raises(SystemExit):
+            run_remote()
+
+    def test_uvicorn_missing_exits(self, monkeypatch, tmp_path):
+        self._base_env(monkeypatch, tmp_path)
+        self._stub_models(monkeypatch)
+        # Make `import uvicorn` raise ImportError inside run_remote.
+        monkeypatch.setitem(sys.modules, "uvicorn", None)
+
+        from mnemon.server_remote import run_remote
+        with pytest.raises(SystemExit):
+            run_remote()
+
+    def test_decay_sweep_closure_runs_decay_and_closes_store(self, monkeypatch, tmp_path):
+        self._base_env(monkeypatch, tmp_path)
+        self._stub_models(monkeypatch)
+
+        captured: dict = {}
+
+        def fake_manager(*_args, **kwargs):
+            captured.update(kwargs)
+            raise SystemExit("abort before uvicorn")
+
+        monkeypatch.setattr(
+            "mnemon.persistent_sessions.PersistentSessionManager", fake_manager
+        )
+
+        from mnemon.server_remote import run_remote
+        with pytest.raises(SystemExit):
+            run_remote()
+
+        decay_fn = captured["decay_fn"]
+        fake_store = MagicMock()
+        monkeypatch.setattr("mnemon.store.Store", lambda: fake_store)
+        monkeypatch.setattr(
+            "mnemon.contradiction.apply_confidence_decay", lambda _s: 7
+        )
+        assert decay_fn() == 7
+        fake_store.close.assert_called_once()
 
 
 class TestMcpServer:

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -21,7 +21,9 @@ from mnemon import upgrade
 from mnemon.upgrade import (
     UpgradeError,
     _archive_local_vault,
+    _client_config_root,
     _fly_app_exists,
+    _reconfigure_clients,
     _validate_app_name,
     upgrade_web,
 )
@@ -55,6 +57,58 @@ def _isolate_env(monkeypatch, tmp_path):
     # The settle test class re-enables it explicitly.
     monkeypatch.setenv("MNEMON_UPGRADE_SETTLE_SECONDS", "0")
     yield
+
+
+# ── _client_config_root / _reconfigure_clients ───────────────────────────────
+
+
+class TestClientConfigRoot:
+    def test_default_is_home(self, tmp_path):
+        # _isolate_env patches Path.home → tmp_path and clears the override.
+        assert _client_config_root() == tmp_path
+
+    def test_override_env_wins(self, monkeypatch, tmp_path):
+        override = tmp_path / "scratch-root"
+        monkeypatch.setenv("MNEMON_CLIENT_CONFIG_ROOT", str(override))
+        assert _client_config_root() == override
+
+
+class TestReconfigureClients:
+    """Exercise the real _reconfigure_clients (the upgrade_web flow tests
+    patch it out). Mirror of downgrade._reconfigure_clients_local but in
+    remote mode (passes remote_url + token to each setup target)."""
+
+    def test_iterates_targets_in_remote_mode_and_restores_home(
+        self, monkeypatch, tmp_path
+    ):
+        from mnemon import setup as setup_mod
+
+        prior_home = setup_mod.Path.home
+        cc = MagicMock()
+        cursor = MagicMock()
+        monkeypatch.setattr(setup_mod, "TARGETS", {"claude-code": cc, "cursor": cursor})
+        monkeypatch.setenv("MNEMON_CLIENT_CONFIG_ROOT", str(tmp_path / "root"))
+
+        result = _reconfigure_clients(
+            "https://app.fly.dev/mcp", "tok123", ["claude-code", "cursor"]
+        )
+
+        assert result == ["claude-code", "cursor"]
+        cc.assert_called_once_with(remote_url="https://app.fly.dev/mcp", token="tok123")
+        cursor.assert_called_once_with(remote_url="https://app.fly.dev/mcp", token="tok123")
+        assert setup_mod.Path.home is prior_home
+
+    def test_restores_home_even_when_setup_raises(self, monkeypatch, tmp_path):
+        from mnemon import setup as setup_mod
+
+        prior_home = setup_mod.Path.home
+        boom = MagicMock(side_effect=RuntimeError("setup blew up"))
+        monkeypatch.setattr(setup_mod, "TARGETS", {"claude-code": boom})
+        monkeypatch.setenv("MNEMON_CLIENT_CONFIG_ROOT", str(tmp_path / "root"))
+
+        with pytest.raises(RuntimeError, match="setup blew up"):
+            _reconfigure_clients("https://app.fly.dev/mcp", "tok", ["claude-code"])
+        assert setup_mod.Path.home is prior_home
 
 
 # ── _validate_app_name ───────────────────────────────────────────────────────


### PR DESCRIPTION
PR 1 of the mnemon OSS-readiness arc — make the test surface comprehensive so the manual-test burden before release is minimal. **No source changes; tests + coverage config only.**

## What this closes
The 17 MCP tools were already strongly covered (unit + a self-enforcing all-tools integration meta-test). The gaps were in the *capabilities around* the tools — the local↔web migration, the recall hook's Phase-0 helpers, and the remote HTTP server's startup branches — plus two tools missing a direct server-surface test.

## Coverage lifts (full suite 1016 → 1059 tests; total 88% → 90%)
| Module | Before | After | What was added |
|---|---|---|---|
| `downgrade.py` | 61% | **98%** | env-var resolution, `_client_config_root`, `_reconfigure_clients_local` (incl. finally-restores-home), `_confirm` (tty/non-tty/EOF), the Step-5 doctor block (clean/issues/crash) |
| `context_surfacing.py` | 74% | **99%** | Phase-0 standing-tier helpers, MCP import-guard, `_standing_tier_enabled` env override, `main()` outer error tail |
| `server_remote.py` | 63% | **95%** | `run_remote()` branches: embedder/NLI pre-load WARNs, AS-misconfig exit, uvicorn-missing exit, happy-path `uvicorn.run`, `_decay_sweep` closure |
| `upgrade.py` | 86% | **93%** | `_client_config_root` + `_reconfigure_clients` (the flow tests patch these out) |
| `server.py` | 89% | **90%** | `TestMemoryDemote` + `TestMemoryListStanding` → all 17 tools now have a direct server-surface test (was 15/17) |

## Config
- **Un-omit `upgrade.py` / `downgrade.py`** from coverage — their Fly+AWS subprocess calls are mocked, so the local↔web migration paths carry CI coverage rather than relying solely on the operator Layer-3 web ritual.
- **Raise `fail_under` 80 → 88** to lock the gain in (can't silently regress).
- README coverage badge 86% → 90%.

## Why
Minimize the maintainer's manual-test surface for long-term maintenance ahead of the OSS release. `server_remote.py`'s real path is exercised by the subprocess integration test, which coverage.py can't see — the new unit tests make those branches visible and deterministic.

## Verification
`1059 passed`, total coverage **89.91%** (≥ 88% gate).

Next in the arc: PR 2 (`mnemon verify` runtime command) and PR 3 (rc→stable + docs/discoverability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)