### PR TITLE
fix(health-monitor): 0.7.2 — threshold prune-health, not session volume (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.7.2] - 2026-06-07
+
+### Fixed
+- **Health-monitor perpetual false-positive (issue #208).** The checker
+  warned when `persisted_sessions_total >= 5000`, opening a tracking
+  issue every run for active users. But that metric is computed by
+  `SessionStore.count()`, which filters `WHERE last_active_at > cutoff` —
+  it only counts *non-expired* sessions, so it tracks legitimate volume
+  and can never reveal a broken prune. Replaced the volume threshold with
+  a **volume-independent prune-health signal**: new
+  `oldest_session_age_seconds` metric (via `SessionStore.oldest_age_seconds()`)
+  reports the age of the least-recently-active row across *all* rows. The
+  checker now warns only if that exceeds the 7-day TTL + 2 prune cycles
+  (12h grace) — i.e. only when the periodic `expire_old()` task has
+  actually stalled. `persisted_sessions_total` is kept for observability
+  (no longer thresholded). Coverage: `tests/test_check_health.py` (incl. a
+  regression guard that high volume no longer warns) +
+  `oldest_age_seconds` store tests.
+
 ## [0.7.1] - 2026-06-07
 
 ### Fixed

--- a/scripts/check_health.py
+++ b/scripts/check_health.py
@@ -12,7 +12,8 @@ Usage::
 Exit codes:
     0 — all checks passed
     1 — hard failure (status != ok, stale_session_misses > 0, schema drift)
-    2 — soft warning (persisted_sessions_total above threshold)
+    2 — soft warning (session prune appears stalled — oldest session far
+        past the TTL)
 """
 
 from __future__ import annotations
@@ -25,14 +26,21 @@ import urllib.request
 
 DEFAULT_URL = "https://mnemon-memory.fly.dev/health"
 
-# Soft cap. Since 0.6.0rc12, PersistentSessionManager runs a periodic
-# expire_old() task on a 6h tick (DEFAULT_EXPIRE_INTERVAL_SECONDS in
-# persistent_sessions.py), so unbounded growth is no longer the failure
-# mode this guarded against. The remaining drift is steady-state count
-# under the 7-day TTL; the threshold trips when actual session volume
-# outpaces the prune cadence — investigate by lowering TTL or tightening
-# the prune interval rather than assuming pruning is broken.
-PERSISTED_SESSIONS_WARN_THRESHOLD = 5_000
+# Prune-health threshold (volume-INDEPENDENT). The previous check warned
+# on persisted_sessions_total >= 5000, but that metric only counts
+# *non-expired* rows (count() filters WHERE last_active_at > cutoff), so
+# it can never reveal a broken prune — it just tracks legitimate session
+# volume and fired perpetually for active users (issue #208).
+#
+# The real failure mode is the periodic expire_old() task stalling, which
+# lets rows survive past the 7-day TTL. oldest_session_age_seconds
+# (added 0.7.1) surfaces exactly that and is independent of how many
+# sessions a user creates. Under a working prune nothing lives past
+# TTL (7d) + one prune interval (6h); we warn at TTL + 2 intervals (12h
+# grace) so a single skipped cycle doesn't trip it.
+_TTL_SECONDS = 7 * 24 * 3600              # DEFAULT_TTL_SECONDS
+_PRUNE_INTERVAL_SECONDS = 6 * 3600        # DEFAULT_EXPIRE_INTERVAL_SECONDS
+SESSION_AGE_WARN_SECONDS = _TTL_SECONDS + 2 * _PRUNE_INTERVAL_SECONDS
 
 
 def fetch_health(url: str, timeout: float = 30.0) -> dict:
@@ -84,16 +92,24 @@ def main() -> int:
             f"persistent_sessions.py registration path)"
         )
 
-    persisted = metrics.get("persisted_sessions_total")
-    if persisted is None:
+    # persisted_sessions_total is kept for observability but NOT
+    # thresholded — high legitimate volume is healthy. Its absence still
+    # signals schema drift.
+    if metrics.get("persisted_sessions_total") is None:
         failures.append("metrics.persisted_sessions_total missing — schema drift")
-    elif persisted >= PERSISTED_SESSIONS_WARN_THRESHOLD:
+
+    # Prune-health: oldest session far past the TTL means expire_old()
+    # stalled. Absent on pre-0.7.1 deploys — skip rather than fail so a
+    # rollback doesn't false-alarm (mirrors the metrics-absent handling).
+    oldest = metrics.get("oldest_session_age_seconds")
+    if oldest is not None and oldest > SESSION_AGE_WARN_SECONDS:
+        oldest_days = oldest / 86400
         warnings.append(
-            f"metrics.persisted_sessions_total = {persisted} "
-            f"(>= {PERSISTED_SESSIONS_WARN_THRESHOLD}). Periodic prune runs "
-            f"every 6h since rc12, so this is steady-state count under the "
-            f"7-day TTL — investigate by lowering TTL or tightening the prune "
-            f"interval if the warning fires repeatedly."
+            f"metrics.oldest_session_age_seconds = {oldest} ({oldest_days:.1f}d) "
+            f"> {SESSION_AGE_WARN_SECONDS} ({SESSION_AGE_WARN_SECONDS / 86400:.1f}d). "
+            f"A session is surviving well past the 7-day TTL — the periodic "
+            f"expire_old() prune has likely stopped running; check the server's "
+            f"lifespan task group / logs."
         )
 
     print(f"OK: status={payload['status']}, metrics={json.dumps(metrics)}")

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/src/mnemon/persistent_sessions.py
+++ b/src/mnemon/persistent_sessions.py
@@ -160,6 +160,24 @@ class SessionStore:
             ).fetchone()
         return int(row[0]) if row else 0
 
+    def oldest_age_seconds(self) -> float:
+        """Age (seconds) of the least-recently-active persisted row, or 0.0.
+
+        This is the volume-INDEPENDENT prune-health signal. ``count()``
+        filters expired rows out, so it can never reveal a broken prune;
+        this looks at *all* rows. Under a working ``expire_old()`` nothing
+        survives past ``ttl_seconds`` (+ up to one prune interval), so this
+        stays bounded near the TTL regardless of session volume. If it
+        climbs well past the TTL, the periodic prune has stopped running.
+        """
+        with self._connect() as db:
+            row = db.execute(
+                "SELECT MIN(last_active_at) FROM mcp_transport_sessions"
+            ).fetchone()
+        if not row or row[0] is None:
+            return 0.0
+        return max(0.0, time.time() - float(row[0]))
+
 
 class _PersistingInstanceDict(dict[str, StreamableHTTPServerTransport]):
     """Dict subclass that ``register()``s every key on assignment.
@@ -266,6 +284,9 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
             **self._counters,
             "persisted_sessions_total": self._session_store.count(),
             "in_memory_sessions_current": len(self._server_instances),
+            # Volume-independent prune-health signal: bounded near the TTL
+            # while expire_old() runs, climbs only if the prune stalls.
+            "oldest_session_age_seconds": int(self._session_store.oldest_age_seconds()),
         }
 
     @contextlib.asynccontextmanager

