### PR TITLE
fix: 0.7.3 — redeploy never silently rotates the OAuth AS passphrase (fail-closed guard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.7.3] - 2026-06-08
+
+### Fixed
+- **Redeploy could silently rotate a live OAuth AS passphrase (fail-open
+  guard).** The rc11 back-fill in `_redeploy_web` provisions the OAuth AS
+  only when `MNEMON_AS_PASSPHRASE` is absent from the Fly secret list, and
+  is meant to *never* rotate an existing passphrase (rotation invalidates
+  every issued token and breaks the operator's claude.ai/Desktop login).
+  But the absence check trusted `_fly_secret_names` unconditionally: if
+  flyctl's `secrets list --json` shape ever changed (e.g. the `Name` field
+  renamed), the parse would silently yield an empty/wrong set, the naive
+  `"MNEMON_AS_PASSPHRASE" not in secrets` check would pass, and the
+  redeploy would **rotate a live passphrase**. Made the guard fail-closed:
+  an existing Fly app always carries `MNEMON_LOCAL_TOKEN`, so it's now used
+  as a parse-sanity **sentinel** — the back-fill fires only on "sentinel
+  present AND AS absent." A parsed list missing the sentinel is treated as
+  an untrustworthy read: the passphrase is left untouched and a loud
+  `WARNING` is emitted to stderr instead of silently rotating. Every other
+  read failure (list call fails → `None`) already skipped. Coverage:
+  `tests/test_upgrade.py::TestRedeployASBackfill` (new regression guard
+  that a renamed-`Name`/empty-set read does NOT provision and DOES warn).
+
 ## [0.7.2] - 2026-06-07
 
 ### Fixed

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"

