### PR TITLE
fix(dashboard): 0.7.0rc17 — comprehensive remote-failure guard on every page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.7.0rc17] - 2026-06-07
+
+### Added / Fixed
+- **Every dashboard page now degrades gracefully on a remote-call failure**
+  (comprehensive UI resilience). Added a shared `remote_guard()` context
+  manager in `loaders.py` and wrapped every page's top-level loader call
+  (Home, Search, Timeline, Graph, Profile): a slow/cold/unreachable remote
+  now yields a clean `st.error` + `st.stop` instead of an unhandled
+  `ExceptionGroup` traceback. (rc16 fixed only Graph; this generalizes it.)
+  The guard passes Streamlit's own control-flow exceptions (`st.stop` /
+  `st.rerun`) through untouched. **Every page now has both a success-render
+  AppTest and a loader-failure AppTest** (13 dashboard tests) — so the UI
+  is comprehensively in the suite for both render and failure paths.
+
 ## [0.7.0rc16] - 2026-06-07
 
 ### Fixed

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.0rc16"
+__version__ = "0.7.0rc17"

--- a/src/mnemon/dashboard/app.py
+++ b/src/mnemon/dashboard/app.py
@@ -8,7 +8,7 @@ st.set_page_config(
     initial_sidebar_state="expanded",
 )
 
-from mnemon.dashboard.loaders import load_status, load_timeline, load_sweep
+from mnemon.dashboard.loaders import load_status, load_timeline, load_sweep, remote_guard
 from mnemon.dashboard.charts import make_type_distribution_chart, make_accumulation_chart
 
 
@@ -41,7 +41,8 @@ def main() -> None:
         + (" · remote" if _use_remote() else " · local")
     )
 
-    status = load_status()
+    with remote_guard("vault status"):
+        status = load_status()
     if not status or status["total_documents"] == 0:
         st.warning("Vault is empty. Start saving memories with `mnemon save` or via MCP tools.")
         st.stop()
@@ -55,13 +56,15 @@ def main() -> None:
         fig = make_type_distribution_chart(status.get("by_type", []))
         st.plotly_chart(fig, use_container_width=True)
     with col2:
-        timeline = load_timeline(limit=500)
+        with remote_guard("the timeline"):
+            timeline = load_timeline(limit=500)
         fig = make_accumulation_chart(timeline)
         st.plotly_chart(fig, use_container_width=True)
 
     st.divider()
     st.subheader("Stale Memory Candidates")
-    sweep = load_sweep()
+    with remote_guard("stale-memory candidates"):
+        sweep = load_sweep()
     _render_sweep_candidates(sweep)
 
 

--- a/src/mnemon/dashboard/loaders.py
+++ b/src/mnemon/dashboard/loaders.py
@@ -16,10 +16,43 @@ from __future__ import annotations
 import dataclasses
 import json
 import os
+from contextlib import contextmanager
 from pathlib import Path
 
 import numpy as np
 import streamlit as st
+
+
+# ── Remote-failure guard ─────────────────────────────────────────────────────
+
+# Streamlit control-flow exceptions must pass THROUGH the guard untouched —
+# st.stop() / st.rerun() are normal flow, not errors. Matched by name so we
+# don't depend on Streamlit's internal exception module paths.
+_ST_CONTROL_EXC = {"StopException", "RerunException", "RerunData"}
+
+
+@contextmanager
+def remote_guard(what: str = "data from the remote vault"):
+    """Wrap a page's top-level loader call so a remote-call failure degrades
+    to a clean ``st.error`` + ``st.stop`` instead of an unhandled traceback.
+
+    The MCP remote calls (via ``call_tool_sync`` → streamable HTTP) can fail
+    at the transport layer on a slow/cold/unreachable remote, surfacing as an
+    anyio ``ExceptionGroup`` (or a timeout). Loaders are ``@st.cache_data``
+    so they can't safely emit UI on failure; the page is the right place to
+    catch — hence this guard around the call site.
+    """
+    try:
+        yield
+    except Exception as exc:  # noqa: BLE001 — UI boundary: degrade, don't crash
+        if type(exc).__name__ in _ST_CONTROL_EXC:
+            raise  # let st.stop()/st.rerun() flow normally
+        st.error(
+            f"Couldn't load {what} ({type(exc).__name__}). The remote may be "
+            "slow, cold-starting, or unreachable — retry, or run "
+            "`mnemon doctor` to check the connection."
+        )
+        st.stop()
 
 
 # ── Mode detection ──────────────────────────────────────────────────────────

--- a/src/mnemon/dashboard/pages/1_Search.py
+++ b/src/mnemon/dashboard/pages/1_Search.py
@@ -5,7 +5,7 @@ import streamlit as st
 st.set_page_config(page_title="Search — mnemon", layout="wide")
 st.title("Search Memories")
 