--- a/tests/test_check_health.py
+++ b/tests/test_check_health.py
@@ -1,0 +1,96 @@
+"""Tests for scripts/check_health.py — the health-monitor checker.
+
+Loaded by path (it's a standalone script, not a package module) and
+driven with a stubbed ``fetch_health`` so no network is touched.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_PATH = Path(__file__).resolve().parents[1] / "scripts" / "check_health.py"
+_spec = importlib.util.spec_from_file_location("check_health", _PATH)
+check_health = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check_health)
+
+
+def _run_with(monkeypatch, payload):
+    monkeypatch.setattr(check_health, "fetch_health", lambda url, timeout=30.0: payload)
+    monkeypatch.setattr(check_health.sys, "argv", ["check_health.py"])
+    return check_health.main()
+
+
+def _healthy_metrics(**ov):
+    m = {
+        "in_memory_hits": 100,
+        "resume_hits": 0,
+        "fresh_inits": 10,
+        "stale_session_misses": 0,
+        "persisted_sessions_total": 12,
+        "in_memory_sessions_current": 8,
+        "oldest_session_age_seconds": 3600,  # 1h — well under TTL
+    }
+    m.update(ov)
+    return m
+
+
+def test_healthy_passes(monkeypatch):
+    rc = _run_with(monkeypatch, {"status": "ok", "metrics": _healthy_metrics()})
+    assert rc == 0
+
+
+def test_high_volume_no_longer_warns(monkeypatch, capsys):
+    # Issue #208 regression: a large persisted_sessions_total is healthy
+    # steady-state and must NOT trip the checker now.
+    rc = _run_with(
+        monkeypatch,
+        {"status": "ok", "metrics": _healthy_metrics(persisted_sessions_total=8327)},
+    )
+    assert rc == 0
+    assert "WARN" not in capsys.readouterr().out
+
+
+def test_stalled_prune_warns(monkeypatch, capsys):
+    # Oldest session well past TTL + grace → prune-stalled WARN (exit 2).
+    overdue = check_health.SESSION_AGE_WARN_SECONDS + 86400
+    rc = _run_with(
+        monkeypatch,
+        {"status": "ok", "metrics": _healthy_metrics(oldest_session_age_seconds=overdue)},
+    )
+    assert rc == 2
+    assert "prune" in capsys.readouterr().out.lower()
+
+
+def test_stale_session_misses_is_hard_failure(monkeypatch):
+    rc = _run_with(
+        monkeypatch,
+        {"status": "ok", "metrics": _healthy_metrics(stale_session_misses=3)},
+    )
+    assert rc == 1
+
+
+def test_status_not_ok_fails(monkeypatch):
+    rc = _run_with(monkeypatch, {"status": "degraded", "metrics": _healthy_metrics()})
+    assert rc == 1
+
+
+def test_missing_persisted_total_is_schema_drift(monkeypatch):
+    m = _healthy_metrics()
+    del m["persisted_sessions_total"]
+    rc = _run_with(monkeypatch, {"status": "ok", "metrics": m})
+    assert rc == 1
+
+
+def test_missing_oldest_age_is_tolerated(monkeypatch):
+    # Pre-0.7.1 deploys lack the new metric — must not false-alarm.
+    m = _healthy_metrics()
+    del m["oldest_session_age_seconds"]
+    rc = _run_with(monkeypatch, {"status": "ok", "metrics": m})
+    assert rc == 0
+
+
+def test_threshold_is_ttl_plus_two_prune_cycles():
+    assert check_health.SESSION_AGE_WARN_SECONDS == 7 * 24 * 3600 + 2 * 6 * 3600

--- a/tests/test_persistent_sessions.py
+++ b/tests/test_persistent_sessions.py
@@ -78,6 +78,28 @@ class TestSessionStore:
         # Sanity: the default isn't accidentally short.
         assert DEFAULT_TTL_SECONDS == 7 * 24 * 3600
 
+    def test_oldest_age_seconds_empty_is_zero(self, tmp_path):
+        store = SessionStore(tmp_path / "sessions.sqlite")
+        assert store.oldest_age_seconds() == 0.0
+
+    def test_oldest_age_seconds_tracks_least_recently_active(self, tmp_path):
+        store = SessionStore(tmp_path / "sessions.sqlite")
+        store.register("old")
+        time.sleep(0.5)
+        store.register("new")
+        age = store.oldest_age_seconds()
+        # Reflects the oldest row (the first register), so ≥ the gap.
+        assert age >= 0.5
+
+    def test_oldest_age_seconds_surfaces_unpruned_overdue_rows(self, tmp_path):
+        # The prune-health signal: a row past the TTL that expire_old()
+        # hasn't removed must show up here even though count() hides it.
+        store = SessionStore(tmp_path / "sessions.sqlite", ttl_seconds=1)
+        store.register("overdue")
+        time.sleep(1.1)
+        assert store.count() == 0  # expired → excluded from count()
+        assert store.oldest_age_seconds() > 1.0  # but still visible here
+
 
 # ---------------------------------------------------------------------------
 # _PersistingInstanceDict
@@ -283,6 +305,7 @@ class TestMetricsCounters:
         assert m["stale_session_misses"] == 0
         assert m["persisted_sessions_total"] == 0
         assert m["in_memory_sessions_current"] == 0
+        assert m["oldest_session_age_seconds"] == 0
 
     async def test_in_memory_hit_increments_counter(self, tmp_path, monkeypatch):
         manager = self._make_manager(tmp_path)


### PR DESCRIPTION
Closes #208.

## The false-positive

The health-monitor opened a tracking issue **every run**. The `/health` endpoint returns `status=ok` and `stale_session_misses=0` (the real regression signal is clean) — it only tripped because `persisted_sessions_total = 8327 >= 5000`.

That threshold is meaningless: `persisted_sessions_total` comes from `SessionStore.count()`, which filters `WHERE last_active_at > cutoff` — it counts **only non-expired sessions**. So it tracks legitimate session volume and **can never reveal a broken prune** (expired rows are excluded regardless of whether `expire_old()` ran). For an active user it sits permanently above 5000. Classic perpetual false-positive that masks real signals.

## The fix — threshold the actual failure mode

The real failure is the periodic `expire_old()` prune stalling, which lets rows survive past the 7-day TTL. New **volume-independent** signal:

- `SessionStore.oldest_age_seconds()` → age of the least-recently-active row across **all** rows (not filtered). Bounded near the TTL while prune runs; climbs only if it stalls. Exposed as `oldest_session_age_seconds` in `/health` metrics.
- Checker warns only if `oldest_session_age_seconds > TTL (7d) + 2 prune cycles (12h grace)` — fires precisely when the prune is genuinely stuck, never on volume.
- `persisted_sessions_total` kept for observability, **no longer thresholded**.

## Coverage

- `tests/test_check_health.py` — healthy passes; **high volume no longer warns** (the #208 regression guard); stalled prune warns (exit 2); `stale_session_misses` hard-fails; schema drift fails; pre-0.7.1 missing-metric tolerated.
- `oldest_age_seconds` store tests (empty→0, tracks oldest, surfaces overdue-but-unpruned rows that `count()` hides).
- **Suite 1119 → 1130 passing**, coverage gate held, builds `0.7.2`.

## Deploy note

The new metric needs the remote to serve it: after merge (publishes 0.7.2), `mnemon upgrade web --app-name mnemon-memory` so `/health` exposes `oldest_session_age_seconds`. The checker tolerates its absence in the meantime (won't false-alarm on the old server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)