### PR TITLE
fix(dashboard): 0.7.0rc19 — bulk relation-edge export (second large-vault Graph timeout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.7.0rc19] - 2026-06-07
+
+### Added
+- **Memory Graph relation-edge overlay now scales too** (the second
+  large-vault Graph timeout). The edge overlay fetched relations **one
+  document at a time** — N MCP round-trips (3,000+ on a large remote),
+  which timed out even when the projection itself was fast. New
+  `memory_export_relations` MCP tool returns every edge between live
+  documents in **one** call (`{count, truncated, edges}`), backed by a
+  single `Store.export_relations()` query; the Graph page builds the
+  overlay from that one payload via a new `load_relations_bulk()` loader.
+  Edges are capped at `_RELATIONS_EXPORT_MAX` (20,000) and the bulk call
+  is wrapped in the page's `remote_guard`. Together with rc18's
+  server-side PCA projection, the Graph now renders end-to-end at any
+  vault size. Coverage: server `memory_export_relations` tests +
+  `Store.export_relations` tests (live edges, invalidated-endpoint
+  exclusion) + a dashboard edges-failure-degrade AppTest. Tool inventory
+  18 → 19.
+
 ## [0.7.0rc18] - 2026-06-07
 
 ### Added

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.0rc18"
+__version__ = "0.7.0rc19"

--- a/src/mnemon/dashboard/loaders.py
+++ b/src/mnemon/dashboard/loaders.py
@@ -336,6 +336,40 @@ def load_coords_remote() -> tuple[list[str], np.ndarray, dict[str, dict]] | None
     return vec_ids, coords, doc_map
 
 
+@st.cache_data(ttl=900)
+def load_relations_bulk() -> dict[int, list[dict]]:
+    """All relation edges as ``{source_id: [{id, relation_type, weight}]}``.
+
+    The Graph edge overlay needs every edge. Remote mode fetches them in
+    **one** ``memory_export_relations`` call (the per-node loop was the
+    second large-vault Graph timeout — N round-trips); local mode runs a
+    single store query. ``id`` on each edge is the *target* doc id, the
+    shape ``add_relation_edges`` consumes.
+    """
+    if _use_remote():
+        payload = json.loads(_call_remote(
+            "memory_export_relations", {},
+            timeout=VECTOR_EXPORT_TIMEOUT_SEC,
+        ))
+        edges = payload.get("edges", [])
+        if payload.get("truncated"):
+            st.warning(
+                f"Relation overlay capped at {payload.get('count')} edges — "
+                "raise the server-side relations cap if you need them all."
+            )
+    else:
+        edges = get_store().export_relations()
+
+    rel_map: dict[int, list[dict]] = {}
+    for e in edges:
+        rel_map.setdefault(e["source_id"], []).append({
+            "id": e["target_id"],
+            "relation_type": e.get("relation_type"),
+            "weight": e.get("weight", 0.0),
+        })
+    return rel_map
+
+
 def load_graph_projection(n_neighbors: int = 15) -> tuple[list[str], np.ndarray, dict[str, dict]] | None:
     """Unified Graph-page projection: ``(vec_ids, coords_2d, doc_map)`` or None.
 

--- a/src/mnemon/dashboard/pages/3_Graph.py
+++ b/src/mnemon/dashboard/pages/3_Graph.py
@@ -5,7 +5,7 @@ import streamlit as st
 st.set_page_config(page_title="Memory Graph — mnemon", layout="wide")
 st.title("Memory Graph")
 
-from mnemon.dashboard.loaders import load_graph_projection, load_related, load_status, remote_guard, _use_remote
+from mnemon.dashboard.loaders import load_graph_projection, load_relations_bulk, load_related, load_status, remote_guard, _use_remote
 from mnemon.dashboard.charts import make_graph_scatter, add_relation_edges
 
 CONTENT_TYPES = ["decision", "preference", "antipattern", "observation", "research", "project", "handoff", "note"]
@@ -70,14 +70,11 @@ if len(vec_ids) < 5:
 # Build scatter plot
 fig = make_graph_scatter(coords_2d, vec_ids, doc_map, visible_types=set(visible_types))
 
-# Relation edges
+# Relation edges — one bulk fetch (was one call per document, which
+# timed out on large remotes). add_relation_edges filters to visible nodes.
 if show_edges:
-    all_doc_ids = {info["id"] for info in doc_map.values()}
-    relations: dict[int, list[dict]] = {}
-    for doc_id in all_doc_ids:
-        rels = load_related(doc_id, limit=5)
-        if rels:
-            relations[doc_id] = rels
+    with remote_guard("relation edges"):
+        relations = load_relations_bulk()
     if relations:
         fig = add_relation_edges(fig, coords_2d, vec_ids, doc_map, relations)
 

--- a/src/mnemon/server.py
+++ b/src/mnemon/server.py
@@ -445,6 +445,11 @@ _VECTOR_EXPORT_MAX = 5000
 # Fly machine.
 _COORDS_EXPORT_MAX = 50000
 
+# Relations-export cap: bounds the single bulk edge fetch for the Graph
+# overlay. A few thousand edges render fine in plotly; beyond this the
+# overlay is visual noise anyway.
+_RELATIONS_EXPORT_MAX = 20000
+
 
 def _pca_2d(matrix):
     """Project an (n, d) embedding matrix to (n, 2) via PCA (numpy SVD).
