### PR TITLE
release: 0.7.0 stable + docs-honesty pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [0.7.0] - 2026-06-07
+
+First stable release of the 0.7 line — seals `0.7.0rc1`–`rc8`. The
+project remains pre-1.0 alpha (interfaces may still change), but this is
+the release-discipline cut that makes the package something an outside
+self-hoster can depend on.
+
+Headline capabilities accumulated across the rc line: the **salience /
+standing tier** (`memory_promote` / `memory_demote` / `memory_list_standing`
++ always-on standing-context injection), **capture-attention**
+(recurrence-weighted preserve+relate+boost), **NLI-based contradiction
+detection** (no LLM dependency), the **5-layer stored-injection defense**,
+the **local↔web two-product split** with symmetric `upgrade`/`downgrade`,
+and the **two-vaults guard** (`Store` fails loud in remote mode).
+
+### Added
+- **`mnemon verify-sharing`** — write+read-back a sentinel against the
+  configured remote (proves CLI↔remote), then print the exact search term
+  to confirm another client (Claude Desktop / claude.ai) is wired to the
+  same vault. `--cleanup` removes sentinels. Turns the recurring "is the
+  vault actually shared?" question into a deterministic check.
+- **`doctor` two-vaults shadow guard** (`check_no_shadow_local_vault`,
+  remote mode) — warns if a *populated* local `default.sqlite` is
+  shadowing the remote (the trap that twice served stale local reads),
+  with the archive recipe. Empty stub / absent passes.
+
+### Changed / internal
+- **Comprehensive test coverage pass** — all 17 MCP tools now have a
+  direct server-surface test, and the previously-unmeasured local↔web
+  migration (`upgrade.py` / `downgrade.py`) is un-omitted and covered.
+  Suite ~1016 → 1069; coverage gate raised **80% → 88%** to lock it in.
+
 ## [0.7.0rc8] - 2026-06-04
 
 ### Fix: local vault is inaccessible in remote mode (two-vaults bug, residual)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ src/mnemon/
 ```bash
 # Development
 pip install -e ".[dev]"         # Install with dev deps
-pytest                          # Run tests (450+ tests)
+pytest                          # Run tests (1000+ tests, ≥88% coverage gate)
 pytest -v                       # Verbose output
 pytest tests/test_store.py      # Single file
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ mnemon forget 42
 mnemon status
 ```
 
+### Verify it's working
+
+```bash
+mnemon doctor            # health + auth + a real save→search→forget round-trip
+mnemon verify-sharing    # prove multiple clients share one vault (web mode)
+```
+
+`doctor` auto-detects local vs web and runs the right checks (in web mode it also warns if a stale local vault is shadowing the remote). `verify-sharing` writes a sentinel to the remote and prints a search term to run in another client (e.g. Claude Desktop) — if it shows up there, that client is wired to the same vault. Clean up with `mnemon verify-sharing --cleanup`.
+
 ## MCP Tools
 
 ### Retrieval

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.0rc8"
+__version__ = "0.7.0"


### PR DESCRIPTION
PR 3 of the OSS-readiness arc — the release cut. Seals `0.7.0rc1`–`rc8` as the first **stable** of the 0.7 line.

## ⚠️ Merging this publishes 0.7.0 to PyPI
`publish.yml` (OIDC trusted publishing) fires on push to `main`, so **merging this PR is the release action** — `mnemon-memory==0.7.0` goes live on PyPI automatically. No manual `twine` step.

**Fly redeploy is NOT required** for this cut: the new surface (verify-sharing, doctor guard, tests) is client-side CLI; Fly keeps serving the rc6 server image. Redeploy is operator-driven if/when you want the server image bumped (`mnemon upgrade web`).

## What's in here
- **Version** `0.7.0rc8` → **`0.7.0`**.
- **CHANGELOG** `[0.7.0]` stable entry — summarizes the rc-line headline features (salience tier, capture-attention, NLI contradiction detection, 5-layer injection defense, local↔web split, two-vaults guard) plus this session's `verify-sharing` + doctor guard + coverage pass.
- **README** — new "Verify it's working" section (`doctor` + `verify-sharing`).
- **CLAUDE.md** — stale "450+ tests" → "1000+ tests, ≥88% coverage gate".
- **GitHub About** — topics filled 16 → **20/20** (added `anthropic`, `rag`, `claude-desktop`, `ai-memory`).

## Deliberately *not* a 1.0
The `status: alpha` badge stays. `0.7.0` signals "real and dependable" without overclaiming a frozen interface — same posture as the morning-signal `0.1.1` cut.

## Verification
Suite **1069 passed**, coverage **89.90%** (≥ 88% gate). No source behavior change beyond the version string + the already-merged verify-sharing/doctor features.

This closes the comprehensive-testing + OSS-readiness arc: #192 (coverage) + #193 (two-vaults guard) + #194 (verify-sharing) + this release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)