### PR TITLE
feat(cli): mnemon verify-sharing — prove the remote vault is shared across clients

### DIFF
--- a/src/mnemon/cli.py
+++ b/src/mnemon/cli.py
@@ -486,10 +486,106 @@ def main() -> None:
         subcommand = args[1] if len(args) > 1 else "list"
         _handle_standing(subcommand, args[2:])
 
+    elif command == "verify-sharing":
+        # Prove the configured remote vault is shared across MCP clients
+        # (Claude Code ↔ Claude Desktop ↔ claude.ai). Complements `doctor`,
+        # which only verifies CLI↔remote within one process.
+        _verify_sharing(cleanup="--cleanup" in args[1:])
+
     else:
         print(f"Unknown command: {command}", file=sys.stderr)
         _print_usage()
         sys.exit(1)
+
+
+_SHARING_SENTINEL_PREFIX = "mnemon-sharing-check"
+
+
+def _verify_sharing(*, cleanup: bool) -> None:
+    """Prove the configured remote vault is shared across MCP clients.
+
+    Writes a uniquely-named sentinel to the remote and reads it back —
+    proving CLI↔remote round-trips — then prints the exact search term to
+    run in another client (Claude Desktop / claude.ai) to confirm that
+    client is wired to the SAME vault. ``--cleanup`` removes sentinels.
+
+    The Desktop side cannot be auto-checked — no CLI can drive another
+    app's MCP connector — so this makes that one manual step deterministic
+    (fixed sentinel + exact search term + one-flag cleanup) rather than
+    ad-hoc. ``doctor``'s round-trip only covers CLI↔remote in one process.
+    """
+    import json as _json
+    import time
+    import uuid
+
+    from .hooks._remote_client import RemoteClientConfigError, call_tool_sync
+
+    if not _remote_mode_active():
+        print(
+            "verify-sharing is for REMOTE mode (proving multiple clients share "
+            "one cloud vault). No remote is configured — this machine is "
+            "local-only, so there is nothing to share.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if cleanup:
+        try:
+            raw, _ = call_tool_sync(
+                "memory_search",
+                {"query": _SHARING_SENTINEL_PREFIX, "limit": 50},
+                timeout=8.0,
+            )
+            results = _json.loads(raw)
+        except RemoteClientConfigError as exc:
+            print(f"verify-sharing cleanup failed: {exc}", file=sys.stderr)
+            sys.exit(1)
+        ids = [
+            r["doc_id"]
+            for r in results
+            if str(r.get("title", "")).startswith(_SHARING_SENTINEL_PREFIX)
+        ]
+        for doc_id in ids:
+            call_tool_sync("memory_forget", {"id": doc_id}, timeout=8.0)
+        print(f"Removed {len(ids)} sharing-check sentinel(s) from the remote vault.")
+        return
+
+    term = f"{_SHARING_SENTINEL_PREFIX}-{uuid.uuid4().hex[:8]}"
+    content = (
+        f"Sharing-check sentinel written by `mnemon verify-sharing` at "
+        f"{time.strftime('%Y-%m-%d %H:%M:%S')}. Safe to delete via "
+        f"`mnemon verify-sharing --cleanup`."
+    )
+    try:
+        call_tool_sync(
+            "memory_save",
+            {"title": term, "content": content, "content_type": "note"},
+            timeout=8.0,
+        )
+        raw, _ = call_tool_sync(
+            "memory_search", {"query": term, "limit": 5}, timeout=8.0
+        )
+        results = _json.loads(raw)
+    except RemoteClientConfigError as exc:
+        print(f"verify-sharing failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if not any(str(r.get("title", "")) == term for r in results):
+        print(
+            f"✗ Wrote sentinel {term!r} but could not read it back from the "
+            f"remote — the remote vault may not be accepting writes. Run "
+            f"`mnemon doctor` to diagnose.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(f"✓ CLI↔remote verified — wrote and read back sentinel {term!r}.")
+    print("")
+    print("Now confirm another client shares this vault:")
+    print(f'  • In Claude Desktop / claude.ai, ask: "search your memory for {term}"')
+    print("  • If it returns the sentinel, that client is wired to the SAME vault.")
+    print("")
+    print("When done, remove it:  mnemon verify-sharing --cleanup")
 
 
 def _status_remote() -> None:
@@ -989,6 +1085,11 @@ Setup (configure MCP clients; use --remote-url for web mode):
                             [--remote-url URL] [--token TOKEN] [--skip-doctor]
   mnemon doctor             Run diagnostics (local or remote, auto-detected)
                             [--fail-on-warn] treat warnings as failures
+  mnemon verify-sharing     Prove the remote vault is shared across clients:
+                            writes + reads back a sentinel (CLI↔remote), then
+                            prints a search term to confirm in another client
+                            (Claude Desktop / claude.ai). [--cleanup] removes
+                            sentinels when you're done.
 
 Upgrade local → web (deploys a Fly.io app + reconfigures every client).
 Idempotent: rerun to redeploy an existing app with the current mnemon

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1259,3 +1259,95 @@ class TestAttentionStatusPrint:
         assert "Some canonical fact" in out
         assert "Last 10 'restates' relations" in out
         assert "#   99 → #   42" in out
+
+
+class TestVerifySharing:
+    """`mnemon verify-sharing` — write+read-back a sentinel against the
+    remote and print the cross-client confirmation recipe. Automates the
+    'is the vault actually shared?' check (CLI↔remote half) so the manual
+    step is just one search in Desktop."""
+
+    @patch("mnemon.cli._remote_mode_active", return_value=True)
+    def test_write_path_verifies_and_prints_recipe(self, _mode, capsys):
+        import json
+
+        saved = {}
+
+        def fake_call(tool, args, timeout=8.0):
+            if tool == "memory_save":
+                saved["title"] = args["title"]
+                return ("Saved memory #1.", 0.01)
+            if tool == "memory_search":
+                return (
+                    json.dumps([{"doc_id": 1, "title": saved.get("title", ""), "content": "x"}]),
+                    0.01,
+                )
+            return ("", 0.01)
+
+        with patch("mnemon.hooks._remote_client.call_tool_sync", side_effect=fake_call):
+            with patch("sys.argv", ["mnemon", "verify-sharing"]):
+                main()
+
+        out = capsys.readouterr().out
+        assert "CLI↔remote verified" in out
+        assert "mnemon-sharing-check-" in out
+        assert "search your memory for mnemon-sharing-check-" in out
+        assert "verify-sharing --cleanup" in out
+
+    @patch("mnemon.cli._remote_mode_active", return_value=True)
+    def test_read_back_failure_exits_nonzero(self, _mode, capsys):
+        import json
+
+        def fake_call(tool, args, timeout=8.0):
+            if tool == "memory_save":
+                return ("Saved memory #1.", 0.01)
+            if tool == "memory_search":
+                return (json.dumps([]), 0.01)  # sentinel not found
+            return ("", 0.01)
+
+        with patch("mnemon.hooks._remote_client.call_tool_sync", side_effect=fake_call):
+            with patch("sys.argv", ["mnemon", "verify-sharing"]):
+                with pytest.raises(SystemExit) as exc:
+                    main()
+        assert exc.value.code == 1
+        assert "could not read it back" in capsys.readouterr().err
+
+    @patch("mnemon.cli._remote_mode_active", return_value=False)
+    def test_local_mode_exits_nonzero(self, _mode, capsys):
+        with patch("sys.argv", ["mnemon", "verify-sharing"]):
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 1
+        assert "local-only" in capsys.readouterr().err
+
+    @patch("mnemon.cli._remote_mode_active", return_value=True)
+    def test_cleanup_forgets_only_sentinels(self, _mode, capsys):
+        import json
+
+        forgotten = []
+
+        def fake_call(tool, args, timeout=8.0):
+            if tool == "memory_search":
+                return (
+                    json.dumps([
+                        {"doc_id": 10, "title": "mnemon-sharing-check-aaaa"},
+                        {"doc_id": 11, "title": "mnemon-sharing-check-bbbb"},
+                        {"doc_id": 12, "title": "an unrelated real memory"},
+                    ]),
+                    0.01,
+                )
+            if tool == "memory_forget":
+                forgotten.append(args["id"])
+                return ("Forgot.", 0.01)
+            return ("", 0.01)
+
+        with patch("mnemon.hooks._remote_client.call_tool_sync", side_effect=fake_call):
+            with patch("sys.argv", ["mnemon", "verify-sharing", "--cleanup"]):
+                main()
+
+        assert forgotten == [10, 11]  # the non-sentinel #12 is left alone
+        assert "Removed 2 sharing-check sentinel(s)" in capsys.readouterr().out
+
+    def test_usage_lists_verify_sharing(self, capsys):
+        _print_usage()
+        assert "verify-sharing" in capsys.readouterr().out


### PR DESCRIPTION
Companion to the two-vaults guard (#193). Makes the recurring "is mnemon actually doing anything / do Claude Code and Claude Desktop share one vault?" question a **deterministic, repeatable check** — reducing the manual-test surface, which is the goal.

## What it does
`mnemon verify-sharing` writes a uniquely-named sentinel to the configured remote and reads it back — proving **CLI↔remote** round-trips — then prints the exact search term to run in another client (Claude Desktop / claude.ai) to confirm that client is wired to the **same** vault. `--cleanup` forgets all sentinels.

```
$ mnemon verify-sharing
✓ CLI↔remote verified — wrote and read back sentinel 'mnemon-sharing-check-1a2b3c4d'.

Now confirm another client shares this vault:
  • In Claude Desktop / claude.ai, ask: "search your memory for mnemon-sharing-check-1a2b3c4d"
  • If it returns the sentinel, that client is wired to the SAME vault.

When done, remove it:  mnemon verify-sharing --cleanup
```

## Why a command, not just docs
It turns an ad-hoc forensic exercise into a one-liner. The Desktop half is inherently human-in-the-loop (no CLI can drive another app's MCP connector), so the command makes that one step deterministic rather than fully automating it. `doctor`'s round-trip only covers CLI↔remote within one process; this adds the cross-client confirmation recipe.

## Verification
5 tests (write/read-back, read-back-failure exit, local-mode guard, cleanup forgets only sentinels, usage lists it); full suite **1069 passed**, coverage **89.90%** (≥88 gate).

> Note: this was recovered onto a fresh branch off `main` after #193 squash-merged mid-session and its branch auto-deleted — cherry-picked the verify-sharing commit cleanly; the orphan branch was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)