-from mnemon.dashboard.loaders import load_search
+from mnemon.dashboard.loaders import load_search, remote_guard
 from mnemon.dashboard.charts import make_score_bars
 
 CONTENT_TYPES = ["All", "decision", "preference", "antipattern", "observation", "research", "project", "handoff", "note"]
@@ -15,7 +15,8 @@ content_type_filter = st.selectbox("Filter by type", CONTENT_TYPES)
 
 if query:
     ct = None if content_type_filter == "All" else content_type_filter
-    results = load_search(query, limit=20, content_type=ct)
+    with remote_guard("search results"):
+        results = load_search(query, limit=20, content_type=ct)
 
     if not results:
         st.info("No results found.")

--- a/src/mnemon/dashboard/pages/2_Timeline.py
+++ b/src/mnemon/dashboard/pages/2_Timeline.py
@@ -6,7 +6,7 @@ from datetime import datetime, date
 st.set_page_config(page_title="Timeline — mnemon", layout="wide")
 st.title("Memory Timeline")
 
-from mnemon.dashboard.loaders import load_timeline
+from mnemon.dashboard.loaders import load_timeline, remote_guard
 
 CONTENT_TYPES = ["decision", "preference", "antipattern", "observation", "research", "project", "handoff", "note"]
 
@@ -15,7 +15,8 @@ col1, col2 = st.sidebar.columns(2)
 date_from = col1.date_input("From", value=date(2024, 1, 1))
 date_to = col2.date_input("To", value=date.today())
 