--- a/src/mnemon/upgrade.py
+++ b/src/mnemon/upgrade.py
@@ -612,20 +612,49 @@ def _redeploy_web(
     """
     # Back-fill the OAuth AS if this app predates auto-provisioning (rc10).
     # Cross-device (claude.ai/Desktop) is the default path, so a redeploy
-    # of an older app should gain the browser-auth AS too. Only act when
-    # we can confirm the secret is ABSENT — if the list call fails
-    # (None) or the passphrase already exists, leave it alone (never
-    # rotate an existing passphrase: that invalidates issued tokens).
+    # of an older app should gain the browser-auth AS too.
+    #
+    # FAIL-CLOSED on the never-rotate invariant: provisioning generates a
+    # FRESH passphrase that invalidates every issued token (and breaks the
+    # operator's claude.ai/Desktop login), so we must act ONLY on a
+    # POSITIVELY confirmed absence — never on an ambiguous read. A read can
+    # lie two ways: (1) the list call fails → _fly_secret_names returns
+    # None; (2) flyctl's `--json` shape changes (e.g. the `Name` field is
+    # renamed) → the parse silently yields an empty / wrong set. Case (2)
+    # is the dangerous one: an empty set passes a naive `"AS" not in set`
+    # check and triggers a rotation.
+    #
+    # Guard: an existing Fly app ALWAYS carries MNEMON_LOCAL_TOKEN (set at
+    # first-time deploy), so we use it as a parse-sanity SENTINEL. Only
+    # "sentinel present AND AS absent" is a confirmed back-fill. If the
+    # list parsed but the sentinel is missing, the read is untrustworthy —
+    # WARN loudly and leave the passphrase untouched rather than silently
+    # rotate a live credential.
     newly_provisioned_passphrase: str | None = None
     existing_secrets = _fly_secret_names(app_name)
-    if existing_secrets is not None and "MNEMON_AS_PASSPHRASE" not in existing_secrets:
-        newly_provisioned_passphrase = secrets.token_urlsafe(32)
-        _fly_set_as_secrets(
-            app_name,
-            newly_provisioned_passphrase,
-            f"https://{app_name}.fly.dev",
-        )
-        _persist_as_passphrase(newly_provisioned_passphrase)
+    if existing_secrets is not None:
+        if "MNEMON_LOCAL_TOKEN" not in existing_secrets:
+            # No sentinel in a parsed secret list — impossible for a real
+            # deployed app. flyctl's output shape likely changed; do NOT
+            # provision (it would rotate a live passphrase and break every
+            # connected client).
+            print(
+                "WARNING: could not confirm existing Fly secrets for "
+                f"'{app_name}' — the parse-sanity sentinel MNEMON_LOCAL_TOKEN "
+                "is missing from the secret list (flyctl's --json output shape "
+                "may have changed). Leaving the OAuth AS passphrase UNTOUCHED "
+                "to avoid invalidating issued tokens. If claude.ai/Desktop "
+                "auth is not yet provisioned, set MNEMON_AS_* manually.",
+                file=sys.stderr,
+            )
+        elif "MNEMON_AS_PASSPHRASE" not in existing_secrets:
+            newly_provisioned_passphrase = secrets.token_urlsafe(32)
+            _fly_set_as_secrets(
+                app_name,
+                newly_provisioned_passphrase,
+                f"https://{app_name}.fly.dev",
+            )
+            _persist_as_passphrase(newly_provisioned_passphrase)
 
     with tempfile.TemporaryDirectory(prefix="mnemon-redeploy-") as tdir:
         workdir = Path(tdir)

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -590,6 +590,28 @@ class TestRedeployASBackfill:
             )
         mock_set_as.assert_not_called()
 
+    def test_redeploy_does_not_rotate_when_sentinel_absent(self, capsys):
+        """Fail-closed: if the secret list parses but the MNEMON_LOCAL_TOKEN
+        sentinel is missing (e.g. flyctl renamed its `--json` `Name` field, so
+        the parse silently yields a wrong/empty set), the back-fill must NOT
+        fire — provisioning would rotate a live passphrase and break every
+        connected client. The naive `"AS" not in secrets` guard would mis-fire
+        here; the sentinel gate must catch it and WARN."""
+        with patch("mnemon.upgrade._fly_secret_names", return_value=set()), \
+            patch("mnemon.upgrade._fly_set_as_secrets") as mock_set_as, \
+            patch("mnemon.upgrade._persist_as_passphrase") as mock_persist, \
+            patch("mnemon.upgrade._fly_deploy"), \
+            patch("mnemon.upgrade._settle_after_deploy"):
+            result = upgrade._redeploy_web(
+                app_name="app", region="sjc",
+                mnemon_version="0.7.0rc11", skip_doctor=True,
+            )
+        mock_set_as.assert_not_called()
+        mock_persist.assert_not_called()
+        assert "newly enabled" not in result
+        # Fail-loud: the anomalous read is surfaced, not swallowed.
+        assert "MNEMON_LOCAL_TOKEN" in capsys.readouterr().err
+
 
 # ── _fly_app_exists detection ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

Found while diagnosing why Brian's Claude Desktop connector passphrase stopped working: the **first** post-rc10 redeploy of a pre-rc10 Fly app provisions a fresh OAuth AS passphrase (the intended `absent → present` back-fill). That part is correct and one-time. But the guard that's supposed to **never rotate an existing** passphrase is *fail-open*.

`_redeploy_web` back-fills the AS only when `MNEMON_AS_PASSPHRASE` is absent from the Fly secret list:

```python
existing_secrets = _fly_secret_names(app_name)
if existing_secrets is not None and "MNEMON_AS_PASSPHRASE" not in existing_secrets:
    # generate fresh passphrase + rotate
```

The safety rests entirely on `_fly_secret_names` *correctly seeing* the existing secret. But it parses `flyctl secrets list --json` and returns `{r.get("Name") for r in rows ...}`. If a future flyctl renames the `Name` JSON field (or changes the shape), the parse silently returns an **empty set** — not `None`. An empty set sails through the guard (`is not None` → True, `"AS" not in set()` → True) and **rotates a live passphrase**, invalidating every issued token and breaking every connected claude.ai/Desktop/mobile client. Rotation is precisely the outcome this guard exists to prevent.

## Fix (fail-closed)

An existing Fly app **always** carries `MNEMON_LOCAL_TOKEN` (set at first-time deploy), so use it as a parse-sanity **sentinel**:

- **sentinel present AND AS absent** → confirmed back-fill, provision (unchanged behavior).
- **sentinel present AND AS present** → skip (unchanged).
- **list unreadable (`None`)** → skip (unchanged).
- **parsed list missing the sentinel** → untrustworthy read (renamed field / partial output / perms). **Leave the passphrase untouched and emit a loud `WARNING` to stderr** instead of silently rotating.

Now every failure mode falls to "don't act" — the passphrase is never rotated unless we *prove* it's genuinely missing on a known-good read. Composes with the no-silent-fails posture (fail loud, fail closed).

## Tests

`tests/test_upgrade.py::TestRedeployASBackfill` — new regression guard `test_redeploy_does_not_rotate_when_sentinel_absent`: a renamed-`Name`/empty-set read does **not** provision and **does** warn. The naive guard would mis-fire here. Existing 6 back-fill tests unchanged and green (one already used `{"MNEMON_LOCAL_TOKEN"}` as the present set, so it doubles as the sentinel-present happy path).

- Suite: **1127 passed**, 4 integration deselected
- Coverage: **89.99%** (gate 88%)
- Bump `0.7.2 → 0.7.3` + CHANGELOG entry

## Operator note

This does **not** change Brian's live app — its `MNEMON_AS_PASSPHRASE` already exists, so the existing guard already skips on redeploy. The fix closes the *latent* fail-open hole against a future flyctl output-shape change. The current passphrase remains the one in `~/.mnemon/as_passphrase`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)