@@ -630,6 +635,32 @@ def memory_export_coords() -> str:
         "count": len(items),
         "truncated": truncated,
         "items": items,
+    })
+
+
+@mcp.tool()
+def memory_export_relations() -> str:
+    """Export every relation edge between live documents in one call.
+
+    The Graph page's edge overlay previously fetched relations one
+    document at a time (``memory_related`` per node — N round-trips,
+    which times out on a large remote vault even when the projection is
+    fast). This returns all edges between non-invalidated docs in a
+    single call:
+
+    ``{count, truncated, edges:[{source_id, target_id, relation_type,
+    weight}]}``. Edges are ordered by weight desc and capped at
+    ``_RELATIONS_EXPORT_MAX``.
+    """
+    store = _get_store()
+    edges = store.export_relations(limit=_RELATIONS_EXPORT_MAX + 1)
+    truncated = len(edges) > _RELATIONS_EXPORT_MAX
+    if truncated:
+        edges = edges[:_RELATIONS_EXPORT_MAX]
+    return json.dumps({
+        "count": len(edges),
+        "truncated": truncated,
+        "edges": edges,
     })
 
 

--- a/src/mnemon/store.py
+++ b/src/mnemon/store.py
@@ -858,6 +858,28 @@ class Store:
             results.append(rd)
         return results
 
+    def export_relations(self, limit: int = 20000) -> list[dict]:
+        """All relation edges between live documents, in one query.
+
+        The Graph page's edge overlay used to call ``get_related`` once per
+        document — N round-trips, untenable on a large remote vault. This
+        returns every edge whose *both* endpoints are non-invalidated, as
+        ``[{source_id, target_id, relation_type, weight}]`` ordered by
+        weight desc, capped at ``limit``. Lightweight (ids + type + weight
+        only — no document content, so no defang needed).
+        """
+        rows = self.db.execute(
+            """SELECT r.source_id, r.target_id, r.relation_type, r.weight
+               FROM relations r
+               JOIN documents s ON s.id = r.source_id
+               JOIN documents t ON t.id = r.target_id
+               WHERE s.invalidated_at IS NULL AND t.invalidated_at IS NULL
+               ORDER BY r.weight DESC
+               LIMIT ?""",
+            (limit,),
+        ).fetchall()
+        return [dict(row) for row in rows]
+
     def add_relation(self, source_id: int, target_id: int, relation_type: str, weight: float = 1.0) -> None:
         """Add a relation between two documents."""
         self.db.execute(

--- a/tests/test_dashboard_pages.py
+++ b/tests/test_dashboard_pages.py
@@ -189,7 +189,7 @@ def test_graph_renders_with_points_local_umap():
              return_value=(vec_ids, np.zeros((6, 4)), doc_map),
          ), \
          patch("mnemon.dashboard.loaders.load_umap_coords", return_value=coords), \
-         patch("mnemon.dashboard.loaders.load_related", return_value=[]):
+         patch("mnemon.dashboard.loaders.load_relations_bulk", return_value={}):
         at = AppTest.from_file(str(PAGES / "3_Graph.py"), default_timeout=RUN_TIMEOUT).run()
     _assert_clean(at)
 
@@ -208,7 +208,10 @@ def test_graph_renders_with_points_remote_pca():
              "mnemon.dashboard.loaders.load_coords_remote",
              return_value=(vec_ids, coords, doc_map),
          ), \
