### PR TITLE
release: 0.7.4 — publish the Fly suspend-on-idle fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.7.4] - 2026-06-10
+
+### Fixed
+- **Self-hosted web deploys now `suspend` an idle Fly machine instead of
+  `stop`, so a connector survives the host going to sleep.** The
+  self-hosted OAuth AS (`/oauth/token`) introduced in rc10/rc11 runs on the
+  same Fly machine as the MCP server. With `auto_stop_machines = "stop"` an
+  idle machine cold-boots on wake, which is slow enough that a connector's
+  silent token refresh after the operator's host reboots (e.g. Claude
+  Desktop after an overnight shutdown) times out — dropping the connector
+  to "disconnected" and forcing a full passphrase re-auth (observed as
+  repeated DCR client registrations piling up). Switching the generated
+  `fly.toml` (and `fly.toml.example`) to `auto_stop_machines = "suspend"`
+  snapshots RAM and resumes in ~1s, keeping refresh under the client
+  timeout so the connection persists. Server-side token/key state already
+  persisted on the volume; this only addresses cold-start latency on the
+  auth endpoint. Existing deployments can apply the fix without a redeploy
+  via `fly machine update <id> --autostop=suspend`.
+
 ## [0.7.3] - 2026-06-08
 
 ### Fixed

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"


### PR DESCRIPTION
## Why

PR #213 switched the generated `fly.toml` / `fly.toml.example` to `auto_stop_machines = "suspend"` (fixing the Claude Desktop connector dropping on host reboot), but **did not bump the version**. The auto-publish ran with `skip-existing`, saw 0.7.3 already on PyPI, and skipped — so the suspend template is on `main` but **not in any installable PyPI release**.

`mnemon upgrade web` generates `fly.toml` from the `_FLY_TOML_TEMPLATE` in the locally-running `upgrade.py`. If that CLI is ever resolved from PyPI (rather than an editable checkout), it would still emit `"stop"` and silently reintroduce the bug.

## What

- Bump `__version__` 0.7.3 → 0.7.4 (single-sourced in `src/mnemon/__init__.py`).
- CHANGELOG entry documenting the suspend fix + the no-redeploy remediation (`fly machine update <id> --autostop=suspend`).

No code changes beyond the version bump — the template fix already landed in #213. This release just makes it reach PyPI so the fix is durable across all `upgrade web` invocations.

## Test

- `pytest tests/test_upgrade.py` — 57 passed (in #213).
- Version-flag tests reference `__version__` dynamically — green.
- The two `test_mnemon_ops.py::TestChangelogExtract` failures observed locally are a pre-existing **environment** issue (the shell test hardcodes `/opt/homebrew/opt/python@3.14/bin/python`, absent on this machine) — they fail identically on unmodified `main` and pass in CI's clean env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)