### PR TITLE
docs: one-time OAuth passphrase re-auth when upgrading a pre-rc10 web deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ pip install -U 'mnemon-memory[server]'
 mnemon upgrade web --app-name my-mnemon
 ```
 
+> **Upgrading from a pre-0.7.0rc10 deployment? Re-auth your browser connectors once.** Apps deployed before the OAuth Authorization Server was auto-provisioned only ever had the headless bearer token. The first `upgrade web` on such an app **provisions a brand-new OAuth passphrase** (and enables the AS) — so your existing claude.ai / Desktop / mobile connector login stops working until you re-authenticate. Grab the new passphrase from the deploy summary or `~/.mnemon/as_passphrase` and re-enter it on the connector's login page. This is a **one-time** transition: once the passphrase exists, every later redeploy leaves it untouched (it is never rotated). Headless clients (Claude Code, Cursor) are unaffected — they keep their bearer token.
+
 ### Downgrade back to local
 
 ```bash


### PR DESCRIPTION
## What

Documents the one-time OAuth passphrase re-auth that the **legitimate** rc10 back-fill triggers — the docs half of the audit finding whose code half shipped in #211 (0.7.3 fail-closed guard).

## Why

Apps deployed before the OAuth AS was auto-provisioned (pre-0.7.0rc10) only ever had the headless bearer token. The first `upgrade web` on such an app provisions a brand-new OAuth passphrase and enables the AS — so the operator's existing claude.ai / Desktop / mobile connector login stops working until they re-auth. That transition was undocumented: you hit a silent "passphrase rejected" wall with no explanation. (This is exactly how Brian's Desktop connector "broke" — the diagnosis that kicked off this whole thread.)

## The callout

Added to the README "Upgrade to a newer version (already on web)" section:

> **Upgrading from a pre-0.7.0rc10 deployment? Re-auth your browser connectors once.** … The first `upgrade web` provisions a brand-new OAuth passphrase … grab it from the deploy summary or `~/.mnemon/as_passphrase` and re-enter it on the connector's login page. One-time: once the passphrase exists, every later redeploy leaves it untouched. Headless clients are unaffected.

## Scope

Docs-only — no version bump (0.7.3 already published; no tests reference README). Pairs with the 0.7.3 code fix (#211) that guarantees the "later redeploy leaves it untouched" promise is fail-closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)