### PR TITLE
fix: 0.7.6 — decay sweep survives Fly suspend, no longer silent (#217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [0.7.6] - 2026-06-11
+
+### Fixed
+- **Confidence-decay sweep now fires on a wall-clock cadence, so it
+  survives the suspend-on-idle Fly machine — and is no longer silent
+  (issue #217).** Same root cause as the 0.7.5 session-prune fix: the
+  periodic decay task (`_run_periodic_decay`, 24h) is an event-loop
+  interval timer, and that clock freezes while the Fly machine is
+  suspended (`auto_stop_machines = "suspend"`, `min_machines_running =
+  0`), so on the web tier decay effectively stopped running — degrading
+  scoring quality with **no red signal**, because (unlike the prune)
+  nothing on `/health` tracked it. Added a request-path decay trigger
+  (`_maybe_decay`, called from `_handle_stateful_request`) gated on
+  `time.time()` + an in-memory `_last_decay_ts` (both survive a RAM
+  snapshot). Because `apply_confidence_decay` walks the full vault
+  (slow, blocking SQL), the sweep is **not** run inline — it's spawned
+  onto the lifespan task group to run in a worker thread without blocking
+  the client request. `_last_decay_ts` initializes to construction time
+  (not `0.0`), so decay runs ~once per interval rather than re-walking
+  the vault on every cold boot; a suspend longer than the interval still
+  trips the gate on the next request. The periodic timer is retained for
+  warm uptimes and stamps `_last_decay_ts` to coordinate.
+- **`/health` now exposes `seconds_since_last_decay`** (emitted only when
+  decay is wired — the web server, not stdio). `scripts/check_health.py`
+  soft-warns (exit 2) when it exceeds the 24h interval + 12h grace, so a
+  stalled decay surfaces on the Health Monitor instead of failing
+  silently. Absence is tolerated (decay-disabled or pre-0.7.6 servers).
+
 ## [0.7.5] - 2026-06-11
 
 ### Fixed

--- a/scripts/check_health.py
+++ b/scripts/check_health.py
@@ -42,6 +42,17 @@ _TTL_SECONDS = 7 * 24 * 3600              # DEFAULT_TTL_SECONDS
 _PRUNE_INTERVAL_SECONDS = 6 * 3600        # DEFAULT_EXPIRE_INTERVAL_SECONDS
 SESSION_AGE_WARN_SECONDS = _TTL_SECONDS + 2 * _PRUNE_INTERVAL_SECONDS
 
+# Decay-health threshold. Mirrors the prune signal for the confidence-
+# decay sweep, which shares the suspend-freeze hazard (issue #217): its
+# periodic event-loop timer stalls while a Fly machine is suspended, so
+# the request-path trigger (_maybe_decay) keeps seconds_since_last_decay
+# bounded under the interval on a trafficked deploy. We warn at interval
+# + 12h grace so a single skipped cycle (or a brief traffic lull) doesn't
+# trip it. Absence of the metric is tolerated below (decay-disabled
+# deploy or pre-0.7.6 server) — not a failure.
+_DECAY_INTERVAL_SECONDS = 24 * 3600       # DEFAULT_DECAY_INTERVAL_SECONDS
+DECAY_AGE_WARN_SECONDS = _DECAY_INTERVAL_SECONDS + 12 * 3600
+
 
 def fetch_health(url: str, timeout: float = 30.0) -> dict:
     # 30s tolerates a Fly cold-start (machine wake + Python boot + bge-small
@@ -110,6 +121,23 @@ def main() -> int:
             f"A session is surviving well past the 7-day TTL — the periodic "
             f"expire_old() prune has likely stopped running; check the server's "
             f"lifespan task group / logs."
+        )
+
+    # Decay-health: seconds_since_last_decay climbing past the interval
+    # means BOTH the periodic timer and the request-path trigger have
+    # stalled — the suspend-freeze failure mode of issue #217. Absent on
+    # decay-disabled deploys (stdio) and pre-0.7.6 servers — skip rather
+    # than fail, mirroring the oldest-age handling.
+    since_decay = metrics.get("seconds_since_last_decay")
+    if since_decay is not None and since_decay > DECAY_AGE_WARN_SECONDS:
+        since_hours = since_decay / 3600
+        warnings.append(
+            f"metrics.seconds_since_last_decay = {since_decay} ({since_hours:.1f}h) "
+            f"> {DECAY_AGE_WARN_SECONDS} ({DECAY_AGE_WARN_SECONDS / 3600:.1f}h). "
+            f"Confidence decay has not run within the interval — the periodic "
+            f"sweep has likely stalled (e.g. an idle suspended machine) and no "
+            f"request has triggered the request-path fallback; check the "
+            f"server's lifespan task group / logs."
         )
 
     print(f"OK: status={payload['status']}, metrics={json.dumps(metrics)}")

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"

--- a/src/mnemon/persistent_sessions.py
+++ b/src/mnemon/persistent_sessions.py
@@ -273,6 +273,19 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
         # passes a closure that opens its own thread-local Store.
         self._decay_fn = decay_fn
         self._decay_interval_seconds = decay_interval_seconds
+        # Wall-clock timestamp of the last decay sweep (periodic OR
+        # request-path). Same suspend hazard as _last_prune_ts: the
+        # periodic decay timer freezes while the Fly machine is suspended
+        # (issue #217), so the request-path trigger (_maybe_decay) gates
+        # on this real-clock timestamp instead. Initialized to the
+        # construction wall-clock — NOT 0.0 — so decay runs ~once per
+        # interval rather than walking the full vault on every cold boot:
+        # unlike the prune (which must fire on each wake to bound the
+        # TTL), a missed decay cycle is cheap, so there's no value in
+        # re-decaying immediately after every deploy/wake. A suspend
+        # longer than the interval still trips the gate on the next
+        # request, which is the failure mode #217 is about.
+        self._last_decay_ts: float = time.time()
         # Process-lifetime counters scraped via /health for cold-stop diagnosis.
         # Single-event-loop server, so plain ints are race-free without a Lock.
         # NOTE: scripts/check_health.py reads these key names directly. If you
@@ -293,7 +306,7 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
         surface. ``resume_hits`` counts the cold-stop recovery path firing.
         Persistent across process lifetime; resets on cold-stop.
         """
-        return {
+        m: dict[str, int] = {
             **self._counters,
             "persisted_sessions_total": self._session_store.count(),
             "in_memory_sessions_current": len(self._server_instances),
@@ -301,6 +314,18 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
             # while expire_old() runs, climbs only if the prune stalls.
             "oldest_session_age_seconds": int(self._session_store.oldest_age_seconds()),
         }
+        # Decay-health signal — emitted ONLY when the decay sweep is wired
+        # (the web server passes decay_fn; stdio does not, and would have
+        # no sweep to reset it). Seconds since decay was last TRIGGERED
+        # (periodic timer OR request-path _maybe_decay). Bounded under the
+        # interval while either path fires; climbs only if BOTH stall —
+        # i.e. the suspend-freeze failure mode of issue #217, which was
+        # previously silent. check_health.py soft-warns (exit 2) when it
+        # exceeds the interval + grace. Its ABSENCE is tolerated (decay-
+        # disabled deploy / older server) — NOT treated as schema drift.
+        if self._decay_fn is not None:
+            m["seconds_since_last_decay"] = int(time.time() - self._last_decay_ts)
+        return m
 
     @contextlib.asynccontextmanager
     async def run(self) -> AsyncIterator[None]:
@@ -366,6 +391,9 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
         assert self._decay_fn is not None
         while True:
             await anyio.sleep(self._decay_interval_seconds)
+            # Coordinate with the request-path decay so the next request
+            # after a timer tick doesn't redundantly re-sweep the vault.
+            self._last_decay_ts = time.time()
             try:
                 updated = await anyio.to_thread.run_sync(self._decay_fn)
             except Exception:  # noqa: BLE001
@@ -409,6 +437,50 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
         if expired:
             logger.info("Request-path prune: removed %d expired MCP session(s)", expired)
 
+    def _maybe_decay(self) -> None:
+        """Wall-clock-gated decay trigger on the request path — the
+        suspend-robust companion to _run_periodic_decay, whose event-loop
+        timer freezes while a Fly machine is suspended (issue #217). Gated
+        on ``time.time()`` + the in-memory ``_last_decay_ts`` (both survive
+        a RAM snapshot), so the first request after the decay interval has
+        elapsed fires one sweep regardless of suspension.
+
+        Unlike _maybe_prune, the sweep is NOT run inline:
+        ``apply_confidence_decay`` walks the full vault (slow, blocking
+        SQL), so it's spawned onto the lifespan task group to run in a
+        worker thread (_run_request_path_decay) without blocking the
+        client request it rides on. The gate is stamped synchronously
+        BEFORE spawning so concurrent requests in the same interval fire
+        at most one sweep (single event loop → the check-and-set can't
+        interleave). Disabled when decay isn't wired or the interval <= 0.
+        """
+        if self._decay_fn is None or self._decay_interval_seconds <= 0:
+            return
+        if self._task_group is None:
+            # Lifespan not started yet (e.g. a request races startup);
+            # the periodic task covers warm uptime once run() spawns it.
+            return
+        now = time.time()
+        if now - self._last_decay_ts < self._decay_interval_seconds:
+            return
+        self._last_decay_ts = now
+        self._task_group.start_soon(self._run_request_path_decay)
+
+    async def _run_request_path_decay(self) -> None:
+        """The decay sweep spawned by :meth:`_maybe_decay`, run in a
+        worker thread off the request's event-loop task. Mirrors the body
+        of _run_periodic_decay; failures are logged and swallowed so a
+        transient SQLite hiccup can't crash the spawning task group.
+        """
+        assert self._decay_fn is not None
+        try:
+            updated = await anyio.to_thread.run_sync(self._decay_fn)
+        except Exception:  # noqa: BLE001
+            logger.exception("Request-path memory decay raised; retrying next interval")
+            return
+        if updated:
+            logger.info("Request-path decay: aged %d memory document(s)", updated)
+
     async def _handle_stateful_request(
         self,
         scope: Scope,
@@ -416,6 +488,7 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
         send: Send,
     ) -> None:
         self._maybe_prune()
+        self._maybe_decay()
         request = Request(scope, receive)
         session_id = request.headers.get(MCP_SESSION_ID_HEADER)
 

--- a/tests/test_check_health.py
+++ b/tests/test_check_health.py
@@ -94,3 +94,34 @@ def test_missing_oldest_age_is_tolerated(monkeypatch):
 
 def test_threshold_is_ttl_plus_two_prune_cycles():
     assert check_health.SESSION_AGE_WARN_SECONDS == 7 * 24 * 3600 + 2 * 6 * 3600
+
+
+def test_fresh_decay_age_passes(monkeypatch):
+    # A recently-run decay sweep is healthy and must not warn.
+    rc = _run_with(
+        monkeypatch,
+        {"status": "ok", "metrics": _healthy_metrics(seconds_since_last_decay=3600)},
+    )
+    assert rc == 0
+
+
+def test_stalled_decay_warns(monkeypatch, capsys):
+    # Decay not run within the interval + grace → decay-stalled WARN (exit 2).
+    overdue = check_health.DECAY_AGE_WARN_SECONDS + 3600
+    rc = _run_with(
+        monkeypatch,
+        {"status": "ok", "metrics": _healthy_metrics(seconds_since_last_decay=overdue)},
+    )
+    assert rc == 2
+    assert "decay" in capsys.readouterr().out.lower()
+
+
+def test_missing_decay_age_is_tolerated(monkeypatch):
+    # Decay-disabled deploys (stdio) and pre-0.7.6 servers lack the metric —
+    # absence must not false-alarm (the default _healthy_metrics omits it).
+    rc = _run_with(monkeypatch, {"status": "ok", "metrics": _healthy_metrics()})
+    assert rc == 0
+
+
+def test_decay_threshold_is_interval_plus_grace():
+    assert check_health.DECAY_AGE_WARN_SECONDS == 24 * 3600 + 12 * 3600

--- a/tests/test_persistent_sessions.py
+++ b/tests/test_persistent_sessions.py
@@ -834,6 +834,130 @@ class TestPeriodicDecayTask:
 
 
 # ---------------------------------------------------------------------------
+# Request-path decay (_maybe_decay) — the suspend-robust companion to the
+# periodic decay timer (issue #217). Wall-clock-gated; spawns the sweep onto
+# the lifespan task group so the full-vault walk doesn't block the request.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+class TestRequestPathDecay:
+    @pytest.fixture
+    def anyio_backend(self):
+        return "asyncio"
+
+    @staticmethod
+    def _make_manager(tmp_path, *, decay_fn=lambda: 0, decay_interval_seconds=3600):
+        store = SessionStore(tmp_path / "sessions.sqlite")
+        return PersistentSessionManager(
+            app=MagicMock(name="mcp_server"),
+            session_store=store,
+            decay_fn=decay_fn,
+            decay_interval_seconds=decay_interval_seconds,
+        )
+
+    def test_last_decay_ts_inits_to_construction_time_not_zero(self, tmp_path):
+        """Unlike the prune (_last_prune_ts = 0.0 → prune on first request),
+        decay inits to wall-clock now so it does NOT walk the full vault on
+        every cold boot — only once the interval has elapsed."""
+        manager = self._make_manager(tmp_path)
+        assert manager._last_decay_ts > 0.0
+
+    def test_fires_after_interval_elapsed(self, tmp_path):
+        manager = self._make_manager(tmp_path, decay_interval_seconds=3600)
+        manager._task_group = MagicMock(name="task_group")
+        manager._last_decay_ts = 0.0  # far in the past → gate open
+        manager._maybe_decay()
+        manager._task_group.start_soon.assert_called_once_with(
+            manager._run_request_path_decay
+        )
+
+    def test_gated_within_interval(self, tmp_path):
+        """Fresh manager (_last_decay_ts ≈ now) must not fire."""
+        manager = self._make_manager(tmp_path, decay_interval_seconds=3600)
+        manager._task_group = MagicMock(name="task_group")
+        manager._maybe_decay()
+        manager._task_group.start_soon.assert_not_called()
+
+    def test_stamps_before_spawn_so_concurrent_requests_fire_once(self, tmp_path):
+        manager = self._make_manager(tmp_path, decay_interval_seconds=3600)
+        manager._task_group = MagicMock(name="task_group")
+        manager._last_decay_ts = 0.0
+        manager._maybe_decay()  # fires + stamps _last_decay_ts ≈ now
+        manager._maybe_decay()  # gated by the fresh stamp
+        assert manager._task_group.start_soon.call_count == 1
+
+    def test_disabled_when_decay_fn_none(self, tmp_path):
+        manager = self._make_manager(tmp_path, decay_fn=None)
+        manager._task_group = MagicMock(name="task_group")
+        manager._last_decay_ts = 0.0
+        manager._maybe_decay()
+        manager._task_group.start_soon.assert_not_called()
+
+    def test_disabled_when_interval_zero(self, tmp_path):
+        manager = self._make_manager(tmp_path, decay_interval_seconds=0)
+        manager._task_group = MagicMock(name="task_group")
+        manager._last_decay_ts = 0.0
+        manager._maybe_decay()
+        manager._task_group.start_soon.assert_not_called()
+
+    def test_noop_when_task_group_not_started(self, tmp_path):
+        """A request racing lifespan startup must not crash."""
+        manager = self._make_manager(tmp_path)
+        manager._task_group = None
+        manager._last_decay_ts = 0.0
+        manager._maybe_decay()  # must not raise
+
+    async def test_spawned_sweep_runs_decay_through_real_task_group(self, tmp_path):
+        """End-to-end: the gate spawns onto a real anyio task group and the
+        sweep actually executes (in a worker thread) before the group exits."""
+        import anyio
+
+        calls: list[int] = []
+        manager = self._make_manager(
+            tmp_path,
+            decay_fn=lambda: (calls.append(1), 5)[1],
+            decay_interval_seconds=3600,
+        )
+        manager._last_decay_ts = 0.0
+        async with anyio.create_task_group() as tg:
+            manager._task_group = tg
+            manager._maybe_decay()
+        assert calls == [1]
+
+    async def test_run_request_path_decay_logs_count(self, tmp_path, caplog):
+        manager = self._make_manager(tmp_path, decay_fn=lambda: 4)
+        with caplog.at_level("INFO", logger="mnemon.persistent_sessions"):
+            await manager._run_request_path_decay()
+        assert any(
+            "Request-path decay" in rec.message and "4 memory" in rec.message
+            for rec in caplog.records
+        )
+
+    async def test_run_request_path_decay_swallows_errors(self, tmp_path, caplog):
+        def _boom():
+            raise RuntimeError("disk on fire")
+
+        manager = self._make_manager(tmp_path, decay_fn=_boom)
+        with caplog.at_level("ERROR", logger="mnemon.persistent_sessions"):
+            await manager._run_request_path_decay()  # must not raise
+        assert any(
+            "Request-path memory decay raised" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_metrics_emits_decay_age_only_when_decay_wired(self, tmp_path):
+        with_decay = self._make_manager(tmp_path, decay_fn=lambda: 0)
+        assert "seconds_since_last_decay" in with_decay.metrics()
+        without = PersistentSessionManager(
+            app=MagicMock(name="mcp_server"),
+            session_store=SessionStore(tmp_path / "s2.sqlite"),
+            decay_fn=None,
+        )
+        assert "seconds_since_last_decay" not in without.metrics()
+
+
+# ---------------------------------------------------------------------------
 # Narrow-lock contract — _session_creation_lock must be released BEFORE
 # transport.handle_request is awaited, so a wedged handler can't block
 # subsequent fresh-init / resume requests from acquiring the lock


### PR DESCRIPTION
Closes #217.

## What & why

Same bug class as #215 / PR #216 (0.7.5), the latent half I flagged when fixing the prune. The periodic **confidence-decay** sweep (`_run_periodic_decay`, 24h, active on the web tier via `server_remote.py` `decay_fn=_decay_sweep`) is an event-loop interval timer (`await anyio.sleep`), and that clock **freezes while the Fly machine is suspended** (`auto_stop_machines = "suspend"`, `min_machines_running = 0`). So on a scale-to-zero deploy decay effectively stopped running — and **unlike the prune, nothing on `/health` tracked it, so it failed silently**: scoring quality degrades with no red signal.

## The fix

- **Request-path decay trigger** — `_maybe_decay()`, called from `_handle_stateful_request` (right after `_maybe_prune`), gated on `time.time()` + an in-memory `_last_decay_ts` (both survive the RAM snapshot). Mirrors the prune's wall-clock pattern.
- **Spawned, not inline** — `apply_confidence_decay` walks the full vault (slow, blocking SQL), so unlike the prune's single DELETE it must not run on the request's own task. `_maybe_decay` stamps the gate synchronously (so concurrent requests fire at most one sweep), then `start_soon`s `_run_request_path_decay` onto the lifespan task group → runs in a worker thread via `anyio.to_thread`, no request blocking.
- **`_last_decay_ts` inits to construction time, not `0.0`** — deliberately different from the prune. The prune must fire on every wake to bound the TTL; decay is cheap-to-miss daily hygiene, so we don't want a full-vault walk on every cold boot. A suspend longer than the interval still trips the gate on the next request (the #217 failure mode).
- **Periodic timer retained** for warm uptimes; now stamps `_last_decay_ts` to coordinate (no redundant back-to-back sweep).
- **De-silenced** — `/health` now exposes `seconds_since_last_decay` (emitted only when decay is wired — web, not stdio). `check_health.py` soft-warns (exit 2) past `24h interval + 12h grace`, so a stalled decay shows up on the Health Monitor the way the prune stall did. Absence tolerated (decay-disabled / pre-0.7.6 servers), mirroring the `oldest_session_age` handling.

## Tests

- 11 new `TestRequestPathDecay` tests: construction-time init, gate fires/gated/stamps-once, disabled (no decay_fn / interval 0 / task group not started), **end-to-end spawn through a real anyio task group**, sweep logs count, error-swallow, metric emitted only when wired.
- 4 new `check_health` tests: fresh-decay passes, stalled-decay warns, absence tolerated, threshold constant.
- Full suite green: **1152 passed**.

## Deploy / aftermath

Code-only — picked up on the next `mnemon upgrade web` redeploy (publishes 0.7.6 first). After deploy, the first MCP request past the interval triggers a sweep and `/health` starts reporting `seconds_since_last_decay`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)