### PR TITLE
feat(dashboard): 0.7.0rc18 — server-side PCA Graph projection (scales to large vaults)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.7.0rc18] - 2026-06-07
+
+### Added
+- **Memory Graph now scales to large vaults.** The Graph page previously
+  pulled every document's full 384-d vector over MCP
+  (`memory_export_vectors` — ~10 MB JSON for a few thousand docs) and ran
+  UMAP client-side; on a large or cold remote that transfer timed out and
+  the page couldn't render. New `memory_export_coords` MCP tool collapses
+  each document to one mean-pooled, L2-normalized vector and runs **PCA →
+  2-D server-side** (numpy SVD, zero new deps), returning only the
+  coordinates + metadata. The payload is now O(n_docs × 2) regardless of
+  embedding dimension, so the Graph renders at any vault size.
+  - Remote mode uses the server-side PCA projection; **local mode keeps
+    client-side UMAP** (small demo vaults, no transfer cost). The Graph
+    page dispatches via a new `load_graph_projection()` loader and labels
+    which projection is in use.
+  - Coverage: server tests for `memory_export_coords` + `_pca_2d`
+    (collapse, invalidated-doc skip, cap, cluster separation) and dashboard
+    AppTests for both the remote-PCA render path and a remote-coords
+    failure-degrade path.
+
 ## [0.7.0rc17] - 2026-06-07
 
 ### Added / Fixed

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.0rc17"
+__version__ = "0.7.0rc18"

--- a/src/mnemon/dashboard/loaders.py
+++ b/src/mnemon/dashboard/loaders.py
@@ -298,6 +298,65 @@ def load_umap_coords(_vectors: np.ndarray, n_neighbors: int = 15) -> np.ndarray:
     return reducer.fit_transform(_vectors)
 
 
