### PR TITLE
fix(dashboard): 0.7.0rc16 — Graph page degrades when vector export fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.7.0rc16] - 2026-06-07
+
+### Fixed
+- **Dashboard Graph page crash when the vector export fails.**
+  `memory_export_vectors` is the heaviest remote call (it exports every
+  vector); on a large or cold remote it can time out / fail at the
+  transport layer (surfacing as an unhandled anyio `ExceptionGroup`),
+  which crashed the Graph page with a raw traceback. The page now wraps
+  the load in try/except → a clear, actionable `st.error` + `st.stop`
+  (retry / run `mnemon doctor`). Covered by a new loader-*failure*-path
+  AppTest (the success-mocked render tests didn't exercise it).
+
 ## [0.7.0rc15] - 2026-06-07
 
 ### Added

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.0rc15"
+__version__ = "0.7.0rc16"

--- a/src/mnemon/dashboard/pages/3_Graph.py
+++ b/src/mnemon/dashboard/pages/3_Graph.py
@@ -13,7 +13,20 @@ CONTENT_TYPES = ["decision", "preference", "antipattern", "observation", "resear
 # One point per document. Multi-chunk docs are mean-pooled in the
 # loader — otherwise a long memory showed up as several near-identical
 # points, which read as duplicates.
-vec_data = load_vectors_collapsed()
+try:
+    vec_data = load_vectors_collapsed()
+except Exception as exc:  # noqa: BLE001 — UI loader: degrade, don't crash the page
+    # memory_export_vectors is the heaviest remote call (it exports every
+    # vector). On a large or cold remote it can time out / fail at the
+    # transport layer (surfaces as an anyio ExceptionGroup). Show a clear,
+    # actionable error instead of a raw traceback.
+    st.error(
+        f"Couldn't load vectors from the vault ({type(exc).__name__}). "
+        "The vector export is the heaviest call — on a large or cold "
+        "remote it can time out. Retry, or run `mnemon doctor` to check "
+        "the connection."
+    )
+    st.stop()
 if vec_data is None:
     # Disambiguate: empty vault vs. saved-but-unembedded memories. The
     # second case is a silent-failure signal — tell the user how to fix it.

--- a/tests/test_dashboard_pages.py
+++ b/tests/test_dashboard_pages.py
@@ -177,3 +177,18 @@ def test_graph_renders_with_points():
          patch("mnemon.dashboard.loaders.load_related", return_value=[]):
         at = AppTest.from_file(str(PAGES / "3_Graph.py"), default_timeout=RUN_TIMEOUT).run()
     _assert_clean(at)
+
+
+def test_graph_degrades_when_vector_export_fails():
+    # The heavy memory_export_vectors call can fail (timeout / transport
+    # ExceptionGroup) against a large/cold remote. The page must show a
+    # clean error + st.stop — NOT crash with a traceback. This is the
+    # loader-*failure* path the success-mocked tests don't exercise.
+    with patch(
+        "mnemon.dashboard.loaders.load_vectors_collapsed",
+        side_effect=RuntimeError("boom: vector export failed"),
+    ):
+        at = AppTest.from_file(str(PAGES / "3_Graph.py"), default_timeout=RUN_TIMEOUT).run()
+    _assert_clean(at)
+    assert any("Couldn't load vectors" in e.value for e in at.error), \
+        "expected a clean on-page error when the vector export fails"


### PR DESCRIPTION
**Caught live** on your ~3057-doc prod remote: the Graph page crashed with an unhandled `ExceptionGroup`.

## Bug
`memory_export_vectors` exports **every** vector in one MCP call — the heaviest call by far. On a large or cold remote it times out / fails at the transport layer (anyio `ExceptionGroup`), and the Graph page let it propagate → raw traceback. (My rc15 AppTest harness mocked the loader to *succeed*, so it tested render logic but not the loader *failing* — that's the gap, now closed.)

## Fix
The Graph page wraps `load_vectors_collapsed()` in try/except → a clear, actionable `st.error` + `st.stop` ("the vector export is the heaviest call… retry, or run `mnemon doctor`") instead of a traceback. A new **loader-failure-path AppTest** asserts the page degrades cleanly (no exception, on-page error message).

## Follow-ups filed (ROADMAP P2)
- `memory_export_vectors` doesn't scale over HTTP for large vaults — paginate, auto-scale the timeout, or compute UMAP server-side and ship only 2-D coords. (Graph is an optional viz, so the graceful-degrade is enough for now.)
- The other dashboard pages share the same remote-call-failure vulnerability (they work against a responsive remote; only Graph is guarded so far). A shared `remote_guard()` + per-page failure AppTests would close the class.

Also: tightened the GitHub About to "any MCP client (Claude, Cursor, Gemini CLI, and more)" per your point — the prior exhaustive list implied only those.

Suite **1094 → 1095** green; build → `0.7.0rc16`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)