### PR TITLE
feat: 0.7.0rc12 — scripts/validate_cross_device.sh (live-validation tool)

### DIFF
--- a/.github/workflows/ci-server-extras.yml
+++ b/.github/workflows/ci-server-extras.yml
@@ -32,9 +32,21 @@ jobs:
     # run means something hung — fail in 15 min instead of stalling on
     # GitHub's 6h default.
     timeout-minutes: 15
+    env:
+      # Cache the embedder + NLI models (the non-integration suite still
+      # loads them in unit tests); avoids a ~100MB cold download — the
+      # source of an intermittent hang on this job.
+      FASTEMBED_CACHE_DIR: ${{ github.workspace }}/.model-cache/fastembed
+      HF_HOME: ${{ github.workspace }}/.model-cache/hf
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Cache embedder + NLI models
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.model-cache
+          key: mnemon-models-${{ runner.os }}-v1
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v5
@@ -51,7 +63,7 @@ jobs:
       # imports that would mask a server-only break. pytest itself is
       # a test runner, not a mnemon runtime dep.
       - name: Install test framework
-        run: pip install "pytest>=8.0" "pytest-asyncio>=0.23" "httpx>=0.27"
+        run: pip install "pytest>=8.0" "pytest-asyncio>=0.23" "pytest-timeout>=2.3" "httpx>=0.27"
 
       # Verify the [llm] extras are NOT installed. If a future PR
       # accidentally moves llama-cpp-python or huggingface-hub into
@@ -76,4 +88,6 @@ jobs:
       # unit suite (incl. the run_remote branch tests) already exercises
       # under [server]-only.
       - name: Run tests under [server]-only install
-        run: pytest tests/ -v --tb=short -m "not integration"
+        # --timeout backstop: a stalled cold model download fails that test
+        # fast instead of hanging the job to its 15-min cap.
+        run: pytest tests/ -v --tb=short -m "not integration" --timeout=300 --timeout-method=thread

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,15 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    # Backstop against a hung test (e.g. the integration tests cold-
-    # downloading models at server boot) stalling on the 6h default.
+    # Backstop against a hung test (e.g. a stalled cold model download)
+    # stalling on the 6h default.
     timeout-minutes: 20
+    env:
+      # Pin the embedder (FastEmbed) + NLI (HF) model caches to a path we
+      # restore via actions/cache below, so tests don't cold-download
+      # ~100MB on every run — the source of an intermittent CI hang.
+      FASTEMBED_CACHE_DIR: ${{ github.workspace }}/.model-cache/fastembed
+      HF_HOME: ${{ github.workspace }}/.model-cache/hf
     strategy:
       fail-fast: false
       matrix:
@@ -29,6 +35,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Cache embedder + NLI models
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.model-cache
+          key: mnemon-models-${{ runner.os }}-v1
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -42,8 +54,9 @@ jobs:
         # [tool.coverage.report] fail_under. Build fails if a PR drops
         # coverage below the gate. Configuration (source paths, omits,
         # exclude_lines) lives in pyproject.toml so this stays a one-line
-        # invocation.
-        run: pytest tests/ -v --cov --cov-report=term-missing
+        # invocation. --timeout is a per-test backstop: a stalled cold
+        # model download fails that test fast instead of hanging the job.
+        run: pytest tests/ -v --cov --cov-report=term-missing --timeout=300 --timeout-method=thread
 
   secrets:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.7.0rc12] - 2026-06-07
