### PR TITLE
feat: 0.7.7 — prose supersession auto-detect + examples/bench remote-mode fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.7.7] - 2026-06-11
+
+### Added
+- **`memory_save` auto-detects prose supersession.** When `correction_of`
+  is omitted but the saved content explicitly states it supersedes a
+  specific id (`supersedes id N` / `supersedes #N`, including the
+  motivating "Supersedes the partial financial framings in id 2402"
+  form), the `'supersedes'` relation is now recorded automatically. It is
+  additive and safe: it WARNs (never silent), tolerates a non-existent id
+  (the save still succeeds, unlike the explicit param which raises), and
+  the detection is clause-local + bounded so cross-clause mentions
+  ("supersedes the old way; see id 5") don't false-link. Pass
+  `correction_of` explicitly to opt out of the scan. (The explicit param
+  always takes precedence.)
+
+### Fixed
+- **`examples/quickstart.py` and `bench/search_stress.py` run again on a
+  machine with a remote vault configured.** Both create an isolated
+  throwaway local vault but predated the remote-mode `Store` guard, so
+  they crashed with `LocalVaultInaccessibleError` whenever a remote was
+  set (i.e. on any dev machine that had run `mnemon upgrade web`). They
+  now set `MNEMON_ALLOW_LOCAL_STORE=1` — the sanctioned escape hatch for
+  a deliberately-isolated local vault. Fresh users (no remote) were
+  unaffected.
+
 ## [0.7.6] - 2026-06-11
 
 ### Fixed

--- a/bench/search_stress.py
+++ b/bench/search_stress.py
@@ -30,6 +30,10 @@ from pathlib import Path
 # before importing Store.
 EXAMPLE_VAULT = Path(tempfile.mkdtemp(prefix="mnemon-bench-"))
 os.environ["MNEMON_VAULT_DIR"] = str(EXAMPLE_VAULT)
+# A configured remote vault otherwise makes Store refuse to open ANY local
+# vault (the fail-loud remote-mode guard). This script deliberately uses an
+# isolated throwaway local vault — the sanctioned use of the escape hatch.
+os.environ["MNEMON_ALLOW_LOCAL_STORE"] = "1"
 
 from mnemon.search import search  # noqa: E402
 from mnemon.store import Store, _sha256  # noqa: E402

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -26,6 +26,10 @@ from pathlib import Path
 # user's real ~/.mnemon. This must be set BEFORE importing Store.
 EXAMPLE_VAULT = Path(tempfile.mkdtemp(prefix="mnemon-quickstart-"))
 os.environ["MNEMON_VAULT_DIR"] = str(EXAMPLE_VAULT)
+# A configured remote vault otherwise makes Store refuse to open ANY local
+# vault (the fail-loud remote-mode guard). This script deliberately uses an
+# isolated throwaway local vault — the sanctioned use of the escape hatch.
+os.environ["MNEMON_ALLOW_LOCAL_STORE"] = "1"
 
 from mnemon.search import search  # noqa: E402
 from mnemon.store import Store  # noqa: E402

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.6"
+__version__ = "0.7.7"

--- a/src/mnemon/store.py
+++ b/src/mnemon/store.py
@@ -8,7 +8,9 @@ Vectors stored in a companion .npz file (brute-force cosine search).
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
+import re
 import sqlite3
 import time
 import uuid
@@ -149,8 +151,42 @@ class RelatedDocument(Document):
     weight: float = 0.0
 
 