-timeline = load_timeline(limit=500)
+with remote_guard("the timeline"):
+    timeline = load_timeline(limit=500)
 
 filtered = [
     d for d in timeline

--- a/src/mnemon/dashboard/pages/3_Graph.py
+++ b/src/mnemon/dashboard/pages/3_Graph.py
@@ -5,28 +5,17 @@ import streamlit as st
 st.set_page_config(page_title="Memory Graph — mnemon", layout="wide")
 st.title("Memory Graph")
 
-from mnemon.dashboard.loaders import load_vectors_collapsed, load_umap_coords, load_related, load_status
+from mnemon.dashboard.loaders import load_vectors_collapsed, load_umap_coords, load_related, load_status, remote_guard
 from mnemon.dashboard.charts import make_graph_scatter, add_relation_edges
 
 CONTENT_TYPES = ["decision", "preference", "antipattern", "observation", "research", "project", "handoff", "note"]
 
 # One point per document. Multi-chunk docs are mean-pooled in the
 # loader — otherwise a long memory showed up as several near-identical
-# points, which read as duplicates.
-try:
+# points, which read as duplicates. memory_export_vectors is the heaviest
+# remote call — on a large/cold remote it can time out, so guard it.
+with remote_guard("the vector export (the heaviest call)"):
     vec_data = load_vectors_collapsed()
-except Exception as exc:  # noqa: BLE001 — UI loader: degrade, don't crash the page
-    # memory_export_vectors is the heaviest remote call (it exports every
-    # vector). On a large or cold remote it can time out / fail at the
-    # transport layer (surfaces as an anyio ExceptionGroup). Show a clear,
-    # actionable error instead of a raw traceback.
-    st.error(
-        f"Couldn't load vectors from the vault ({type(exc).__name__}). "
-        "The vector export is the heaviest call — on a large or cold "
-        "remote it can time out. Retry, or run `mnemon doctor` to check "
-        "the connection."
-    )
-    st.stop()
 if vec_data is None:
     # Disambiguate: empty vault vs. saved-but-unembedded memories. The
     # second case is a silent-failure signal — tell the user how to fix it.

--- a/src/mnemon/dashboard/pages/4_Profile.py
+++ b/src/mnemon/dashboard/pages/4_Profile.py
@@ -5,13 +5,14 @@ import streamlit as st
 st.set_page_config(page_title="Profile — mnemon", layout="wide")
 st.title("Your Profile")
 
-from mnemon.dashboard.loaders import load_timeline
+from mnemon.dashboard.loaders import load_timeline, remote_guard
 
 col1, col2 = st.columns(2)
 
 with col1:
     st.subheader("Preferences")
-    prefs = load_timeline(limit=50, content_type="preference")
+    with remote_guard("preferences"):
+        prefs = load_timeline(limit=50, content_type="preference")
     if not prefs:
         st.info("No preferences stored yet.")
     for p in prefs:
@@ -21,7 +22,8 @@ with col1:
 
 with col2:
     st.subheader("Decisions")
-    decisions = load_timeline(limit=50, content_type="decision")
+    with remote_guard("decisions"):
+        decisions = load_timeline(limit=50, content_type="decision")
     if not decisions:
         st.info("No decisions stored yet.")
     for d in decisions:

--- a/tests/test_dashboard_pages.py
+++ b/tests/test_dashboard_pages.py
@@ -87,6 +87,14 @@ def _assert_clean(at: AppTest):
     assert not at.exception, f"page raised: {at.exception}"
 
 
+def _assert_degraded(at: AppTest):
+    """A loader failure must degrade to a clean on-page error (the
+    remote_guard message starts 'Couldn't load …') + no raw exception."""
+    assert not at.exception, f"page raised instead of degrading: {at.exception}"
+    assert any("Couldn't load" in e.value for e in at.error), \
+        "expected a clean 'Couldn't load …' error from remote_guard"
+
+
 # ── Home (app.py) ────────────────────────────────────────────────────────────
 
 def test_home_renders():
@@ -179,16 +187,40 @@ def test_graph_renders_with_points():
     _assert_clean(at)
 
 
+# ── loader-FAILURE paths (remote_guard) — every page must degrade, not crash ──
+# A remote-call failure (timeout / transport ExceptionGroup on a slow/cold/
+# unreachable remote) must surface as a clean on-page error, never a traceback.
+# These are the paths the success-mocked render tests above don't exercise.
+
 def test_graph_degrades_when_vector_export_fails():
-    # The heavy memory_export_vectors call can fail (timeout / transport
-    # ExceptionGroup) against a large/cold remote. The page must show a
-    # clean error + st.stop — NOT crash with a traceback. This is the
-    # loader-*failure* path the success-mocked tests don't exercise.
     with patch(
         "mnemon.dashboard.loaders.load_vectors_collapsed",
         side_effect=RuntimeError("boom: vector export failed"),
     ):
         at = AppTest.from_file(str(PAGES / "3_Graph.py"), default_timeout=RUN_TIMEOUT).run()
-    _assert_clean(at)
-    assert any("Couldn't load vectors" in e.value for e in at.error), \
-        "expected a clean on-page error when the vector export fails"
+    _assert_degraded(at)
+
+
+def test_search_degrades_on_loader_failure():
+    with patch("mnemon.dashboard.loaders.load_search", side_effect=RuntimeError("remote down")):
+        at = AppTest.from_file(str(PAGES / "1_Search.py"), default_timeout=RUN_TIMEOUT).run()
+        at.text_input[0].set_value("anything").run()
+    _assert_degraded(at)
+
+
+def test_timeline_degrades_on_loader_failure():
+    with patch("mnemon.dashboard.loaders.load_timeline", side_effect=RuntimeError("remote down")):
+        at = AppTest.from_file(str(PAGES / "2_Timeline.py"), default_timeout=RUN_TIMEOUT).run()
+    _assert_degraded(at)
+
+
+def test_profile_degrades_on_loader_failure():
+    with patch("mnemon.dashboard.loaders.load_timeline", side_effect=RuntimeError("remote down")):
+        at = AppTest.from_file(str(PAGES / "4_Profile.py"), default_timeout=RUN_TIMEOUT).run()
+    _assert_degraded(at)
+
+
+def test_home_degrades_on_loader_failure():
+    with patch("mnemon.dashboard.loaders.load_status", side_effect=RuntimeError("remote down")):
+        at = AppTest.from_file(str(DASH / "app.py"), default_timeout=RUN_TIMEOUT).run()
+    _assert_degraded(at)


### PR DESCRIPTION
**Makes the UI comprehensively tested** — the honest answer to "is the UI comprehensively in the suite?" is now *yes*.

## What
rc15 added success-render tests for every page; rc16 fixed + failure-tested only the Graph page. This generalizes the failure handling to **all** pages:
- New shared **`remote_guard()`** context manager in `loaders.py` wraps every page's top-level loader call (Home, Search, Timeline, Graph, Profile). A slow/cold/unreachable remote now degrades to a clean `st.error` + `st.stop` instead of an unhandled `ExceptionGroup` traceback.
- The guard **re-raises Streamlit's own control-flow exceptions** (`st.stop` / `st.rerun`) so normal flow (e.g. the empty-vault stop) is untouched.

## Tests — now both paths, every page
**13 dashboard tests**: a success-render AppTest *and* a loader-failure AppTest for each of the 5 pages. The failure tests mock the loader to raise and assert the page shows a clean "Couldn't load…" error with no exception. This is the class that bit us twice (recency_score render gap; Graph export failure) — now covered for every page, both directions.

Closes the rc16 ROADMAP P2 (other pages shared the vulnerability).

Suite **1095 → 1099** green; build → `0.7.0rc17`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)