### PR TITLE
fix: 0.7.5 — session prune survives Fly suspend (issue #215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [0.7.5] - 2026-06-11
+
+### Fixed
+- **Session prune now fires on a wall-clock cadence, so it survives the
+  suspend-on-idle Fly machine (regression from 0.7.4).** The expired-MCP-
+  session prune was driven solely by an event-loop interval timer
+  (`await anyio.sleep(6h)` in `_run_periodic_expire`). When 0.7.4 switched
+  the idle machine to `auto_stop_machines = "suspend"`, that clock began
+  freezing during suspension: on a `min_machines_running = 0` deploy the
+  machine is suspended most of the day, so the 6h timer only advanced
+  during *awake* time and `expire_old()` fired far less often than every
+  6h of wall-clock. Rows survived past the 7-day TTL and
+  `oldest_session_age_seconds` climbed 1:1 with real time — the
+  health-monitor's prune-health check (added 0.7.1) caught it and went
+  red (issue #215). Added a request-path prune (`_maybe_prune`, called at
+  the top of `_handle_stateful_request`) gated on `time.time()` plus an
+  in-memory `_last_prune_ts` — both of which survive a RAM snapshot — so
+  the first request after the expire interval has elapsed prunes once,
+  bounding the oldest row near the TTL on every machine wake regardless of
+  how long it was suspended. The periodic timer is retained for long warm
+  uptimes and now stamps `_last_prune_ts` to coordinate with the
+  request-path prune. The prune is a single indexed `DELETE`, gated to at
+  most once per `expire_interval_seconds`, and its failures are logged and
+  swallowed so a transient SQLite hiccup can't fail the client request it
+  rides on.
+
 ## [0.7.4] - 2026-06-10
 
 ### Fixed

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.4"
+__version__ = "0.7.5"

--- a/src/mnemon/persistent_sessions.py
+++ b/src/mnemon/persistent_sessions.py
@@ -254,6 +254,19 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
         # sessions table otherwise grows monotonically until the next
         # restart.
         self._expire_interval_seconds = expire_interval_seconds
+        # Wall-clock timestamp of the last expire_old() (periodic OR
+        # request-path). The periodic task above relies on the event-loop
+        # clock, which FREEZES while a Fly machine is suspended
+        # (auto_stop_machines = "suspend", min_machines_running = 0): a 6h
+        # anyio.sleep only advances during awake time, so on a scale-to-
+        # zero deploy the prune fires far less often than every 6h of
+        # WALL-CLOCK time and rows survive past the TTL (issue #215). The
+        # request-path prune (_maybe_prune, called from
+        # _handle_stateful_request) is gated on this real-clock timestamp
+        # instead, so every machine wake bounds the oldest row near the
+        # TTL regardless of suspension. 0.0 → the first request after a
+        # cold boot prunes immediately.
+        self._last_prune_ts: float = 0.0
         # Decay sweep is opt-in via an injected callable so this module
         # doesn't import Store directly — keeps the session-management
         # layer decoupled from the memory-vault layer. server_remote.py
@@ -326,6 +339,9 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
             except Exception:  # noqa: BLE001
                 logger.exception("Periodic session prune raised; retrying next tick")
                 continue
+            # Coordinate with the request-path prune so the next request
+            # after a timer tick doesn't redundantly re-prune.
+            self._last_prune_ts = time.time()
             if expired:
                 logger.info(
                     "Periodic prune: removed %d expired MCP session(s)",
@@ -361,12 +377,45 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
                     updated,
                 )
 
+    def _maybe_prune(self) -> None:
+        """Wall-clock-gated prune, run synchronously on the request path.
+
+        Companion to the event-loop-timer prune (_run_periodic_expire),
+        which is unreliable on a suspend-on-idle Fly machine because the
+        monotonic clock freezes during suspension. This path keys off
+        ``time.time()`` (real wall-clock, survives the RAM snapshot) and
+        an in-memory ``_last_prune_ts`` (also survives suspend/resume),
+        so the first request after the expire interval has elapsed prunes
+        once — bounding ``oldest_session_age_seconds`` near the TTL on
+        every wake regardless of how long the machine was suspended.
+
+        Cheap: a single indexed DELETE, gated to at most once per
+        ``_expire_interval_seconds``. Failures are logged and swallowed —
+        a transient SQLite hiccup must not fail the client request it's
+        riding on; the next request retries. ``_expire_interval_seconds
+        <= 0`` disables it (mirrors the periodic-task opt-out).
+        """
+        if self._expire_interval_seconds <= 0:
+            return
+        now = time.time()
+        if now - self._last_prune_ts < self._expire_interval_seconds:
+            return
+        self._last_prune_ts = now
+        try:
+            expired = self._session_store.expire_old()
+        except Exception:  # noqa: BLE001
+            logger.exception("Request-path session prune raised; retrying next request")
+            return
+        if expired:
+            logger.info("Request-path prune: removed %d expired MCP session(s)", expired)
+
     async def _handle_stateful_request(
         self,
         scope: Scope,
         receive: Receive,
         send: Send,
     ) -> None:
+        self._maybe_prune()
         request = Request(scope, receive)
         session_id = request.headers.get(MCP_SESSION_ID_HEADER)
 

--- a/tests/test_persistent_sessions.py
+++ b/tests/test_persistent_sessions.py
@@ -526,6 +526,164 @@ class TestPeriodicExpireTask:
 
 
 # ---------------------------------------------------------------------------
+# Request-path prune (_maybe_prune) — the suspend-robust companion to the
+# periodic task. Keyed on wall-clock time.time() + an in-memory timestamp,
+# so it fires on machine wake even when the event-loop timer froze under a
+# Fly suspend (issue #215). Gated to once per expire_interval_seconds.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+class TestRequestPathPrune:
+    @pytest.fixture
+    def anyio_backend(self):
+        return "asyncio"
+
+    @staticmethod
+    def _make_manager(tmp_path, *, expire_interval_seconds=3600):
+        store = SessionStore(tmp_path / "sessions.sqlite")
+        return PersistentSessionManager(
+            app=MagicMock(name="mcp_server"),
+            session_store=store,
+            expire_interval_seconds=expire_interval_seconds,
+        )
+
+    @staticmethod
+    def _scope(session_id: bytes | None):
+        headers = []
+        if session_id is not None:
+            headers.append((b"mcp-session-id", session_id))
+        return {"type": "http", "method": "POST", "path": "/mcp", "headers": headers}
+
+    @staticmethod
+    async def _noop_receive():  # pragma: no cover — never invoked
+        return {"type": "http.disconnect"}
+
+    @staticmethod
+    async def _noop_send(_):  # pragma: no cover — never invoked
+        pass
+
+    async def _drive_stale_request(self, manager, monkeypatch):
+        """Send one request through _handle_stateful_request (stale-id
+        branch, the cheapest) so _maybe_prune runs at the top."""
+
+        async def fake_super(self, scope, receive, send):  # noqa: ANN001
+            pass
+
+        monkeypatch.setattr(
+            "mnemon.persistent_sessions.StreamableHTTPSessionManager."
+            "_handle_stateful_request",
+            fake_super,
+        )
+        await manager._handle_stateful_request(
+            self._scope(b"phantom"), self._noop_receive, self._noop_send
+        )
+
+    async def test_first_request_prunes_immediately(self, tmp_path, monkeypatch):
+        """_last_prune_ts starts at 0.0, so the first request after a cold
+        boot always prunes — the cold-boot-then-suspend case."""
+        manager = self._make_manager(tmp_path)
+        calls: list[None] = []
+        original = manager._session_store.expire_old
+        monkeypatch.setattr(
+            manager._session_store,
+            "expire_old",
+            lambda: (calls.append(None), original())[1],
+        )
+        await self._drive_stale_request(manager, monkeypatch)
+        assert len(calls) == 1
+
+    async def test_second_request_within_interval_is_gated(
+        self, tmp_path, monkeypatch
+    ):
+        """A 6h-interval deploy must not prune on every request — only the
+        first one past the interval boundary."""
+        manager = self._make_manager(tmp_path, expire_interval_seconds=3600)
+        calls: list[None] = []
+        original = manager._session_store.expire_old
+        monkeypatch.setattr(
+            manager._session_store,
+            "expire_old",
+            lambda: (calls.append(None), original())[1],
+        )
+        await self._drive_stale_request(manager, monkeypatch)  # prunes (ts was 0)
+        await self._drive_stale_request(manager, monkeypatch)  # gated
+        assert len(calls) == 1
+
+    async def test_request_after_interval_prunes_again(self, tmp_path, monkeypatch):
+        """Advance wall-clock past the interval → the next request prunes."""
+        import mnemon.persistent_sessions as mod
+
+        manager = self._make_manager(tmp_path, expire_interval_seconds=3600)
+        calls: list[None] = []
+        original = manager._session_store.expire_old
+        monkeypatch.setattr(
+            manager._session_store,
+            "expire_old",
+            lambda: (calls.append(None), original())[1],
+        )
+        clock = {"t": 1_000_000.0}
+        monkeypatch.setattr(mod.time, "time", lambda: clock["t"])
+
+        await self._drive_stale_request(manager, monkeypatch)  # prunes (ts was 0)
+        clock["t"] += 1800  # half an interval — still gated
+        await self._drive_stale_request(manager, monkeypatch)
+        clock["t"] += 1801  # now past 3600s since the first prune
+        await self._drive_stale_request(manager, monkeypatch)
+        assert len(calls) == 2
+
+    async def test_zero_interval_disables_request_path_prune(
+        self, tmp_path, monkeypatch
+    ):
+        manager = self._make_manager(tmp_path, expire_interval_seconds=0)
+        calls: list[None] = []
+        monkeypatch.setattr(
+            manager._session_store,
+            "expire_old",
+            lambda: calls.append(None),
+        )
+        await self._drive_stale_request(manager, monkeypatch)
+        assert calls == []
+
+    async def test_request_path_removes_overdue_row_without_periodic_task(
+        self, tmp_path, monkeypatch
+    ):
+        """The issue #215 scenario end-to-end: the periodic timer never
+        ran (suspended machine), a row is past the TTL, and a single
+        request prunes it — bounding oldest_session_age_seconds."""
+        store = SessionStore(tmp_path / "sessions.sqlite", ttl_seconds=1)
+        store.register("overdue")
+        time.sleep(1.1)
+        assert store.oldest_age_seconds() > 1.0  # survives, prune hasn't run
+        manager = PersistentSessionManager(
+            app=MagicMock(name="mcp_server"),
+            session_store=store,
+            expire_interval_seconds=3600,
+        )
+        await self._drive_stale_request(manager, monkeypatch)
+        assert store.oldest_age_seconds() == 0.0  # row gone
+
+    async def test_request_path_prune_swallows_errors(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """A transient SQLite hiccup in the prune must not fail the client
+        request riding on it."""
+        manager = self._make_manager(tmp_path)
+        monkeypatch.setattr(
+            manager._session_store,
+            "expire_old",
+            MagicMock(side_effect=RuntimeError("disk on fire")),
+        )
+        with caplog.at_level("ERROR", logger="mnemon.persistent_sessions"):
+            await self._drive_stale_request(manager, monkeypatch)  # must not raise
+        assert manager.metrics()["stale_session_misses"] == 1  # request still served
+        assert any(
+            "Request-path session prune raised" in rec.message
+            for rec in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
 # Periodic memory-decay sweep — wired alongside the prune task in run().
 # Runs apply_confidence_decay() on the vault every decay_interval_seconds
 # in a worker thread. Failures swallowed; counts logged when nonzero.


### PR DESCRIPTION
## What & why

The hourly **Health Monitor** went red today (run 27341777375, 10:52 UTC; tracking issue #215). Not a false positive — the server is healthy (`status: ok`, `stale_session_misses: 0`); the tripped check was prune-health:

```
oldest_session_age_seconds = 649615 (7.5d) > 648000 threshold
```

Live it's **657997 (7.6d) and climbing 1:1 with wall-clock** — the periodic `expire_old()` prune is not running.

**Root cause — regression from #214 (0.7.4).** That PR switched the idle Fly machine to `auto_stop_machines = "suspend"` (to keep the OAuth AS warm across wake). But the prune is an event-loop interval timer — `await anyio.sleep(6h)` in `_run_periodic_expire`. Under **suspend** the VM RAM is snapshotted and the event-loop clock freezes; a resume never re-runs the lifespan. With `min_machines_running = 0` the machine is suspended most of the day, so the 6h timer only advances during *awake* time and `expire_old()` fires far less often than every 6h of wall-clock → rows survive past the 7-day TTL.

## The fix

An event-loop interval timer is the wrong mechanism on a scale-to-zero / suspend-on-idle machine. Added a **wall-clock-gated request-path prune** (`_maybe_prune`, called at the top of `_handle_stateful_request`):

- gated on `time.time()` (real wall-clock) + an in-memory `_last_prune_ts` — **both survive the RAM snapshot**, so the first request after the expire interval has elapsed prunes once, bounding the oldest row near the TTL on **every machine wake** regardless of suspension duration;
- the periodic timer is **retained** for long warm uptimes and now stamps `_last_prune_ts` to coordinate (no redundant back-to-back prune);
- a single indexed `DELETE`, gated to once per `expire_interval_seconds`; failures logged + swallowed so a transient SQLite hiccup can't fail the client request it rides on;
- `expire_interval_seconds <= 0` disables it, mirroring the periodic opt-out.

No health-check threshold change — this fixes the root cause, not the symptom.

## Tests

- 6 new regression tests in `TestRequestPathPrune` (first-request prune, interval gating, re-prune after interval, zero-interval disable, **end-to-end issue-#215 scenario** (overdue row pruned with the periodic task never running), error-swallow).
- Full suite green: **1137 passed**.

## Deploy / aftermath note

Code-only — picked up on the next `mnemon upgrade web` redeploy (publishes 0.7.5 first, per the publish-before-redeploy gotcha). Once deployed, the first `/mcp` request prunes the stuck row and the next hourly Health Monitor run goes green, **auto-closing #215**. The currently-suspended live machine won't self-heal until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)