+@st.cache_data(ttl=900)
+def load_coords_remote() -> tuple[list[str], np.ndarray, dict[str, dict]] | None:
+    """Remote Graph path: the server computes the 2-D PCA projection and
+    returns only coordinates (O(n_docs) payload), so it scales to large
+    vaults where exporting full vectors would time out on a cold remote.
+
+    Returns ``(vec_ids, coords_2d, doc_map)`` — same shape the Graph page
+    consumes from the local UMAP path — or None when the vault has no
+    embeddings yet.
+    """
+    payload = json.loads(_call_remote(
+        "memory_export_coords", {},
+        timeout=VECTOR_EXPORT_TIMEOUT_SEC,
+    ))
+    items = payload.get("items", [])
+    if not items:
+        return None
+    vec_ids = [it["vec_id"] for it in items]
+    coords = np.array([[it["x"], it["y"]] for it in items], dtype=np.float32)
+    doc_map = {
+        it["vec_id"]: {
+            "id": it["doc_id"],
+            "title": it["title"],
+            "content_type": it["content_type"],
+            "confidence": it["confidence"],
+            "created_at": it["created_at"],
+        }
+        for it in items
+    }
+    if payload.get("truncated"):
+        st.warning(
+            f"Graph projection was capped at {payload.get('count')} of your "
+            "vault's documents — raise the server-side coords cap if you need "
+            "the full set."
+        )
+    return vec_ids, coords, doc_map
+
+
+def load_graph_projection(n_neighbors: int = 15) -> tuple[list[str], np.ndarray, dict[str, dict]] | None:
+    """Unified Graph-page projection: ``(vec_ids, coords_2d, doc_map)`` or None.
+
+    - **Remote** (the default on Fly): server-side PCA via
+      ``memory_export_coords`` — ships only coordinates, scales to large
+      vaults. ``n_neighbors`` is ignored (PCA has no neighbor knob).
+    - **Local**: client-side UMAP over the collapsed vectors — small demo
+      vaults where ``umap`` is installed and there's no transfer cost.
+
+    Dispatch only — the underlying loaders are individually cached.
+    """
+    if _use_remote():
+        return load_coords_remote()
+    raw = load_vectors_collapsed()
+    if raw is None:
+        return None
+    vec_ids, vectors, doc_map = raw
+    coords = load_umap_coords(vectors, n_neighbors=n_neighbors)
+    return vec_ids, coords, doc_map
+
+
 def _build_vector_doc_map_local(vec_ids: list[str]) -> dict[str, dict]:
     """Local-mode doc-map: open a fresh SQLite connection and resolve
     vec_ids → doc metadata via content_hash. Remote mode gets this

--- a/src/mnemon/dashboard/pages/3_Graph.py
+++ b/src/mnemon/dashboard/pages/3_Graph.py
@@ -5,32 +5,56 @@ import streamlit as st
 st.set_page_config(page_title="Memory Graph — mnemon", layout="wide")
 st.title("Memory Graph")
 
-from mnemon.dashboard.loaders import load_vectors_collapsed, load_umap_coords, load_related, load_status, remote_guard
+from mnemon.dashboard.loaders import load_graph_projection, load_related, load_status, remote_guard, _use_remote
 from mnemon.dashboard.charts import make_graph_scatter, add_relation_edges
 
 CONTENT_TYPES = ["decision", "preference", "antipattern", "observation", "research", "project", "handoff", "note"]
 
-# One point per document. Multi-chunk docs are mean-pooled in the
-# loader — otherwise a long memory showed up as several near-identical
-# points, which read as duplicates. memory_export_vectors is the heaviest
-# remote call — on a large/cold remote it can time out, so guard it.
-with remote_guard("the vector export (the heaviest call)"):
-    vec_data = load_vectors_collapsed()
-if vec_data is None:
-    # Disambiguate: empty vault vs. saved-but-unembedded memories. The
-    # second case is a silent-failure signal — tell the user how to fix it.
+remote = _use_remote()
+
+# Status first (cheap) — bounds the empty-vault case and the local UMAP
+# n_neighbors slider without paying for the projection up front.
+with remote_guard("vault status"):
     doc_count = load_status().get("total_documents", 0)
-    if doc_count == 0:
-        st.warning("No memories saved yet. Save a memory to get started.")
-    else:
-        st.warning(
-            f"{doc_count} memor{'y' if doc_count == 1 else 'ies'} saved but no embeddings found — "
-            "the embedding step did not run or failed silently. "
-            "Run `mnemon doctor` to diagnose, then `mnemon rebuild` to re-embed."
-        )
+if doc_count == 0:
+    st.warning("No memories saved yet. Save a memory to get started.")
     st.stop()
 
-vec_ids, vectors, doc_map = vec_data
+# Sidebar controls. The neighbor knob is UMAP-only (local); the remote
+# path is server-side PCA, which ships just the 2-D coordinates so the
+# Graph scales to large vaults instead of timing out on a full export.
+if remote:
+    st.sidebar.caption("Projection: PCA — computed server-side, scales to large vaults.")
+    n_neighbors = 15  # unused on the remote (PCA) path
+else:
+    max_neighbors = min(50, max(2, doc_count - 1))
+    if max_neighbors > 5:
+        n_neighbors = st.sidebar.slider("UMAP n_neighbors", min_value=5, max_value=max_neighbors, value=min(15, max_neighbors), step=5, help="Higher = more global structure, lower = more local clusters")
+    else:
+        n_neighbors = max_neighbors
+        st.sidebar.caption(f"UMAP n_neighbors: {n_neighbors} (auto — small vault)")
+visible_types = st.sidebar.multiselect("Visible types", CONTENT_TYPES, default=CONTENT_TYPES)
+show_edges = st.sidebar.checkbox("Show relation edges", value=True)
+
+# One point per document. Multi-chunk docs are mean-pooled (so a long
+# memory isn't several near-identical points). Remote reduces server-side
+# (tiny payload); local runs UMAP client-side — both can be slow/cold, so
+# guard the call.
+with remote_guard("the memory graph projection"):
+    with st.spinner("Computing projection..."):
+        proj = load_graph_projection(n_neighbors=n_neighbors)
+
+if proj is None:
+    # doc_count > 0 but no embeddings — a silent-failure signal; tell the
+    # user how to fix it rather than showing a blank graph.
+    st.warning(
+        f"{doc_count} memor{'y' if doc_count == 1 else 'ies'} saved but no embeddings found — "
+        "the embedding step did not run or failed silently. "
+        "Run `mnemon doctor` to diagnose, then `mnemon rebuild` to re-embed."
+    )
+    st.stop()
+
+vec_ids, coords_2d, doc_map = proj
 
 # Post-collapse each point = one memory, so count in memory-units here —
 # otherwise the Graph page's "1 vector" contradicts `mnemon status`'s
@@ -38,26 +62,10 @@ vec_ids, vectors, doc_map = vec_data
 if len(vec_ids) < 5:
     st.warning(
         f"Only {len(vec_ids)} memor{'y' if len(vec_ids) == 1 else 'ies'} — "
-        "need at least 5 memories for a meaningful UMAP projection. "
+        "need at least 5 memories for a meaningful projection. "
         "Add more and come back."
     )
     st.stop()
-
-# Sidebar controls
-max_neighbors = min(50, len(vec_ids) - 1)
-if max_neighbors > 5:
-    n_neighbors = st.sidebar.slider("UMAP n_neighbors", min_value=5, max_value=max_neighbors, value=min(15, max_neighbors), step=5, help="Higher = more global structure, lower = more local clusters")
-else:
-    n_neighbors = max_neighbors
-    st.sidebar.caption(f"UMAP n_neighbors: {n_neighbors} (auto — small vault)")
-visible_types = st.sidebar.multiselect("Visible types", CONTENT_TYPES, default=CONTENT_TYPES)
-show_edges = st.sidebar.checkbox("Show relation edges", value=True)
-
-# UMAP reduction
-with st.spinner("Computing UMAP projection..."):
-    coords_2d = load_umap_coords(vectors, n_neighbors=n_neighbors)
-
-# doc_map is already populated by load_vectors() — no extra query needed.
 
 # Build scatter plot
 fig = make_graph_scatter(coords_2d, vec_ids, doc_map, visible_types=set(visible_types))

--- a/src/mnemon/server.py
+++ b/src/mnemon/server.py
@@ -438,6 +438,32 @@ def memory_related(id: int, limit: int = 10) -> str:
 # cap so a runaway vault size doesn't OOM the server process silently.
 _VECTOR_EXPORT_MAX = 5000
 
+# Coords-export cap: the projected payload is O(n_docs × 2) regardless of
+# embedding dim, so it stays tiny even for large vaults — the cap here
+# bounds server-side PCA compute/memory, not wire size. SVD on
+# 50000 × 384 float32 is a few seconds and ~150 MB, comfortably within a
+# Fly machine.
+_COORDS_EXPORT_MAX = 50000
+
+
+def _pca_2d(matrix):
+    """Project an (n, d) embedding matrix to (n, 2) via PCA (numpy SVD).
+
+    Zero new deps (numpy is a base requirement) and O(n·d·min(n,d)) — the
+    scalable alternative to shipping full vectors and reducing client-side.
+    Mean-centers, then projects onto the top-2 right singular vectors.
+    """
+    import numpy as np
+
+    X = np.asarray(matrix, dtype=np.float64)
+    if X.shape[0] < 2:
+        # 0 or 1 point — nothing to separate; place at the origin.
+        return np.zeros((X.shape[0], 2), dtype=np.float64)
+    Xc = X - X.mean(axis=0)
+    # Economy SVD: Vt rows are the principal axes (descending variance).
+    _, _, Vt = np.linalg.svd(Xc, full_matrices=False)
+    return Xc @ Vt[:2].T
+
 
 @mcp.tool()
 def memory_export_vectors() -> str:
@@ -510,6 +536,98 @@ def memory_export_vectors() -> str:
     return json.dumps({
         "count": len(items),
         "dim": store.vec_store.dim,
+        "truncated": truncated,
+        "items": items,
+    })
+
+
+@mcp.tool()
+def memory_export_coords() -> str:
+    """Export a 2-D PCA projection of the vault's document embeddings.
+
+    The dashboard Graph page's **scalable** path. ``memory_export_vectors``
+    ships every full 384-d vector over the wire (~10 MB for a few thousand
+    docs) and reduces client-side — untenable on a cold/slow remote, where
+    the transport times out. This instead collapses each document to one
+    mean-pooled, L2-normalized vector, runs PCA → 2-D **server-side**, and
+    returns only the coordinates plus metadata. The payload is
+    O(n_docs × 2) regardless of embedding dim, so it scales to large vaults
+    where exporting full vectors would fail.
+
+    Returns ``{count, truncated, items}`` where each item is
+    ``{doc_id, vec_id, x, y, title, content_type, confidence, created_at,
+    pinned}``. ``vec_id`` is the synthetic ``"doc_{id}"`` so the Graph
+    page's click-to-detail (via ``customdata.doc_id``) keeps working.
+    Invalidated docs are excluded. ``truncated`` is True if the vault
+    exceeds ``_COORDS_EXPORT_MAX``.
+    """
+    import numpy as np
+
+    store = _get_store()
+    vec_ids, vectors = store.vec_store.export_all()
+    if not vec_ids:
+        return json.dumps({"count": 0, "truncated": False, "items": []})
+
+    truncated = len(vec_ids) > _COORDS_EXPORT_MAX
+    if truncated:
+        vec_ids = vec_ids[:_COORDS_EXPORT_MAX]
+        vectors = vectors[:_COORDS_EXPORT_MAX]
+
+    hashes = [vid.rsplit("_", 1)[0] for vid in vec_ids]
+    unique_hashes = list(dict.fromkeys(hashes))
+    placeholders = ",".join("?" * len(unique_hashes))
+    rows = store.db.execute(
+        f"""SELECT hash, id, title, content_type, confidence, created_at, pinned
+            FROM documents
+            WHERE hash IN ({placeholders})
+              AND invalidated_at IS NULL""",
+        unique_hashes,
+    ).fetchall()
+    hash_to_doc = {r["hash"]: dict(r) for r in rows}
+
+    # Collapse chunks → one mean-pooled, L2-normalized vector per document
+    # (mirrors the dashboard's former client-side load_vectors_collapsed),
+    # then keep insertion order so coords align with docs deterministically.
+    by_doc: dict = {}
+    for vec_id, content_hash, vector in zip(vec_ids, hashes, vectors):
+        doc = hash_to_doc.get(content_hash)
+        if doc is None:
+            # Vector's source doc was invalidated/deleted — skip.
+            continue
+        entry = by_doc.setdefault(doc["id"], {"doc": doc, "vecs": []})
+        entry["vecs"].append(np.asarray(vector, dtype=np.float32))
+
+    if not by_doc:
+        return json.dumps({"count": 0, "truncated": truncated, "items": []})
+
+    doc_ids = list(by_doc.keys())
+    pooled = []
+    for did in doc_ids:
+        mean_vec = np.mean(by_doc[did]["vecs"], axis=0)
+        norm = np.linalg.norm(mean_vec)
+        if norm > 0:
+            mean_vec = mean_vec / norm
+        pooled.append(mean_vec)
+
+    coords = _pca_2d(np.array(pooled, dtype=np.float32))
+
+    items = []
+    for did, (x, y) in zip(doc_ids, coords):
+        doc = by_doc[did]["doc"]
+        items.append({
+            "doc_id": doc["id"],
+            "vec_id": f"doc_{doc['id']}",
+            "x": float(x),
+            "y": float(y),
+            "title": doc["title"],
+            "content_type": doc["content_type"],
+            "confidence": doc["confidence"],
+            "created_at": doc["created_at"],
+            "pinned": bool(doc["pinned"]),
+        })
+
+    return json.dumps({
+        "count": len(items),
         "truncated": truncated,
         "items": items,
     })

--- a/tests/test_dashboard_pages.py
+++ b/tests/test_dashboard_pages.py
@@ -155,18 +155,8 @@ def test_profile_renders():
 
 # ── Graph (3_Graph.py) ───────────────────────────────────────────────────────
 
-def test_graph_empty_is_graceful():
-    with patch("mnemon.dashboard.loaders.load_vectors_collapsed", return_value=None), \
-         patch("mnemon.dashboard.loaders.load_status", return_value={"total_documents": 0}):
-        at = AppTest.from_file(str(PAGES / "3_Graph.py"), default_timeout=RUN_TIMEOUT).run()
-    _assert_clean(at)
-
-
-def test_graph_renders_with_points():
-    import numpy as np
-
-    vec_ids = [f"v{i}" for i in range(6)]
-    doc_map = {
+def _graph_doc_map(vec_ids):
+    return {
         vid: {
             "id": i,
             "title": f"Doc {i}",
@@ -176,12 +166,48 @@ def test_graph_renders_with_points():
         }
         for i, vid in enumerate(vec_ids)
     }
+
+
+def test_graph_empty_is_graceful():
+    with patch("mnemon.dashboard.loaders._use_remote", return_value=False), \
+         patch("mnemon.dashboard.loaders.load_status", return_value={"total_documents": 0}):
+        at = AppTest.from_file(str(PAGES / "3_Graph.py"), default_timeout=RUN_TIMEOUT).run()
+    _assert_clean(at)
+
+
+def test_graph_renders_with_points_local_umap():
+    import numpy as np
+
+    vec_ids = [f"v{i}" for i in range(6)]
+    doc_map = _graph_doc_map(vec_ids)
     # load_umap_coords returns an (N, 2) numpy array (charts index it as [i, 0]).
     coords = np.array([[float(i), float(i)] for i in range(6)])
-    with patch(
-        "mnemon.dashboard.loaders.load_vectors_collapsed",
-        return_value=(vec_ids, np.zeros((6, 4)), doc_map),
-    ), patch("mnemon.dashboard.loaders.load_umap_coords", return_value=coords), \
+    with patch("mnemon.dashboard.loaders._use_remote", return_value=False), \
+         patch("mnemon.dashboard.loaders.load_status", return_value={"total_documents": 6}), \
+         patch(
+             "mnemon.dashboard.loaders.load_vectors_collapsed",
+             return_value=(vec_ids, np.zeros((6, 4)), doc_map),
+         ), \
+         patch("mnemon.dashboard.loaders.load_umap_coords", return_value=coords), \
+         patch("mnemon.dashboard.loaders.load_related", return_value=[]):
+        at = AppTest.from_file(str(PAGES / "3_Graph.py"), default_timeout=RUN_TIMEOUT).run()
+    _assert_clean(at)
+
+
+def test_graph_renders_with_points_remote_pca():
+    # Remote path: server-side PCA coords come back via load_coords_remote
+    # as (vec_ids, (N,2) coords, doc_map). The page must render the same.
+    import numpy as np
+
+    vec_ids = [f"doc_{i}" for i in range(6)]
+    doc_map = _graph_doc_map(vec_ids)
+    coords = np.array([[float(i), -float(i)] for i in range(6)], dtype=np.float32)
+    with patch("mnemon.dashboard.loaders._use_remote", return_value=True), \
+         patch("mnemon.dashboard.loaders.load_status", return_value={"total_documents": 6}), \
+         patch(
+             "mnemon.dashboard.loaders.load_coords_remote",
+             return_value=(vec_ids, coords, doc_map),
+         ), \
          patch("mnemon.dashboard.loaders.load_related", return_value=[]):
         at = AppTest.from_file(str(PAGES / "3_Graph.py"), default_timeout=RUN_TIMEOUT).run()
     _assert_clean(at)
@@ -192,11 +218,26 @@ def test_graph_renders_with_points():
 # unreachable remote) must surface as a clean on-page error, never a traceback.
 # These are the paths the success-mocked render tests above don't exercise.
 
-def test_graph_degrades_when_vector_export_fails():
-    with patch(
-        "mnemon.dashboard.loaders.load_vectors_collapsed",
-        side_effect=RuntimeError("boom: vector export failed"),
-    ):
+def test_graph_degrades_when_local_projection_fails():
+    with patch("mnemon.dashboard.loaders._use_remote", return_value=False), \
+         patch("mnemon.dashboard.loaders.load_status", return_value={"total_documents": 6}), \
+         patch(
+             "mnemon.dashboard.loaders.load_vectors_collapsed",
+             side_effect=RuntimeError("boom: vector export failed"),
+         ):
+        at = AppTest.from_file(str(PAGES / "3_Graph.py"), default_timeout=RUN_TIMEOUT).run()
+    _assert_degraded(at)
+
+
+def test_graph_degrades_when_remote_coords_fail():
+    # The exact failure class Brian hit: the heavy remote projection call
+    # times out / transport-errors on a cold or large remote.
+    with patch("mnemon.dashboard.loaders._use_remote", return_value=True), \
+         patch("mnemon.dashboard.loaders.load_status", return_value={"total_documents": 3057}), \
+         patch(
+             "mnemon.dashboard.loaders.load_coords_remote",
+             side_effect=RuntimeError("remote coords export failed"),
+         ):
         at = AppTest.from_file(str(PAGES / "3_Graph.py"), default_timeout=RUN_TIMEOUT).run()
     _assert_degraded(at)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -946,6 +946,140 @@ class TestMemoryExportVectors:
         assert parsed["count"] == _VECTOR_EXPORT_MAX
 
 
+# ── memory_export_coords (server-side PCA) ───────────────────────────────────
+
+
+class TestMemoryExportCoords:
+    def _rows(self, n):
+        return [
+            {"hash": f"hash{i}", "id": i, "title": f"T{i}",
+             "content_type": "note", "confidence": 0.5,
+             "created_at": "2026-01-01", "pinned": i % 2}
+            for i in range(n)
+        ]
+
+    @patch("mnemon.server.Store")
+    def test_empty_vault(self, MockStore):
+        import numpy as np
+        MockStore.return_value.vec_store.export_all.return_value = (
+            [], np.zeros((0, 384))
+        )
+        from mnemon.server import memory_export_coords
+        assert json.loads(memory_export_coords()) == {
+            "count": 0, "truncated": False, "items": [],
+        }
+
+    @patch("mnemon.server.Store")
+    def test_returns_2d_coords_not_full_vectors(self, MockStore):
+        import numpy as np
+        from mnemon.server import memory_export_coords
+        n = 8
+        vec_ids = [f"hash{i}_0" for i in range(n)]
+        # Spread points so PCA has variance to project onto.
+        rng = np.zeros((n, 384), dtype=np.float32)
+        for i in range(n):
+            rng[i, i % 384] = float(i + 1)
+            rng[i, (i + 1) % 384] = float(n - i)
+        MockStore.return_value.vec_store.export_all.return_value = (vec_ids, rng)
+        MockStore.return_value.db.execute.return_value.fetchall.return_value = self._rows(n)
+
+        parsed = json.loads(memory_export_coords())
+        assert parsed["count"] == n
+        assert parsed["truncated"] is False
+        for it in parsed["items"]:
+            # The whole point: coords, not raw vectors over the wire.
+            assert "vector" not in it
+            assert isinstance(it["x"], float) and isinstance(it["y"], float)
+            # Synthetic vec_id keeps click-to-detail working.
+            assert it["vec_id"] == f"doc_{it['doc_id']}"
+        # pinned round-trips as bool.
+        assert any(it["pinned"] is True for it in parsed["items"])
+        assert any(it["pinned"] is False for it in parsed["items"])
+
+    @patch("mnemon.server.Store")
+    def test_collapses_multichunk_docs_to_one_point(self, MockStore):
+        """Two chunks of the same doc → one mean-pooled point."""
+        import numpy as np
+        from mnemon.server import memory_export_coords
+        # Three chunks across two docs (hashA has 2 chunks, hashB has 1)
+        # plus a couple more so PCA has ≥2 points of variance.
+        vec_ids = ["hashA_0", "hashA_1", "hashB_0", "hashC_0"]
+        vecs = np.zeros((4, 384), dtype=np.float32)
+        vecs[0, 0] = 1.0; vecs[1, 1] = 1.0; vecs[2, 2] = 1.0; vecs[3, 3] = 1.0
+        MockStore.return_value.vec_store.export_all.return_value = (vec_ids, vecs)
+        MockStore.return_value.db.execute.return_value.fetchall.return_value = [
+            {"hash": "hashA", "id": 1, "title": "A", "content_type": "note",
+             "confidence": 0.5, "created_at": "2026-01-01", "pinned": 0},
+            {"hash": "hashB", "id": 2, "title": "B", "content_type": "note",
+             "confidence": 0.5, "created_at": "2026-01-01", "pinned": 0},
+            {"hash": "hashC", "id": 3, "title": "C", "content_type": "note",
+             "confidence": 0.5, "created_at": "2026-01-01", "pinned": 0},
+        ]
+        parsed = json.loads(memory_export_coords())
+        assert parsed["count"] == 3  # 4 chunks → 3 docs
+        assert {it["doc_id"] for it in parsed["items"]} == {1, 2, 3}
+
+    @patch("mnemon.server.Store")
+    def test_skips_invalidated_docs(self, MockStore):
+        import numpy as np
+        from mnemon.server import memory_export_coords
+        MockStore.return_value.vec_store.export_all.return_value = (
+            ["abc_0", "orphan_0", "def_0"],
+            np.array([[1.0] + [0.0] * 383, [0.5] * 384, [0.0] * 383 + [1.0]],
+                     dtype=np.float32),
+        )
+        MockStore.return_value.db.execute.return_value.fetchall.return_value = [
+            {"hash": "abc", "id": 1, "title": "Kept", "content_type": "note",
+             "confidence": 0.5, "created_at": "2026-01-01", "pinned": 0},
+            {"hash": "def", "id": 2, "title": "Kept2", "content_type": "note",
+             "confidence": 0.5, "created_at": "2026-01-01", "pinned": 0},
+        ]
+        parsed = json.loads(memory_export_coords())
+        assert parsed["count"] == 2
+        assert {it["doc_id"] for it in parsed["items"]} == {1, 2}
+
+    @patch("mnemon.server.Store")
+    def test_truncates_at_cap(self, MockStore):
+        import numpy as np
+        from mnemon.server import memory_export_coords, _COORDS_EXPORT_MAX
+        n = _COORDS_EXPORT_MAX + 25
+        vec_ids = [f"hash{i}_0" for i in range(n)]
+        vecs = np.zeros((n, 384), dtype=np.float32)
+        for i in range(n):
+            vecs[i, i % 384] = float(i + 1)
+        MockStore.return_value.vec_store.export_all.return_value = (vec_ids, vecs)
+        MockStore.return_value.db.execute.return_value.fetchall.return_value = \
+            self._rows(_COORDS_EXPORT_MAX)
+        parsed = json.loads(memory_export_coords())
+        assert parsed["truncated"] is True
+        assert parsed["count"] == _COORDS_EXPORT_MAX
+
+
+class TestPCA2D:
+    def test_projects_to_two_dims(self):
+        import numpy as np
+        from mnemon.server import _pca_2d
+        X = np.random.RandomState(0).randn(20, 384)
+        coords = _pca_2d(X)
+        assert coords.shape == (20, 2)
+
+    def test_handles_degenerate_small_inputs(self):
+        import numpy as np
+        from mnemon.server import _pca_2d
+        assert _pca_2d(np.zeros((0, 384))).shape == (0, 2)
+        assert _pca_2d(np.ones((1, 384))).shape == (1, 2)
+
+    def test_preserves_dominant_axis_separation(self):
+        # Two well-separated clusters must stay separated in 2-D.
+        import numpy as np
+        from mnemon.server import _pca_2d
+        a = np.tile([5.0] + [0.0] * 383, (10, 1))
+        b = np.tile([-5.0] + [0.0] * 383, (10, 1))
+        coords = _pca_2d(np.vstack([a, b]).astype(np.float32))
+        # First-component means of the two clusters differ substantially.
+        assert abs(coords[:10, 0].mean() - coords[10:, 0].mean()) > 1.0
+
+
 # ── Output-boundary defanging ────────────────────────────────────────────────
 
 

--- a/tests/test_server_remote.py
+++ b/tests/test_server_remote.py
@@ -220,7 +220,8 @@ class TestMcpServer:
         tools = mcp._tool_manager._tools
         # 14 originals + 3 salience-tier Phase 1 (memory_promote /
         # memory_demote / memory_list_standing, added 2026-05-22)
-        assert len(tools) == 17
+        # + 1 memory_export_coords (server-side PCA Graph path, rc18)
+        assert len(tools) == 18
 
     def test_mcp_tool_names(self):
         from mnemon.server import mcp
@@ -230,7 +231,7 @@ class TestMcpServer:
             "memory_get", "memory_timeline",
             "memory_save", "memory_pin", "memory_forget",
             "memory_status", "memory_sweep", "memory_related",
-            "memory_export_vectors",
+            "memory_export_vectors", "memory_export_coords",
             "memory_rebuild", "memory_check_contradictions",
             "profile_get", "profile_update",
             # Salience tier Phase 1 (added 2026-05-22) —

--- a/tests/test_tools_integration.py
+++ b/tests/test_tools_integration.py
@@ -110,6 +110,7 @@ def _tool_inputs_for(seeded: dict[str, Any]) -> dict[str, dict]:
         "memory_related": {"id": ids[0], "limit": 5},
         "memory_list_standing": {},
         "memory_export_vectors": {},
+        "memory_export_coords": {},
         "profile_get": {},
 
         # Pure-create — safe, doesn't modify existing rows


### PR DESCRIPTION
## What

The Memory Graph page now renders at **any vault size**. Previously it pulled every document's full 384-d embedding vector over MCP (`memory_export_vectors` — ~10 MB of JSON for a few thousand docs) and ran UMAP client-side. On a large or cold remote that transfer timed out at the transport layer (the `ExceptionGroup` crash), so the Graph simply couldn't render for larger vaults.

## How

New **`memory_export_coords`** MCP tool:
- Collapses each document to one mean-pooled, L2-normalized vector (server-side — was client-side).
- Runs **PCA → 2-D via numpy SVD** on the server (`_pca_2d`). Zero new dependencies (numpy is already a base requirement) — deliberately *not* server-side UMAP, which would bloat the Fly image with numba/llvmlite (~100MB+) and hurt OSS self-hosters for an optional viz.
- Returns only `{doc_id, vec_id, x, y, …metadata}`. Payload is **O(n_docs × 2)** regardless of embedding dim.

Dashboard:
- New `load_graph_projection()` loader dispatches by mode — **remote → server-side PCA** (scales); **local → client-side UMAP** (small demo vaults, no transfer cost, keeps the `n_neighbors` slider).
- Graph page labels which projection is in use and keeps the existing remote-failure guard + empty/unembedded/under-5 handling.

## Tradeoff (chosen with operator)

PCA is a linear projection — clusters look rougher than UMAP — but it **works at scale** where the full-vector export doesn't, with no image bloat. Local mode still gets full UMAP quality.

## Coverage

- `TestMemoryExportCoords` — empty vault, coords-not-vectors, multi-chunk collapse, invalidated-doc skip, cap.
- `TestPCA2D` — shape, degenerate small inputs, dominant-axis cluster separation.
- Dashboard AppTests — remote-PCA render path + remote-coords failure-degrade path (the exact ~3057-doc class).
- Tool-inventory assertions bumped 17 → 18. **Suite 1099 → 1109 passing**, coverage gate (88%) held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)