### PR TITLE
feat(doctor): two-vaults shadow guard in remote mode

### DIFF
--- a/src/mnemon/doctor.py
+++ b/src/mnemon/doctor.py
@@ -384,6 +384,54 @@ def _best_effort_forget(doc_id: int) -> None:
         pass
 
 
+def check_no_shadow_local_vault() -> CheckResult:
+    """Two-vaults guard (remote mode): there must be no *populated* local
+    default vault shadowing the remote.
+
+    A populated ``~/.mnemon/default.sqlite`` while a remote is configured
+    is the trap that twice silently served stale local reads (the rc8
+    ``Store`` guard now makes it structurally inaccessible — this check
+    catches a residual file before it can confuse anyone). An empty stub
+    is harmless and passes; a populated one warns with the archive recipe.
+    """
+    from .config import vault_dir
+
+    vault_file = vault_dir() / "default.sqlite"
+    if not vault_file.exists():
+        return CheckResult(
+            "No shadow local vault",
+            True,
+            "no local default.sqlite — remote is the sole vault",
+        )
+
+    import sqlite3
+
+    try:
+        conn = sqlite3.connect(f"file:{vault_file}?mode=ro", uri=True)
+        try:
+            n = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        # No documents table / unreadable → not a populated vault.
+        n = 0
+
+    if n > 0:
+        return CheckResult(
+            "No shadow local vault",
+            True,
+            f"{vault_file} holds {n} documents while in remote mode — possible "
+            f"two-vaults shadow. Archive it: "
+            f"mv {vault_file}* ~/.mnemon/decommissioned/",
+            warn=True,
+        )
+    return CheckResult(
+        "No shadow local vault",
+        True,
+        f"local default.sqlite present but empty ({vault_file})",
+    )
+
+
 # ── Local-mode checks ──────────────────────────────────────────────────────
 
 
@@ -519,6 +567,7 @@ REMOTE_CHECKS: list[Callable[[], CheckResult]] = [
     check_oauth_as_metadata,
     check_auth_and_tool_call,
     check_round_trip,
+    check_no_shadow_local_vault,
 ]
 
 LOCAL_CHECKS: list[Callable[[], CheckResult]] = [

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -571,3 +571,58 @@ class TestLocalChecks:
             with pytest.raises(SystemExit) as excinfo:
                 main()
         assert excinfo.value.code == 1
+
+
+class TestCheckNoShadowLocalVault:
+    """The two-vaults guard (remote mode): a populated local default.sqlite
+    shadowing the remote is the trap that twice served stale local reads.
+    Empty stub passes; populated warns; absent passes."""
+
+    def _make_vault(self, tmp_path, n_docs):
+        import sqlite3
+
+        vault = tmp_path / "default.sqlite"
+        conn = sqlite3.connect(vault)
+        conn.execute("CREATE TABLE documents (id INTEGER PRIMARY KEY)")
+        for _ in range(n_docs):
+            conn.execute("INSERT INTO documents DEFAULT VALUES")
+        conn.commit()
+        conn.close()
+        return vault
+
+    def test_passes_when_no_local_vault(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MNEMON_VAULT_DIR", str(tmp_path))
+        result = doctor.check_no_shadow_local_vault()
+        assert result.ok and not result.warn
+        assert "no local default.sqlite" in result.detail
+
+    def test_passes_when_empty_stub(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MNEMON_VAULT_DIR", str(tmp_path))
+        self._make_vault(tmp_path, 0)
+        result = doctor.check_no_shadow_local_vault()
+        assert result.ok and not result.warn
+        assert "present but empty" in result.detail
+
+    def test_warns_when_populated(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MNEMON_VAULT_DIR", str(tmp_path))
+        self._make_vault(tmp_path, 3)
+        result = doctor.check_no_shadow_local_vault()
+        assert result.ok and result.warn  # non-fatal note, not a hard fail
+        assert "3 documents" in result.detail
+        assert "two-vaults shadow" in result.detail
+
+    def test_passes_when_no_documents_table(self, monkeypatch, tmp_path):
+        import sqlite3
+
+        monkeypatch.setenv("MNEMON_VAULT_DIR", str(tmp_path))
+        vault = tmp_path / "default.sqlite"
+        conn = sqlite3.connect(vault)
+        conn.execute("CREATE TABLE unrelated (x)")
+        conn.commit()
+        conn.close()
+        result = doctor.check_no_shadow_local_vault()
+        assert result.ok and not result.warn
+        assert "present but empty" in result.detail
+
+    def test_registered_in_remote_checks(self):
+        assert doctor.check_no_shadow_local_vault in doctor.REMOTE_CHECKS


### PR DESCRIPTION
PR 2 of the OSS-readiness arc — the runtime-verification piece.

## Why not a new `verify` command
`mnemon doctor` already *is* the runtime verify suite in remote mode: `check_remote_url`, `check_health_endpoint`, `check_auth_and_tool_call`, and a full `check_round_trip` (save→search→forget against the live remote). The one thing it didn't guard was the **two-vaults trap** — so this adds exactly that rather than a redundant parallel command.

## What this adds
`check_no_shadow_local_vault` in the remote-mode checks. A *populated* local `~/.mnemon/default.sqlite` while a remote is configured is the trap that twice silently served stale local reads (the rc8 `Store` guard made it structurally inaccessible — this surfaces a residual file before it can confuse anyone).

- **Absent** local vault → pass ("remote is the sole vault").
- **Empty stub** (0 docs / no documents table) → pass (harmless — matches the current machine state).
- **Populated** while remote configured → **WARN** with the archive recipe (non-fatal; `doctor --fail-on-warn` escalates it).

## Verification
5 tests; suite 1059 → **1064**, total coverage **89.94%** (≥ 88% gate).

## Note on the cross-client sharing proof
The remaining "do Code and Desktop share?" question is inherently a cross-application check no in-repo test can assert (it depends on Desktop's connector + model behavior). The architecture already guarantees it (both clients connect through the one claude.ai connector → one Fly vault), and it's provable in ~60s with a live sentinel. I can either prove it live now or add a small `mnemon verify-sharing` helper — flagged for your call given the minimize-surface preference (see PR discussion).

Next: PR 3 — rc→stable cut + docs-honesty + discoverability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)