### PR TITLE
fix(dashboard): 0.7.0rc14 — Search page KeyError (memory_search missing recency_score)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.7.0rc14] - 2026-06-07
+
+### Fixed
+- **Dashboard Search page crash (`KeyError: 'recency_score'`).** The
+  dashboard's remote path renders `memory_search` JSON, but that tool
+  hand-built its result dict and omitted `recency_score` (the local
+  `dataclasses.asdict` path included it). `memory_search` now serializes
+  `recency_score` too (additive), and the Search page reads score fields
+  with `.get(..., 0.0)` so it also tolerates an older remote (e.g. a Fly
+  app on a pre-`recency_score` mnemon) that doesn't send it. Caught
+  during the dashboard manual smoke. (`memory_search` was the only tool
+  using a hand-picked dict; the others use `asdict`, so no other page is
+  affected.)
+
 ## [0.7.0rc13] - 2026-06-07
 
 ### Changed

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.0rc13"
+__version__ = "0.7.0rc14"

--- a/src/mnemon/dashboard/pages/1_Search.py
+++ b/src/mnemon/dashboard/pages/1_Search.py
@@ -22,8 +22,14 @@ if query:
     else:
         st.caption(f"{len(results)} results")
         for r in results:
-            with st.expander(f"**{r['title']}** — `{r['content_type']}` — score: {r['composite_score']:.3f}"):
-                fig = make_score_bars(r["composite_score"], r["recency_score"], r["confidence"])
+            with st.expander(f"**{r['title']}** — `{r['content_type']}` — score: {r.get('composite_score', 0.0):.3f}"):
+                # .get() defensively: an older remote (e.g. a Fly app on a
+                # pre-recency_score mnemon) won't include every score field.
+                fig = make_score_bars(
+                    r.get("composite_score", 0.0),
+                    r.get("recency_score", 0.0),
+                    r.get("confidence", 0.0),
+                )
                 st.plotly_chart(fig, use_container_width=True, key=f"score_{r['doc_id']}")
                 st.markdown(r["content"])
                 st.caption(f"ID: {r['doc_id']} | Created: {r['created_at']}")

--- a/src/mnemon/server.py
+++ b/src/mnemon/server.py
@@ -81,7 +81,8 @@ def memory_search(
     Returns a JSON string — a list of result objects, empty when nothing
     matches. Each object contains: ``doc_id``, ``title``, ``content``,
     ``content_type``, ``confidence``, ``composite_score``,
-    ``vector_similarity``, ``created_at``. Score fields are floats.
+    ``recency_score``, ``vector_similarity``, ``created_at``. Score fields
+    are floats.
     ``vector_similarity`` is the raw cosine similarity (0.0–1.0) from the
     vector store, preserved before RRF fusion; it is None for BM25-only
     matches and is the right signal for dedup (``composite_score`` is a
@@ -97,6 +98,7 @@ def memory_search(
             "content_type": r.content_type,
             "confidence": r.confidence,
             "composite_score": r.composite_score,
+            "recency_score": r.recency_score,
             "vector_similarity": r.vector_similarity,
             "created_at": r.created_at,
         })

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -46,6 +46,7 @@ def _make_search_result(**overrides):
         "confidence": 0.80,
         "created_at": "2026-04-01T00:00:00Z",
         "composite_score": 0.75,
+        "recency_score": 0.5,
         "vector_similarity": None,
     }
     defaults.update(overrides)
@@ -159,8 +160,8 @@ class TestMemorySearch:
         )]
         parsed = json.loads(memory_search("q"))[0]
         expected = {"doc_id", "title", "content", "content_type",
-                    "confidence", "composite_score", "vector_similarity",
-                    "created_at"}
+                    "confidence", "composite_score", "recency_score",
+                    "vector_similarity", "created_at"}
         assert expected.issubset(parsed.keys())
         assert parsed["vector_similarity"] == 0.87
 


### PR DESCRIPTION
**Caught during the dashboard manual smoke** (the answer to "do we need to test the UI" landing in real time).

## Bug
The Streamlit dashboard's Search page crashed with `KeyError: 'recency_score'`. Root cause: the dashboard's **remote** path renders `memory_search`'s JSON, but that tool **hand-built its result dict** and omitted `recency_score` — whereas the **local** path (`dataclasses.asdict(ScoredResult)`) includes it. So local-mode worked, remote-mode crashed.

## Fix
- `memory_search` now serializes `recency_score` (additive — matches the local path + the dataclass).
- The Search page reads score fields with `.get(..., 0.0)` so it **also tolerates an older remote** — important because prod Fly currently serves **rc6**, which won't send the field until redeploy.
- Field-shape tests updated (`test_includes_all_expected_fields` + the helper) — they correctly **caught the schema change**, which is the system working.

## Scope
Audited the other pages: `memory_search` was the **only** tool using a hand-picked dict; Timeline / Graph / Profile / Home read `asdict`-serialized results, so no other page has this gap.

Suite **1086 green**; build → `0.7.0rc14`.

Follow-up worth considering (separate): a Streamlit `AppTest` smoke harness that renders each page against remote-shaped mocked loaders would catch this whole class automatically — happy to build it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)