+logger = logging.getLogger("mnemon.store")
+
+
 def _sha256(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()
+
+
+# Prose-detected supersession: recognise an EXPLICIT "supersedes … id N"
+# / "supersedes #N" (also "superseded …") in saved content so the chain
+# can be recorded even when the caller forgot the correction_of param.
+# This is the non-LLM analogue of Mem0's UPDATE intent-detection (an LLM
+# intent classifier could be a future opt-in, composing with the
+# --judge anthropic pattern). See ROADMAP "memory_save auto-`supersedes`
+# from prose".
+#
+# The motivating real case had words between the verb and the id
+# ("Supersedes the partial financial framings in id 2402"), so the gap is
+# allowed — but bounded (≤50 chars) and clause-local: the gap excludes
+# sentence/clause punctuation (.;:) so "supersedes the old way; see id 5"
+# does NOT link to id 5. Either an "[words] id [#]N" gap or a direct "#N"
+# is accepted. Precision-first: when in doubt it does nothing (the caller
+# can always pass correction_of explicitly).
+_PROSE_SUPERSEDES_RE = re.compile(
+    r"\bsupersede(?:s|d)?\s+(?:[^.;:\n]{0,50}?\bid\s+#?|#)(\d+)\b",
+    re.IGNORECASE,
+)
+
+
+def _detect_prose_supersedes(content: str) -> int | None:
+    """Return the first explicitly-named superseded doc id, or None.
+
+    Returns the first match; multiple targets aren't expressible via the
+    single-valued ``correction_of`` param.
+    """
+    m = _PROSE_SUPERSEDES_RE.search(content)
+    return int(m.group(1)) if m else None
 
 
 def _row_to_document(row: sqlite3.Row) -> Document:
@@ -467,6 +503,12 @@ class Store:
         an operator may legitimately mark a new memory as superseding
         an already-forgotten one to record the chain. The relation is
         the audit trail.
+
+        If ``correction_of`` is omitted but ``content`` explicitly states
+        ``supersedes id N`` / ``supersedes #N``, it is auto-resolved to
+        ``correction_of`` (with a WARN, and tolerating a non-existent id
+        rather than raising). Pass ``correction_of`` explicitly to opt out
+        of the prose scan.
         """
         content_hash = _sha256(content)
         ct = ContentType(content_type)
@@ -474,6 +516,39 @@ class Store:
         conf = confidence if confidence is not None else DEFAULT_CONFIDENCE[ct]
         if source_client in HOOK_SOURCE_CLIENTS:
             conf = min(conf, HOOK_SOURCE_CONFIDENCE_CEILING)
+
+        # Prose-detected supersession (additive, non-breaking). When the
+        # caller did NOT pass correction_of but the content explicitly says
+        # "supersedes id N" / "supersedes #N", resolve it to correction_of
+        # so the chain is recorded — flowing through the same machinery
+        # below (relation insert + capture-attention skip). Two deliberate
+        # departures from the explicit param: (1) WARN (never silent), so
+        # the auto-link is visible per [[feedback_no_silent_fails]] — this
+        # is what makes prose-detection safe vs the rejected "hidden
+        # auto-insert"; (2) do NOT hard-fail on a non-existent id — the
+        # caller didn't request it, so a stray prose mention must not break
+        # an otherwise-valid save (the explicit param still raises below).
+        if correction_of is None:
+            detected = _detect_prose_supersedes(content)
+            if detected is not None:
+                target_exists = self.db.execute(
+                    "SELECT 1 FROM documents WHERE id = ?", (detected,),
+                ).fetchone()
+                if target_exists is not None:
+                    correction_of = detected
+                    logger.warning(
+                        "save: auto-detected supersession of id %d from "
+                        "content prose; recording a 'supersedes' relation. "
+                        "Pass correction_of=%d explicitly to silence this.",
+                        detected, detected,
+                    )
+                else:
+                    logger.warning(
+                        "save: content prose claims it supersedes id %d, but "
+                        "no such document exists — NOT recording a relation "
+                        "(the save proceeds normally).",
+                        detected,
+                    )
 
         # Validate correction_of target exists before we commit anything.
         # Fail loud rather than insert a dangling relation downstream.
@@ -626,8 +701,7 @@ class Store:
                     source_client=source_client,
                 )
             except CaptureAttentionUnavailableError as exc:
-                import logging
-                logging.getLogger("mnemon.store").warning(
+                logger.warning(
                     "save: capture-attention skipped for doc_id=%d (%s); "
                     "memory is saved but recurrence-boost was not applied",
                     doc_id, exc,

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -364,6 +364,82 @@ class TestCorrectionOf:
         mock_apply.assert_not_called()
 
 
+class TestProseSupersedes:
+    """ROADMAP 'memory_save auto-`supersedes` from prose': when the caller
+    omits correction_of but the content explicitly states it supersedes a
+    specific id, auto-record the relation (additive, WARN, never raise on a
+    bad id). The motivating case is the very prose this codifies —
+    'Supersedes the partial financial framings in id 2402' (#2543)."""
+
+    def test_detect_helper_canonical_and_motivating_forms(self):
+        from mnemon.store import _detect_prose_supersedes as d
+        assert d("supersedes id 42") == 42
+        assert d("Supersedes #42 entirely") == 42
+        assert d("superseded ID 42") == 42
+        # The motivating real case — words between verb and id.
+        assert d("Supersedes the partial financial framings in id 2402") == 2402
+
+    def test_detect_helper_rejects_cross_clause_and_nonmatches(self):
+        from mnemon.store import _detect_prose_supersedes as d
+        # Clause boundary (;) between verb and id → not a supersession link.
+        assert d("supersedes the old way; for context see id 5") is None
+        # "id-based" has no numeric id; plain mentions don't match.
+        assert d("supersedes the need for id-based lookups") is None
+        assert d("a normal note with id 5 mentioned") is None
+        assert d("") is None
+
+    def test_prose_supersedes_inserts_relation(self, store):
+        prior = store.save(title="Old framing", content="old content")
+        new = store.save(
+            title="Corrected", content=f"New authoritative take. Supersedes id {prior}.",
+        )
+        related = store.get_related(new)
+        supersedes = [r for r in related if r.relation_type == "supersedes"]
+        assert len(supersedes) == 1
+        assert supersedes[0].id == prior
+
+    def test_explicit_correction_of_takes_precedence_over_prose(self, store):
+        # When both are present, the explicit param wins; the prose scan
+        # must not double-insert or override.
+        a = store.save(title="A", content="a")
+        b = store.save(title="B", content="b")
+        new = store.save(
+            title="C", content=f"supersedes id {a}", correction_of=b,
+        )
+        rows = store.db.execute(
+            "SELECT target_id FROM relations WHERE source_id = ? "
+            "AND relation_type = 'supersedes'",
+            (new,),
+        ).fetchall()
+        assert [r["target_id"] for r in rows] == [b]
+
+    def test_prose_supersedes_missing_id_does_not_raise(self, store, caplog):
+        # Unlike explicit correction_of, a prose mention of a non-existent
+        # id must NOT break the save — just WARN and skip the relation.
+        with caplog.at_level("WARNING", logger="mnemon.store"):
+            new = store.save(title="N", content="supersedes id 999999")
+        rows = store.db.execute(
+            "SELECT 1 FROM relations WHERE source_id = ?", (new,),
+        ).fetchall()
+        assert rows == []  # no dangling relation
+        assert any("no such document exists" in r.message for r in caplog.records)
+
+    def test_prose_supersedes_warns_on_autolink(self, store, caplog):
+        prior = store.save(title="P", content="p")
+        with caplog.at_level("WARNING", logger="mnemon.store"):
+            store.save(title="N", content=f"supersedes id {prior}")
+        assert any("auto-detected supersession" in r.message for r in caplog.records)
+
+    def test_prose_supersedes_skips_capture_attention(self, store, monkeypatch):
+        # Resolving to correction_of must inherit its capture-attention skip.
+        from mnemon import config
+        monkeypatch.setattr(config, "CAPTURE_ATTENTION_ENABLED", True)
+        prior = store.save(title="P", content="payload")
+        with patch.object(store, "apply_capture_attention") as mock_apply:
+            store.save(title="N", content=f"new payload, supersedes id {prior}")
+        mock_apply.assert_not_called()
+
+
 class TestFindClusters:
     """Phase C — vector-similarity cluster discovery for operator-
     reviewed consolidation. Embedding-only, no LLM dep."""


### PR DESCRIPTION
Part of the "four green-light" batch. Verifying against live code first showed **3 of the 4 were already built** (examples dir, search benchmark, vault-derived auto-exemplars) — so this PR is the genuinely-new package work, plus a regression fix on the two pre-built scripts.

## Added — `memory_save` auto-detects prose supersession
When `correction_of` is omitted but the saved content explicitly states it supersedes a specific id, the `'supersedes'` relation is now recorded automatically — closing the gap the `correction_of` param left (the motivating case was #2543 saved with prose *"Supersedes the partial financial framings in id 2402"*, which inserted no relation).

Design (SOTA-aligned, non-LLM analogue of Mem0's UPDATE intent-detection):
- **Additive + safe:** WARNs (never silent — addresses the "hidden behavior" concern), and **tolerates a non-existent id** (the save still succeeds, unlike the explicit param which raises — a stray prose mention must not break a valid save).
- **Precision-first matching:** recognises `supersedes id N` / `supersedes #N` / `superseded id N`, allows intervening words (so the motivating case matches) but is **clause-local + bounded** (≤50 chars, stops at `.;:`) so `"supersedes the old way; see id 5"` does **not** false-link.
- **Explicit `correction_of` always wins** (no double-insert / override).

## Fixed — examples + bench run again under remote mode
`examples/quickstart.py` and `bench/search_stress.py` create an isolated throwaway local vault but predated the remote-mode `Store` guard (#190), so they crashed with `LocalVaultInaccessibleError` on any machine that had run `mnemon upgrade web`. Both now set `MNEMON_ALLOW_LOCAL_STORE=1` — the sanctioned escape hatch for a deliberately-isolated vault. (Fresh users were unaffected.)

## Tests
- 7 new `TestProseSupersedes` (helper canonical/motivating/cross-clause cases; relation insert; explicit-param precedence; non-existent-id-no-raise; WARN; capture-attention skip).
- Full suite **1159 green** (the 7 `test_integration_remote`/`test_tools_integration` cases that error here only do so because the sandbox blocks their socket bind — they pass outside it).

## Deploy
Patch (no rc). The `store.py` change is server-side, so it goes live on the next `mnemon upgrade web --mnemon-version 0.7.7` after merge.

> Companion: the `mnemon-ops` private repo (4th green light) and the `examples`/`bench`/`auto-exemplars` ROADMAP reconciliation are handled outside this PR (separate private repo / local docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)