### PR TITLE
feat(upgrade): 0.7.0rc10 — cross-device default, OAuth AS auto-provisioned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.7.0rc10] - 2026-06-07
+
+Cross-device is now the **default** path, and it's turnkey.
+
+### Added
+- **`mnemon upgrade web` auto-provisions the self-hosted OAuth AS.** Previously `upgrade web` set up a bearer token (headless clients: Claude Code, Cursor) but left the OAuth Authorization Server — which the **browser** clients (claude.ai web, Claude Desktop, mobile) need — to manual `flyctl secrets` setup. So the cross-device path, mnemon's headline feature, wasn't actually turnkey. Now first-time deploys generate a passphrase and set `MNEMON_AS_ENABLED` + `MNEMON_AS_PASSPHRASE` + `MNEMON_PUBLIC_URL` automatically (the AS keypair already persists on the Fly volume at `/data/oauth_keys`). The passphrase is surfaced in the deploy summary and saved 0600 to `~/.mnemon/as_passphrase` — it's the operator's claude.ai/Desktop login.
+
+### Changed
+- **README leads with cross-device as the default**; local-only is demoted to a "quick demo" you elect *after* seeing the full setup. Reflects that the whole reason to run mnemon (vs. Claude's siloed native memory) is the cross-client vault.
+
 ## [0.7.0rc9] - 2026-06-07
 
 Continuing the 0.7 rc cycle — hardening toward a `0.7.0` stable that is

--- a/README.md
+++ b/README.md
@@ -65,27 +65,35 @@ pip install -e ".[dev]"
 
 ## Quick Start
 
-### Local
+mnemon's whole point is **one memory vault across every client** — Claude Code, claude.ai web, Claude Desktop, the mobile app, Cursor. That's the **default setup** below. It's a deploy of your own Fly.io app (on your keys, your data), and `upgrade web` makes it turnkey — including auth for both headless *and* browser clients.
+
+### Cross-device (the default)
+
+Prereqs: [`flyctl`](https://fly.io/docs/flyctl/install/) authenticated, `aws` CLI configured, an S3 bucket.
+
+```bash
+pip install "mnemon-memory[server]"
+export MNEMON_S3_BUCKET=my-mnemon-vault
+mnemon upgrade web --app-name my-mnemon
+```
+
+This deploys **your own** mnemon to Fly, seeds the vault, and provisions auth for both client kinds:
+
+- **Headless clients** (Claude Code, Cursor) — reconfigured automatically with a bearer token.
+- **Browser clients** (claude.ai web, Claude Desktop, mobile) — a self-hosted OAuth Authorization Server is enabled for you (keypair persists on the Fly volume). Add the connector `https://my-mnemon.fly.dev/mcp` in the app's Settings → Connectors; it opens a login page — sign in with the **passphrase printed at the end of the deploy** (also saved to `~/.mnemon/as_passphrase`).
+
+No third-party auth vendor, no manual secret-wrangling. `mnemon doctor` runs at the end to verify the deployment.
+
+### Local-only (quick demo)
+
+Just trying it on one machine, with no Fly/AWS accounts? You can elect the local-only path instead — but note it's **single-machine, no cross-device sharing** (that's the whole feature you'd be skipping):
 
 ```bash
 pip install mnemon-memory
 mnemon setup
 ```
 
-Auto-detects Claude Code, Claude Desktop, Cursor, Gemini CLI — configures each, then runs `mnemon doctor`.
-
-First `memory_search` takes ~10–20s (one-time FastEmbed model download). Subsequent calls are fast.
-
-### Web
-
-Prereqs: `flyctl` authenticated, `aws` CLI configured, an S3 bucket.
-
-```bash
-export MNEMON_S3_BUCKET=my-mnemon-vault
-mnemon upgrade web --app-name my-mnemon
-```
-
-After it finishes, add `https://my-mnemon.fly.dev/mcp` to claude.ai and the Claude mobile app manually (Settings → Connectors / Connected Apps).
+Auto-detects Claude Code, Claude Desktop, Cursor, Gemini CLI — configures each, then runs `mnemon doctor`. First `memory_search` takes ~10–20s (one-time FastEmbed model download). Move up to the full cross-device setup anytime with `mnemon upgrade web`.
 
 ### Upgrade to a newer version (already on web)
 

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.0rc9"
+__version__ = "0.7.0rc10"

--- a/src/mnemon/upgrade.py
+++ b/src/mnemon/upgrade.py
@@ -383,7 +383,12 @@ def _fly_create_volume(app_name: str, region: str) -> None:
 
 
 def _fly_set_secrets(
-    app_name: str, local_token: str, s3_bucket: str
+    app_name: str,
+    local_token: str,
+    s3_bucket: str,
+    *,
+    as_passphrase: str | None = None,
+    public_url: str | None = None,
 ) -> None:
     """Set Fly secrets: mnemon token + forward AWS creds for sync pull.
 
@@ -397,6 +402,15 @@ def _fly_set_secrets(
     falls back to ``sync.S3_PREFIX_DEFAULT`` / ``VAULT_NAME_DEFAULT`` and
     seeds from the operator's prod prefix instead of any test-scoped
     override (caught 2026-05-21 during the 0.6.0 Layer-3 test).
+
+    When ``as_passphrase`` + ``public_url`` are given, also enables the
+    self-hosted OAuth Authorization Server (``MNEMON_AS_ENABLED`` +
+    passphrase + public URL). This is what lets the **browser** clients —
+    claude.ai web / mobile / Claude Desktop's account connector — connect
+    (they authenticate via OAuth DCR+PKCE, not the static bearer token).
+    Cross-device is mnemon's default path, so first-time deploys provision
+    it automatically; the AS keypair persists on the Fly volume
+    (``/data/oauth_keys``) across restarts.
     """
     env = os.environ.copy()
     aws_access = env.get("AWS_ACCESS_KEY_ID") or _resolve_aws_key(
@@ -432,6 +446,14 @@ def _fly_set_secrets(
         f"MNEMON_S3_PREFIX={s3_prefix}",
         f"MNEMON_VAULT_NAME={vault_name}",
     ]
+    # Self-hosted OAuth AS — the browser-client (claude.ai / Desktop) auth
+    # path. Provisioned on first-time deploy so cross-device works turnkey.
+    if as_passphrase and public_url:
+        secrets_kv += [
+            "MNEMON_AS_ENABLED=true",
+            f"MNEMON_AS_PASSPHRASE={as_passphrase}",
+            f"MNEMON_PUBLIC_URL={public_url}",
+        ]
     # --stage: don't restart machines immediately (they don't exist yet).
     subprocess.run(
         ["flyctl", "secrets", "set", "--app", app_name, "--stage"]
@@ -697,12 +719,18 @@ def upgrade_web(
             os.environ["MNEMON_S3_BUCKET"] = prior_bucket
 
     # Step 3: Fly deploy (or skip if override env var is set).
+    # as_passphrase is the operator's claude.ai/Desktop browser-login
+    # credential (the OAuth AS). Generated + provisioned only on a real
+    # Fly deploy; stays None on the override (Layer-2 test) path.
+    as_passphrase: str | None = None
     override = _fly_endpoint_override()
     if override:
         remote_url = override.rstrip("/")
         if not remote_url.endswith("/mcp"):
             remote_url = remote_url + "/mcp"
     else:
+        as_passphrase = secrets.token_urlsafe(32)
+        public_url = f"https://{app_name}.fly.dev"
         with tempfile.TemporaryDirectory(prefix="mnemon-upgrade-") as tdir:
             workdir = Path(tdir)
             (workdir / "Dockerfile").write_text(
@@ -716,8 +744,15 @@ def upgrade_web(
             )
             _fly_launch(workdir, app_name, region)
             _fly_create_volume(app_name, region)
-            _fly_set_secrets(app_name, local_token, bucket)
+            _fly_set_secrets(
+                app_name, local_token, bucket,
+                as_passphrase=as_passphrase, public_url=public_url,
+            )
             _fly_deploy(workdir, app_name)
+
+        # Persist the AS passphrase locally (0600) — the operator needs it
+        # to log in when adding the claude.ai / Desktop connector.
+        _persist_as_passphrase(as_passphrase)
 
         # Step 4: seed vault on Fly from S3.
         if local_exists:
@@ -743,24 +778,38 @@ def upgrade_web(
         f"Upgrade to web complete: {remote_url}",
         f"  Fly app:       {app_name}",
         f"  S3 bucket:     {bucket}",
-        f"  Token:         {LOCAL_TOKEN_FILE_DISPLAY} (chmod 600)",
+        f"  Token:         {LOCAL_TOKEN_FILE_DISPLAY} (chmod 600) — headless clients (Claude Code, Cursor)",
     ]
+    if as_passphrase:
+        summary_lines.append(
+            f"  AS passphrase: {AS_PASSPHRASE_FILE_DISPLAY} (chmod 600) — your claude.ai / Desktop login"
+        )
     if archived_to:
         summary_lines.append(f"  Local archive: {archived_to}")
     if reconfigured:
         summary_lines.append(
             "  Reconfigured:  " + ", ".join(reconfigured)
         )
-    summary_lines.extend(
-        [
-            "",
-            "Next steps:",
-            "  • Restart each client above to pick up the new MCP endpoint.",
-            f"  • Add the remote manually to claude.ai / mobile: {remote_url}",
-            f"    (Bearer token is in ~/.mnemon/local_token on this machine.)",
-            "  • Run `mnemon downgrade local` to revert (pulls Fly vault back to local).",
+    next_steps = [
+        "",
+        "Next steps:",
+        "  • Restart each client above to pick up the new MCP endpoint.",
+    ]
+    if as_passphrase:
+        next_steps += [
+            f"  • Add the connector in claude.ai / Claude Desktop / mobile: {remote_url}",
+            "    It opens a login page — sign in with the AS passphrase above",
+            f"    (saved to {AS_PASSPHRASE_FILE_DISPLAY}). This is the cross-device path.",
         ]
+    else:
+        next_steps += [
+            f"  • Add the remote manually to claude.ai / mobile: {remote_url}",
+            "    (Bearer token is in ~/.mnemon/local_token on this machine.)",
+        ]
+    next_steps.append(
+        "  • Run `mnemon downgrade local` to revert (pulls Fly vault back to local)."
     )
+    summary_lines.extend(next_steps)
 
     if skip_doctor:
         return "\n".join(summary_lines)
@@ -811,3 +860,18 @@ def upgrade_web(
 # top and pollute hot paths. The real path resolution lives in setup.py;
 # this is purely for the user-facing summary.
 LOCAL_TOKEN_FILE_DISPLAY = "~/.mnemon/local_token"
+AS_PASSPHRASE_FILE_DISPLAY = "~/.mnemon/as_passphrase"
+
+
+def _persist_as_passphrase(passphrase: str) -> None:
+    """Write the OAuth AS passphrase to ``~/.mnemon/as_passphrase`` (0600).
+
+    It's the operator's single-user browser-login credential for the
+    claude.ai / Desktop connector, so they need it readable somewhere
+    after the deploy. Mirrors the bearer-token-on-disk convention.
+    """
+    mnemon_dir = Path.home() / ".mnemon"
+    mnemon_dir.mkdir(parents=True, exist_ok=True)
+    path = mnemon_dir / "as_passphrase"
+    path.write_text(passphrase + "\n")
+    path.chmod(0o600)

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -449,6 +449,77 @@ class TestFlySecretsForwardS3PrefixAndVaultName:
         assert any(kv.startswith("AWS_SECRET_ACCESS_KEY=") for kv in kvs)
 
 
+class TestOAuthASProvisioning:
+    """Cross-device default (2026-06-07): `upgrade web` auto-provisions the
+    self-hosted OAuth AS — the claude.ai / Desktop browser-login path — not
+    just the bearer token. The AS keypair persists on the Fly volume
+    (/data/oauth_keys); the passphrase is generated, set as a Fly secret,
+    surfaced, and saved 0600 locally for the operator's login."""
+
+    def _capture_secrets_args(self, monkeypatch, **kwargs):
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIA-test")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret-test")
+        with patch("mnemon.upgrade.subprocess.run") as mock_run:
+            mock_run.return_value = _ok_completed()
+            upgrade._fly_set_secrets("mnemon-test", "tok", "bucket", **kwargs)
+        return [a for a in mock_run.call_args.args[0] if "=" in a]
+
+    def test_as_secrets_set_when_passphrase_and_url_given(self, monkeypatch):
+        kvs = self._capture_secrets_args(
+            monkeypatch,
+            as_passphrase="super-secret-pass",
+            public_url="https://mnemon-test.fly.dev",
+        )
+        assert "MNEMON_AS_ENABLED=true" in kvs
+        assert "MNEMON_AS_PASSPHRASE=super-secret-pass" in kvs
+        assert "MNEMON_PUBLIC_URL=https://mnemon-test.fly.dev" in kvs
+
+    def test_as_secrets_omitted_when_not_provided(self, monkeypatch):
+        # Back-compat (e.g. the redeploy path passes neither): no AS secrets.
+        kvs = self._capture_secrets_args(monkeypatch)
+        assert not any(kv.startswith("MNEMON_AS_") for kv in kvs)
+        assert not any(kv.startswith("MNEMON_PUBLIC_URL=") for kv in kvs)
+
+    def test_persist_as_passphrase_writes_0600(self, tmp_path, monkeypatch):
+        import stat as _stat
+        # _isolate_env patches Path.home → tmp_path.
+        upgrade._persist_as_passphrase("my-passphrase")
+        f = tmp_path / ".mnemon" / "as_passphrase"
+        assert f.read_text().strip() == "my-passphrase"
+        assert _stat.S_IMODE(f.stat().st_mode) == 0o600
+
+    def test_upgrade_web_provisions_as_end_to_end(self, tmp_path, monkeypatch):
+        vdir = tmp_path / ".mnemon"
+        vdir.mkdir()
+        (vdir / "default.sqlite").write_bytes(b"seeded")
+        monkeypatch.setattr("mnemon.config.vault_dir", lambda: vdir)
+
+        with patch("mnemon.sync.push", return_value={"pushed": ["sqlite"], "errors": []}), \
+            patch("mnemon.upgrade.subprocess.run", return_value=_ok_completed()) as mock_run, \
+            patch("mnemon.upgrade._require_flyctl"), \
+            patch("mnemon.upgrade._require_aws"), \
+            patch("mnemon.upgrade._fly_app_exists", return_value=False), \
+            patch("mnemon.upgrade._reconfigure_clients", return_value=["claude-code"]):
+            result = upgrade_web(
+                app_name="mnemon-xyz", s3_bucket="b", token="t",
+                region="sjc", mnemon_version="0.7.0rc10", skip_doctor=True,
+            )
+
+        secrets_calls = [
+            c.args[0] for c in mock_run.call_args_list
+            if c.args[0][:2] == ["flyctl", "secrets"]
+        ]
+        assert secrets_calls, "expected a flyctl secrets set call"
+        flat = secrets_calls[0]
+        assert "MNEMON_AS_ENABLED=true" in flat
+        assert "MNEMON_PUBLIC_URL=https://mnemon-xyz.fly.dev" in flat
+        assert any(kv.startswith("MNEMON_AS_PASSPHRASE=") for kv in flat)
+        # Passphrase persisted locally + surfaced in the summary.
+        assert (vdir / "as_passphrase").exists()
+        assert "AS passphrase" in result
+        assert "claude.ai" in result
+
+
 # ── _fly_app_exists detection ────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Makes mnemon's headline feature — cross-device, one vault across Claude Code + claude.ai + Desktop + mobile — **turnkey and the default**. Continues the rc cycle (rc10; not stable yet).

## The core fix
`mnemon upgrade web` previously set up only the **bearer token** (headless clients: Claude Code, Cursor). The **browser** clients (claude.ai web, Claude Desktop, mobile) authenticate via OAuth and need the self-hosted Authorization Server — which was left to manual `flyctl secrets`. So the cross-device path wasn't actually turnkey for new self-hosters.

Now first-time `upgrade web` **auto-provisions the AS**: generates a passphrase and sets `MNEMON_AS_ENABLED` + `MNEMON_AS_PASSPHRASE` + `MNEMON_PUBLIC_URL`. The AS keypair already persists on the Fly volume (`/data/oauth_keys`), so no key-dir handling is needed. The passphrase (your claude.ai/Desktop login) is printed in the deploy summary and saved `0600` to `~/.mnemon/as_passphrase`.

## Positioning
README inverted per the decision: **cross-device is the default/full setup**; local-only is demoted to a "quick demo" you elect *after* seeing the real path (since cross-device is the entire reason to run mnemon vs Claude's siloed native memory).

## Back-compat
`_fly_set_secrets` gained optional `as_passphrase`/`public_url`; the **redeploy** path passes neither, so existing apps keep their durable first-time secrets untouched.

## ⚠️ Out-of-scope follow-up (filed ROADMAP)
Apps deployed **before** rc10 won't gain the AS on a plain redeploy (Fly secrets are only set on first-time deploy). They need the 3 secrets set manually, or a fresh deploy. Tracked as a P1 — ideally `_redeploy_web` should ensure the AS secrets exist if missing.

## Verification
4 new tests (AS secrets set/omitted, passphrase persisted 0600, end-to-end provision); suite **1073 passed**, coverage **89.95%** (≥88). Build → `0.7.0rc10` wheel. **Live Fly deploy is operator-only** — unit-tested with mocked flyctl + CI-green; live-validate by deploying a fresh app and confirming a claude.ai connector authenticates with the printed passphrase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)