+
+### Added
+- **`scripts/validate_cross_device.sh`** — scripts the cross-device
+  live-validation: deploys a throwaway Fly app from the current version,
+  asserts the auto-provisioned OAuth AS serves correct RFC-8414 metadata
+  (`mnemon doctor --fail-on-warn`, issuer match), surfaces the generated
+  passphrase + connector URL for the one manual claude.ai-connector step,
+  then tears down. Safety mirrors `promote_stable.sh layer3`: a prod-app
+  guard, fully isolated test state, and an EXIT-trap that restores
+  `~/.mnemon/{remote_url,local_token,as_passphrase}` even on Ctrl-C.
+  `--dry-run` prints the plan (no side effects); `--keep` leaves the app
+  up for unhurried browser testing. CI-smoke-tested in
+  `tests/test_validate_cross_device.py` (syntax, dry-run plan, prod guard).
+
+### Fixed
+- **`promote_stable.sh layer3` now snapshots/restores `as_passphrase`.**
+  rc10+ `upgrade web` writes `~/.mnemon/as_passphrase`; layer3 previously
+  only snapshotted `remote_url`/`local_token`, so a layer3 run would leave
+  the operator's prod passphrase as the destroyed test app's.
+
 ## [0.7.0rc11] - 2026-06-07
 
 Auth-completeness + CI hardening — toward rock-solid.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-cov>=5.0",
+    "pytest-timeout>=2.3",
     "httpx>=0.27",
     "uvicorn>=0.29",
     "starlette>=0.37",