-         patch("mnemon.dashboard.loaders.load_related", return_value=[]):
+         patch(
+             "mnemon.dashboard.loaders.load_relations_bulk",
+             return_value={0: [{"id": 1, "relation_type": "restates", "weight": 0.9}]},
+         ):
         at = AppTest.from_file(str(PAGES / "3_Graph.py"), default_timeout=RUN_TIMEOUT).run()
     _assert_clean(at)
 
@@ -237,6 +240,27 @@ def test_graph_degrades_when_remote_coords_fail():
          patch(
              "mnemon.dashboard.loaders.load_coords_remote",
              side_effect=RuntimeError("remote coords export failed"),
+         ):
+        at = AppTest.from_file(str(PAGES / "3_Graph.py"), default_timeout=RUN_TIMEOUT).run()
+    _assert_degraded(at)
+
+
+def test_graph_degrades_when_relation_edges_fail():
+    # Edges are a bulk call too; if it fails the page must degrade, not crash.
+    import numpy as np
+
+    vec_ids = [f"doc_{i}" for i in range(6)]
+    doc_map = _graph_doc_map(vec_ids)
+    coords = np.array([[float(i), float(i)] for i in range(6)], dtype=np.float32)
+    with patch("mnemon.dashboard.loaders._use_remote", return_value=True), \
+         patch("mnemon.dashboard.loaders.load_status", return_value={"total_documents": 6}), \
+         patch(
+             "mnemon.dashboard.loaders.load_coords_remote",
+             return_value=(vec_ids, coords, doc_map),
+         ), \
+         patch(
+             "mnemon.dashboard.loaders.load_relations_bulk",
+             side_effect=RuntimeError("remote relations export failed"),
          ):
         at = AppTest.from_file(str(PAGES / "3_Graph.py"), default_timeout=RUN_TIMEOUT).run()
     _assert_degraded(at)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1055,6 +1055,42 @@ class TestMemoryExportCoords:
         assert parsed["count"] == _COORDS_EXPORT_MAX
 
 
+class TestMemoryExportRelations:
+    @patch("mnemon.server.Store")
+    def test_empty(self, MockStore):
+        from mnemon.server import memory_export_relations
+        MockStore.return_value.export_relations.return_value = []
+        assert json.loads(memory_export_relations()) == {
+            "count": 0, "truncated": False, "edges": [],
+        }
+
+    @patch("mnemon.server.Store")
+    def test_returns_edges(self, MockStore):
+        from mnemon.server import memory_export_relations
+        MockStore.return_value.export_relations.return_value = [
+            {"source_id": 1, "target_id": 2, "relation_type": "restates", "weight": 0.9},
+            {"source_id": 3, "target_id": 4, "relation_type": "supersedes", "weight": 0.5},
+        ]
+        parsed = json.loads(memory_export_relations())
+        assert parsed["count"] == 2
+        assert parsed["truncated"] is False
+        assert parsed["edges"][0]["source_id"] == 1
+        assert parsed["edges"][0]["relation_type"] == "restates"
+
+    @patch("mnemon.server.Store")
+    def test_truncates_at_cap(self, MockStore):
+        from mnemon.server import memory_export_relations, _RELATIONS_EXPORT_MAX
+        # Store is asked for cap+1; tool reports truncated and trims to cap.
+        edges = [
+            {"source_id": i, "target_id": i + 1, "relation_type": "restates", "weight": 1.0}
+            for i in range(_RELATIONS_EXPORT_MAX + 1)
+        ]
+        MockStore.return_value.export_relations.return_value = edges
+        parsed = json.loads(memory_export_relations())
+        assert parsed["truncated"] is True
+        assert parsed["count"] == _RELATIONS_EXPORT_MAX
+
+
 class TestPCA2D:
     def test_projects_to_two_dims(self):
         import numpy as np

--- a/tests/test_server_remote.py
+++ b/tests/test_server_remote.py
@@ -221,7 +221,8 @@ class TestMcpServer:
         # 14 originals + 3 salience-tier Phase 1 (memory_promote /
         # memory_demote / memory_list_standing, added 2026-05-22)
         # + 1 memory_export_coords (server-side PCA Graph path, rc18)
