### PR TITLE
chore: 0.7.0rc9 — single-source the version + ship post-rc8 work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,22 @@
 # Changelog
 
-## [0.7.0] - 2026-06-07
+## [0.7.0rc9] - 2026-06-07
 
-First stable release of the 0.7 line — seals `0.7.0rc1`–`rc8`. The
-project remains pre-1.0 alpha (interfaces may still change), but this is
-the release-discipline cut that makes the package something an outside
-self-hoster can depend on.
+Continuing the 0.7 rc cycle — hardening toward a `0.7.0` stable that is
+genuinely rock-solid before the version drops the `rc`. (Not stable yet;
+the `status: alpha` posture stands.)
 
-Headline capabilities accumulated across the rc line: the **salience /
-standing tier** (`memory_promote` / `memory_demote` / `memory_list_standing`
-+ always-on standing-context injection), **capture-attention**
-(recurrence-weighted preserve+relate+boost), **NLI-based contradiction
-detection** (no LLM dependency), the **5-layer stored-injection defense**,
-the **local↔web two-product split** with symmetric `upgrade`/`downgrade`,
-and the **two-vaults guard** (`Store` fails loud in remote mode).
+First prerelease to actually ship the post-rc8 work below: rc8 was the
+last published artifact, and the two commits after it (#193, #194) merged
+to `main` without a version bump, so their PyPI publishes skip-existing'd
+as rc8. This rc carries them.
+
+### Fixed (release plumbing)
+- **Version is now single-sourced** from `src/mnemon/__init__.py` via
+  `[tool.hatch.version]` (`dynamic = ["version"]`). Previously the version
+  lived in BOTH `pyproject.toml` (static) and `__init__.py`; they drifted
+  in the 0.7.0 attempt (init→0.7.0, pyproject→rc8) and the build published
+  the wrong version. One bump site now; they can't disagree.
 
 ### Added
 - **`mnemon verify-sharing`** — write+read-back a sentinel against the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mnemon-memory"
-version = "0.7.0rc8"
+dynamic = ["version"]
 description = "Universal long-term memory layer for AI agents via MCP"
 readme = "README.md"
 license = "MIT"
@@ -66,6 +66,15 @@ all = [
 
 [project.scripts]
 mnemon = "mnemon.cli:main"
+
+# Single source of truth for the version: src/mnemon/__init__.py's
+# __version__. Bump it in ONE place and both the package runtime and the
+# built/published artifact agree. (Before 2026-06-07 the version was a
+# static field here AND a separate __version__ constant — they drifted in
+# PR #195, which bumped __init__ to 0.7.0 but left this at rc8, so the
+# build published the wrong version. Dynamic resolution prevents that.)
+[tool.hatch.version]
+path = "src/mnemon/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mnemon"]

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.0rc9"


### PR DESCRIPTION
Continues the 0.7 **rc cycle** (per "keep bumping rc until rock solid" — *not* cutting stable yet; `status: alpha` stands). Two jobs:

## 1. Fix the release-plumbing bug that ate the 0.7.0 attempt
The version lived in **two** places — `pyproject.toml` (static `version = "0.7.0rc8"`) **and** `src/mnemon/__init__.py` (`__version__`). PR #195 bumped only `__init__` → `0.7.0`, left `pyproject` at `rc8`, so the build published **rc8** (skip-existing no-op). `0.7.0` never reached PyPI, and `main` was left inconsistent.

**Fix:** version is now **dynamic from `__init__.py`** via `[tool.hatch.version]` (`dynamic = ["version"]`). One bump site; the runtime constant and the built artifact can't drift again.
- Verified: `python -m build` → `mnemon_memory-0.7.0rc9-py3-none-any.whl`; `import mnemon; mnemon.__version__` → `0.7.0rc9`.

## 2. Actually ship the post-rc8 work
rc8 was the last published artifact. #193 (two-vaults guard) and #194 (verify-sharing) merged after it **without a version bump**, so their publishes skip-existing'd as rc8 — they're on `main` but never hit PyPI. **This rc carries them.**

## Changes
- `__init__` `0.7.0` → `0.7.0rc9` (single source).
- `pyproject` → `dynamic = ["version"]` + `[tool.hatch.version] path`.
- CHANGELOG: relabel the premature `[0.7.0]` "first stable release" entry → `[0.7.0rc9]`, drop the stable framing.

## Verification
Suite **1069 passed**, coverage **89.90%** (≥88 gate). Merging publishes **0.7.0rc9** to PyPI (prerelease — `pip install mnemon-memory` still resolves to 0.6.0 stable).

Next rc (rc10): cross-device-default — auto-provision the OAuth AS in `upgrade web` + README web-first reframe, per the positioning decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)