--- a/scripts/promote_stable.sh
+++ b/scripts/promote_stable.sh
@@ -246,11 +246,19 @@ _layer3_cleanup() {
     #    must put them back. Skipping this leaves prod mnemon unreachable.
     if [ -n "${LAYER3_AUTH_BACKUP_DIR:-}" ] && [ -d "$LAYER3_AUTH_BACKUP_DIR" ]; then
         local restored=0
-        for f in remote_url local_token; do
+        # as_passphrase added 2026-06-07: rc10+ `upgrade web` auto-provisions
+        # the OAuth AS and writes ~/.mnemon/as_passphrase, so layer3 must
+        # snapshot+restore it too (else it leaves the operator's prod
+        # passphrase as the destroyed test app's).
+        for f in remote_url local_token as_passphrase; do
             if [ -f "$LAYER3_AUTH_BACKUP_DIR/$f" ]; then
                 cp -p "$LAYER3_AUTH_BACKUP_DIR/$f" "$HOME/.mnemon/$f" \
                     && restored=$((restored + 1)) \
                     || echo_err "cleanup: FAILED to restore ~/.mnemon/$f — operator must recover by hand"
+            elif [ -f "$HOME/.mnemon/$f" ]; then
+                # File didn't exist pre-run (e.g. as_passphrase the deploy
+                # created) → remove the test artifact rather than leave it.
+                rm -f "$HOME/.mnemon/$f"
             fi
         done
         if [ "$restored" -gt 0 ]; then
@@ -378,7 +386,7 @@ cmd_layer3() {
     # Snapshot now, restore in the cleanup trap.
     export LAYER3_AUTH_BACKUP_DIR
     LAYER3_AUTH_BACKUP_DIR="$(mktemp -d -t mnemon-layer3-auth-XXXXXX)"
-    for f in remote_url local_token; do
+    for f in remote_url local_token as_passphrase; do
         if [ -f "$HOME/.mnemon/$f" ]; then
             cp -p "$HOME/.mnemon/$f" "$LAYER3_AUTH_BACKUP_DIR/$f"
         fi

--- a/scripts/validate_cross_device.sh
+++ b/scripts/validate_cross_device.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+#
+# validate_cross_device.sh — live-validate mnemon's cross-device (web) path.
+#
+# Deploys a THROWAWAY Fly app from the current mnemon version, asserts the
+# auto-provisioned OAuth Authorization Server serves correct RFC-8414
+# metadata (the server-side half of the claude.ai / Desktop login path),
+# and surfaces the generated passphrase + connector URL so you can do the
+# one step no script can — adding the connector in claude.ai's browser UI.
+#
+# Safety (mirrors scripts/promote_stable.sh layer3):
+#   * MNEMON_PROD_APP_NAMES guard refuses to touch the prod app.
+#   * All state is isolated via env overrides (test vault dir, test S3
+#     prefix, fake client-config root, unique app name).
+#   * An EXIT trap restores ~/.mnemon/{remote_url,local_token,as_passphrase}
+#     — which `mnemon upgrade web` overwrites and the env overrides do NOT
+#     protect — even on Ctrl-C or error, then destroys the test app and
+#     cleans the test S3 prefix + scratch dirs.
+#
+# Usage:
+#   scripts/validate_cross_device.sh                 # full cycle (deploy → assert → pause → teardown)
+#   scripts/validate_cross_device.sh --keep          # leave the app up for unhurried browser testing
+#   scripts/validate_cross_device.sh --app-name NAME # override the throwaway app name
+#   scripts/validate_cross_device.sh --version VER   # pin a specific mnemon-memory version (must be on PyPI)
+#   scripts/validate_cross_device.sh --dry-run       # print the plan, no side effects
+#   scripts/validate_cross_device.sh --help
+#
+set -euo pipefail
+
+PROD_APP="mnemon-memory"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MNEMON_BIN="${MNEMON_BIN:-$REPO_ROOT/.venv/bin/mnemon}"
+S3_BUCKET="${MNEMON_S3_BUCKET:-mnemon-memory}"
+DRY_RUN=0
+KEEP=0
+APP_NAME=""
+VERSION=""
+
+c_ok()   { printf '\033[32m✓\033[0m %s\n' "$*"; }
+c_info() { printf '  %s\n' "$*"; }
+c_warn() { printf '\033[33m⚠\033[0m %s\n' "$*"; }
+c_err()  { printf '\033[31m✗\033[0m %s\n' "$*" >&2; }
+die()    { c_err "$*"; exit 1; }
+
+usage() { sed -n '2,30p' "$0" | sed 's/^#\{0,1\} \{0,1\}//'; exit 0; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run)  DRY_RUN=1 ;;
+    --keep)     KEEP=1 ;;
+    --app-name) APP_NAME="${2:-}"; shift ;;
+    --version)  VERSION="${2:-}"; shift ;;
+    --help|-h)  usage ;;
+    *) die "unknown arg: $1 (try --help)" ;;
+  esac
+  shift
+done
+
+TEST_RUN_ID="$(date +%Y%m%d-%H%M%S)"
+TEST_APP_NAME="${APP_NAME:-mnemon-test-$TEST_RUN_ID}"
+
+# Resolve the version to deploy from the source of truth (single-sourced
+# __version__) unless the caller pinned one. It MUST already be on PyPI —
+# the Fly Docker build runs `pip install mnemon-memory[server]==<ver>`.
+if [ -z "$VERSION" ]; then
+  VERSION="$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+[A-Za-z0-9.]*' "$REPO_ROOT/src/mnemon/__init__.py" | head -1)"
+fi
+
+# Hard guard: never let the throwaway name collide with prod.
+[ "$TEST_APP_NAME" = "$PROD_APP" ] && die "refusing to run against the prod app ($PROD_APP)"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  cat <<EOF
+DRY RUN — no side effects. Would:
+  1. preflight: flyctl auth whoami; aws sts get-caller-identity; '$MNEMON_BIN' present
+  2. snapshot ~/.mnemon/{remote_url,local_token,as_passphrase} + install EXIT-trap restore
+  3. isolate: test MNEMON_VAULT_DIR / MNEMON_S3_PREFIX / MNEMON_CLIENT_CONFIG_ROOT
+     + MNEMON_PROD_APP_NAMES=$PROD_APP guard
+  4. $MNEMON_BIN upgrade web --app-name $TEST_APP_NAME --mnemon-version $VERSION
+  5. assert: 'mnemon doctor --fail-on-warn' → 'OAuth AS metadata' ✓
+     (issuer=https://$TEST_APP_NAME.fly.dev)
+  6. print the AS passphrase + connector URL + claude.ai browser steps
+  7. $([ "$KEEP" -eq 1 ] && echo "leave the app running (--keep); print manual teardown" || echo "pause for Enter, then teardown")
+  8. teardown (trap): $([ "$KEEP" -eq 1 ] && echo "skip destroy;" ) restore ~/.mnemon snapshot; $([ "$KEEP" -eq 0 ] && echo "destroy $TEST_APP_NAME; rm test S3 prefix;" ) rm scratch dirs
+EOF
+  exit 0
+fi
+
+# ── preflight ────────────────────────────────────────────────────────────────
+[ -x "$MNEMON_BIN" ] || die "mnemon CLI not found/executable at $MNEMON_BIN (set MNEMON_BIN=...)"
+command -v flyctl >/dev/null 2>&1 || die "flyctl not found"
+command -v aws    >/dev/null 2>&1 || die "aws CLI not found"
+flyctl auth whoami >/dev/null 2>&1 || die "flyctl not authenticated (flyctl auth login)"
+aws sts get-caller-identity >/dev/null 2>&1 || die "AWS credentials not resolvable"
+c_ok "preflight: flyctl + aws authenticated; mnemon at $MNEMON_BIN; deploying version $VERSION"
+
+# ── snapshot prod pointers (env overrides do NOT cover these) ─────────────────
+SNAPSHOT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mnemon-prod-snapshot.XXXXXX")"
+for f in remote_url local_token as_passphrase; do
+  [ -f "$HOME/.mnemon/$f" ] && cp -p "$HOME/.mnemon/$f" "$SNAPSHOT_DIR/$f"
+done
+c_ok "snapshotted prod ~/.mnemon pointers to $SNAPSHOT_DIR"
+
+cleanup() {
+  local rc=$?
+  echo ""
+  echo "── teardown ──────────────────────────────────────────────────────────"
+  if [ "$KEEP" -eq 0 ]; then
+    if flyctl apps destroy "$TEST_APP_NAME" -y >/dev/null 2>&1; then
+      c_ok "destroyed test app $TEST_APP_NAME"
+    else
+      c_warn "could not destroy $TEST_APP_NAME — recover by hand: flyctl apps destroy $TEST_APP_NAME -y"
+    fi
+    if [ -n "${MNEMON_S3_PREFIX:-}" ]; then
+      aws s3 rm "s3://$S3_BUCKET/$MNEMON_S3_PREFIX/" --recursive >/dev/null 2>&1 \
+        || c_warn "s3 cleanup failed for $MNEMON_S3_PREFIX (remove by hand)"
+    fi
+  else
+    c_warn "--keep: test app LEFT RUNNING at https://$TEST_APP_NAME.fly.dev"
+    c_info "tear it down later: flyctl apps destroy $TEST_APP_NAME -y"
+  fi
+  # Auth restore is NOT best-effort — a miss leaves prod mnemon broken.
+  local restored=0 had as_path="$HOME/.mnemon/as_passphrase"
+  for f in remote_url local_token as_passphrase; do
+    had=0; [ -f "$HOME/.mnemon/$f" ] && had=1
+    if [ -f "$SNAPSHOT_DIR/$f" ]; then
+      cp -p "$SNAPSHOT_DIR/$f" "$HOME/.mnemon/$f" && restored=$((restored + 1)) \
+        || c_err "FAILED to restore ~/.mnemon/$f — recover by hand"
+    elif [ "$had" -eq 1 ]; then
+      # File didn't exist before this run (e.g. as_passphrase the deploy created) → remove it.
+      rm -f "$HOME/.mnemon/$f"
+    fi
+  done
+  [ "$restored" -gt 0 ] && c_ok "restored $restored prod auth file(s) under ~/.mnemon/"
+  # Remove local scratch (only ever our own test-scoped dirs).
+  [ -n "${MNEMON_VAULT_DIR:-}" ] && [[ "$MNEMON_VAULT_DIR" == "$HOME/.mnemon-test-"* ]] && rm -rf "$MNEMON_VAULT_DIR"
+  [ -n "${MNEMON_CLIENT_CONFIG_ROOT:-}" ] && [[ "$MNEMON_CLIENT_CONFIG_ROOT" == "$HOME/.mnemon-test-configs-"* ]] && rm -rf "$MNEMON_CLIENT_CONFIG_ROOT"
+  rm -rf "$SNAPSHOT_DIR"
+  [ "$rc" -ne 0 ] && c_err "validation aborted (exit $rc) — see above; prod state restored"
+  return 0
+}
+trap cleanup EXIT
+
+# ── isolate ──────────────────────────────────────────────────────────────────
+export MNEMON_VAULT_DIR="$HOME/.mnemon-test-$TEST_RUN_ID"
+export MNEMON_S3_BUCKET="$S3_BUCKET"
+export MNEMON_S3_PREFIX="test-cross-device/$TEST_RUN_ID"
+export MNEMON_CLIENT_CONFIG_ROOT="$HOME/.mnemon-test-configs-$TEST_RUN_ID"
+export MNEMON_PROD_APP_NAMES="$PROD_APP"
+mkdir -p "$MNEMON_VAULT_DIR" "$MNEMON_CLIENT_CONFIG_ROOT"
+c_ok "isolated test env (vault/$MNEMON_S3_PREFIX/configs scoped to $TEST_RUN_ID; prod guard armed)"
+
+# ── deploy (auto-provisions the OAuth AS on a first-time deploy) ──────────────
+echo ""
+echo "── deploying $TEST_APP_NAME (this is the slow part) ──────────────────"
+"$MNEMON_BIN" upgrade web --app-name "$TEST_APP_NAME" --mnemon-version "$VERSION"
+
+# ── assert: the auto-provisioned AS serves correct metadata ──────────────────
+echo ""
+echo "── asserting OAuth AS (server-side) ──────────────────────────────────"
+# `mnemon doctor` reads the test app's URL+token (upgrade web just wrote them
+# to ~/.mnemon/{remote_url,local_token}); --fail-on-warn turns an absent AS
+# (404 metadata) into a hard failure, and the check also verifies issuer ==
+# the deployment base. Exit 0 here == the AS auto-provision worked.
+doctor_out="$("$MNEMON_BIN" doctor --fail-on-warn 2>&1)" || { echo "$doctor_out"; die "doctor failed against $TEST_APP_NAME — AS not validated"; }
+echo "$doctor_out" | grep -qiE "OAuth AS metadata.*(present|issuer=)" \
+  || { echo "$doctor_out"; die "doctor did not report a passing 'OAuth AS metadata' check"; }
+c_ok "OAuth AS metadata validated (RFC 8414 + issuer match) on $TEST_APP_NAME"
+
+# ── surface the manual step ──────────────────────────────────────────────────
+PASSPHRASE="$(cat "$HOME/.mnemon/as_passphrase" 2>/dev/null || echo "<see deploy output above>")"
+echo ""
+echo "══════════════════════════════════════════════════════════════════════"
+c_ok "Server side PASSED. Now the one manual step — the browser connector:"
+c_info "1. In claude.ai (or Claude Desktop) → Settings → Connectors → add custom connector"
+c_info "   URL:        https://$TEST_APP_NAME.fly.dev/mcp"
+c_info "   Passphrase: $PASSPHRASE"
+c_info "2. Then ask Claude there: \"save a memory: cross-device validation OK\""
+c_info "   then \"search your memory for cross-device validation\" — if it round-trips, PASS."
+echo "══════════════════════════════════════════════════════════════════════"
+
+if [ "$KEEP" -eq 1 ]; then
+  c_warn "--keep set: leaving the app up. Re-run without --keep, or destroy by hand, when done."
+  exit 0
+fi
+echo ""
+read -r -p "Press Enter once you've tested the connector (or Ctrl-C) to tear everything down... " _
+# trap cleanup runs on exit

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.0rc11"
+__version__ = "0.7.0rc12"

--- a/tests/test_validate_cross_device.py
+++ b/tests/test_validate_cross_device.py
@@ -1,0 +1,76 @@
+"""Smoke tests for scripts/validate_cross_device.sh.
+
+The script's real path deploys a Fly app (operator-only, can't run in CI),
+but its syntax, arg-parsing, dry-run plan, and the prod-app safety guard
+are all CI-testable via subprocess. This catches the
+`AttributeError-on-first-run` defect class for the bash operator scripts
+(the python ones are covered by test_scripts_smoke.py).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "validate_cross_device.sh"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_script_exists_and_executable():
+    assert SCRIPT.exists(), f"{SCRIPT} missing"
+    assert SCRIPT.stat().st_mode & 0o111, "script is not executable"
+
+
+def test_bash_syntax_valid():
+    # `bash -n` parses without executing — catches syntax errors.
+    r = subprocess.run(["bash", "-n", str(SCRIPT)], capture_output=True, text=True)
+    assert r.returncode == 0, f"syntax error:\n{r.stderr}"
+
+
+def test_help_exits_zero_and_documents_usage():
+    r = _run("--help")
+    assert r.returncode == 0
+    assert "validate_cross_device.sh" in r.stdout
+    assert "--dry-run" in r.stdout
+
+
+def test_dry_run_prints_plan_no_side_effects():
+    r = _run("--dry-run")
+    assert r.returncode == 0
+    out = r.stdout
+    assert "DRY RUN" in out
+    # The plan must name the load-bearing safety + deploy steps.
+    assert "upgrade web" in out
+    assert "OAuth AS metadata" in out
+    assert "MNEMON_PROD_APP_NAMES=mnemon-memory" in out
+    assert "restore ~/.mnemon snapshot" in out
+
+
+def test_dry_run_keep_changes_teardown():
+    default = _run("--dry-run").stdout
+    keep = _run("--dry-run", "--keep").stdout
+    assert "pause for Enter, then teardown" in default
+    assert "leave the app running" in keep
+    assert "skip destroy" in keep
+
+
+def test_prod_app_guard_refuses():
+    r = _run("--app-name", "mnemon-memory")
+    assert r.returncode != 0
+    assert "refusing to run against the prod app" in r.stderr
+
+
+def test_unknown_arg_errors():
+    r = _run("--bogus-flag")
+    assert r.returncode != 0
+    assert "unknown arg" in r.stderr


### PR DESCRIPTION
Scripts the cross-device live-validation so it's repeatable + trackable (instead of a hand-run runbook), per "can we put this process into a script for ease of tracking and testing."

## `scripts/validate_cross_device.sh`
One command runs the whole loop:
1. **Preflight** — flyctl + aws auth, mnemon CLI present.
2. **Snapshot** `~/.mnemon/{remote_url,local_token,as_passphrase}` + install an **EXIT-trap** that restores them (these are the prod pointers the env-var isolation doesn't cover).
3. **Isolate** — test-scoped vault dir / S3 prefix / client-config root + `MNEMON_PROD_APP_NAMES` guard.
4. **Deploy** a throwaway app (`upgrade web`) — auto-provisions the OAuth AS.
5. **Assert** (automated, server side): `mnemon doctor --fail-on-warn` shows `OAuth AS metadata` ✓ with the issuer matching the deployment.
6. **Surface** the passphrase + connector URL + the one manual step (add the connector in claude.ai and round-trip a memory).
7. **Teardown** (trap): destroy app, restore prod pointers, clean S3 prefix + scratch dirs — even on Ctrl-C.

Flags: `--dry-run` (print plan, no side effects), `--keep` (leave app up for unhurried browser testing), `--app-name`, `--version`.

## Safety
Mirrors `promote_stable.sh layer3` exactly — prod-app guard, full state isolation, non-best-effort auth restore. The prod guard refuses `--app-name mnemon-memory`.

## Also fixed
`promote_stable.sh layer3` now snapshots/restores `as_passphrase` too. rc10+ `upgrade web` writes it; layer3 previously only handled `remote_url`/`local_token`, so a layer3 run would clobber the operator's prod passphrase with the destroyed test app's.

## Tests
`tests/test_validate_cross_device.py` — 7 CI smoke tests (syntax via `bash -n`, `--help`, dry-run plan markers, `--keep` teardown diff, prod-app-guard refusal, unknown-arg error). Runs in the normal pytest matrix. The real Fly deploy path is operator-only.

Suite **1079 → 1086**, coverage **89.97%** (≥88). Build → `0.7.0rc12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)