-        assert len(tools) == 18
+        # + 1 memory_export_relations (bulk Graph-edge export, rc19)
+        assert len(tools) == 19
 
     def test_mcp_tool_names(self):
         from mnemon.server import mcp
@@ -232,6 +233,7 @@ class TestMcpServer:
             "memory_save", "memory_pin", "memory_forget",
             "memory_status", "memory_sweep", "memory_related",
             "memory_export_vectors", "memory_export_coords",
+            "memory_export_relations",
             "memory_rebuild", "memory_check_contradictions",
             "profile_get", "profile_update",
             # Salience tier Phase 1 (added 2026-05-22) —

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -275,6 +275,28 @@ class TestRelations:
         assert len(store.get_related(id1)) == 1
         assert len(store.get_related(id2)) == 1
 
+    def test_export_relations_returns_all_live_edges(self, store):
+        a = store.save(title="A", content="content A")
+        b = store.save(title="B", content="content B")
+        c = store.save(title="C", content="content C")
+        store.add_relation(a, b, "restates", 0.9)
+        store.add_relation(b, c, "supersedes", 0.5)
+
+        edges = store.export_relations()
+        assert len(edges) == 2
+        # Shape: flat source/target/type/weight — no document content.
+        pairs = {(e["source_id"], e["target_id"], e["relation_type"]) for e in edges}
+        assert (a, b, "restates") in pairs
+        assert (b, c, "supersedes") in pairs
+
+    def test_export_relations_excludes_invalidated_endpoints(self, store):
+        a = store.save(title="A", content="content A")
+        b = store.save(title="B", content="content B")
+        store.add_relation(a, b, "restates", 0.9)
+        store.forget(b)  # invalidate one endpoint
+        # Edge whose target is now invalidated must not be exported.
+        assert store.export_relations() == []
+
 
 class TestCorrectionOf:
     """Regression for 2026-05-22 P2 ROADMAP follow-up: ``correction_of``

--- a/tests/test_tools_integration.py
+++ b/tests/test_tools_integration.py
@@ -111,6 +111,7 @@ def _tool_inputs_for(seeded: dict[str, Any]) -> dict[str, dict]:
         "memory_list_standing": {},
         "memory_export_vectors": {},
         "memory_export_coords": {},
+        "memory_export_relations": {},
         "profile_get": {},
 
         # Pure-create — safe, doesn't modify existing rows


### PR DESCRIPTION
## Why "still timing out" after rc18

rc18 fixed the **vector transfer** (server-side PCA, ships only coords). But the Graph's relation-edge overlay had a *second* O(n) remote path I missed: it fetched relations **one document at a time** — `memory_related` per node. On your ~3,088-doc vault that's 3,000+ sequential MCP round-trips with "Show relation edges" on (the default), so the page still hung even though the projection was now fast.

Diagnosed live: probed your remote — `memory_export_coords` wasn't there yet (redeploy hadn't landed), and confirmed the vault is **3,088 docs / 6,809 vectors**.

## Fix (same pattern as coords)

- **`memory_export_relations`** MCP tool — every edge between live documents in **one** call: `{count, truncated, edges:[{source_id, target_id, relation_type, weight}]}`, backed by a single `Store.export_relations()` query (ids/type/weight only — no content, no defang needed).
- Graph page builds the overlay from that one payload via new **`load_relations_bulk()`** loader (remote → one call; local → one store query), replacing the per-node loop. Wrapped in `remote_guard`.
- Edges capped at `_RELATIONS_EXPORT_MAX` (20,000) — beyond that the overlay is visual noise anyway.

Now **both** the projection and the edges are single bulk calls → the Graph renders end-to-end at any vault size.

## Coverage

- Server: `TestMemoryExportRelations` (empty / returns edges / truncation cap).
- Store: `export_relations` returns live edges + **excludes invalidated endpoints**.
- Dashboard: edges-failure-degrade AppTest (bulk edge call fails → clean degrade, no crash).
- Tool inventory 18 → 19. **Suite 1109 → 1115 passing**, coverage gate (88%) held.

## After merge (operator, one redeploy for rc18 **and** rc19)

`mnemon upgrade web` (redeploys Fly with both new tools) + `pip install --pre -U mnemon-memory` locally. Then the Graph renders with edges. Workaround until then: uncheck "Show relation edges".

🤖 Generated with [Claude Code](https://claude.com/claude-code)