### PR TITLE
fix(deploy): suspend (not stop) idle Fly machine so OAuth refresh survives wake

### DIFF
--- a/fly.toml.example
+++ b/fly.toml.example
@@ -24,7 +24,13 @@ primary_region = "sjc"                # pick one close to you: fly platform regi
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = "stop"
+  # "suspend" (not "stop") so an idle machine snapshots RAM and resumes in
+  # ~1s instead of cold-booting. The self-hosted OAuth AS (/oauth/token) runs
+  # on this same machine, so a slow cold boot after idle makes a connector's
+  # token refresh on wake (e.g. Claude Desktop after the host reboots) time
+  # out and drop to "disconnected", forcing a full re-auth. Suspend-resume
+  # stays under the client timeout so the connection persists.
+  auto_stop_machines = "suspend"
   auto_start_machines = true
   min_machines_running = 0
 

--- a/src/mnemon/upgrade.py
+++ b/src/mnemon/upgrade.py
@@ -161,7 +161,14 @@ primary_region = "{region}"
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = "stop"
+  # "suspend" (not "stop") so an idle machine snapshots RAM and resumes in
+  # ~1s instead of cold-booting. Critical because the self-hosted OAuth AS
+  # (/oauth/token) runs on this same machine: a cold boot after idle is slow
+  # enough that a connector's token refresh on wake (e.g. Claude Desktop
+  # after the host reboots overnight) times out and the connector drops to
+  # "disconnected", forcing a full passphrase re-auth. A ~1s suspend-resume
+  # keeps refresh under the client timeout so the connection persists.
+  auto_stop_machines = "suspend"
   auto_start_machines = true
   min_machines_running = 0
 


### PR DESCRIPTION
## Problem

Claude Desktop's mnemon connector drops to **disconnected** after the host computer reboots — and stays disconnected, forcing a full passphrase re-login (the tell: 17 DCR client registrations piled up on the live AS from repeated re-auths).

## Root cause

The self-hosted OAuth Authorization Server (`/oauth/token`), introduced in rc10/rc11 (#197/#198) when we dropped Auth0, runs on the **same Fly machine** as the MCP server. That machine is configured `auto_stop_machines = "stop"` + `min_machines_running = 0`, so it fully stops when idle.

Sequence: host off overnight → no traffic → machine autostops → host back on → Desktop's 1-hour access token has expired → it silently POSTs `/oauth/token` to refresh → the request hits a **cold-booting** machine → boot is slow enough that the refresh times out → connector marked disconnected → full re-auth.

Previously (Auth0) the token endpoint was always-on, so refresh-on-wake always worked. The regression came in with the self-hosted AS migration.

Server-side token/key state is healthy and already persists on the volume (signing key stable, refresh tokens survive restarts) — this is purely cold-start latency on the auth endpoint.

## Fix

Switch the generated `fly.toml` (`upgrade.py` template) and `fly.toml.example` from `auto_stop_machines = "stop"` to `"suspend"`. A suspended machine snapshots RAM and resumes in ~1s instead of cold-booting, keeping the refresh under the client timeout so the connection persists across host reboots. Cost savings of autostop are retained (suspended machines aren't billed for CPU).

## Live state

The running `mnemon-memory` machine was **already flipped to suspend** via `fly machine update 1781e5e6f33018 --autostop=suspend` (verified: `autostop per service: ['suspend']`), so the fix is live now. This PR makes it **durable** across future `mnemon upgrade web` redeploys, which regenerate `fly.toml` from the `upgrade.py` template and would otherwise revert it to `"stop"`.

## Test

`pytest tests/test_upgrade.py` — 57 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)