### PR TITLE
fix: 0.7.8 — /health triggers the gated prune so an idle deploy stops false-warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.7.8] - 2026-06-15
+
+### Fixed
+- **`/health` no longer false-warns on an idle suspend-on-idle deploy.** The
+  request-path prune (`_maybe_prune`) only runs on real MCP traffic, but
+  `/health` is served by the auth middleware and bypasses that path — so on a
+  low-traffic Fly deploy the only guaranteed hourly request (the health probe
+  itself) never bounded the metric it reports. `oldest_session_age_seconds`
+  drifted past the TTL between real requests overnight, soft-tripping
+  `check_health.py`'s prune-health warn (exit 2 → red run + tracker issue)
+  even though the prune was perfectly healthy and self-heals the instant any
+  real request arrives. The endpoint now reads through a new
+  `PersistentSessionManager.health_snapshot()` that triggers the gated,
+  cheap, error-swallowing prune before snapshotting: the hourly probe now
+  guarantees a prune-trigger ≤ one expire interval, bounding
+  `oldest_session_age_seconds` at TTL + interval, and the reported value is
+  post-prune (`/health` never advertises a session the server would already
+  have removed). `metrics()` itself stays a pure read for every other caller.
+
 ## [0.7.7] - 2026-06-11
 
 ### Added

--- a/src/mnemon/__init__.py
+++ b/src/mnemon/__init__.py
@@ -1,3 +1,3 @@
 """mnemon — Universal long-term memory layer for AI agents via MCP."""
 
-__version__ = "0.7.7"
+__version__ = "0.7.8"

--- a/src/mnemon/persistent_sessions.py
+++ b/src/mnemon/persistent_sessions.py
@@ -327,6 +327,32 @@ class PersistentSessionManager(StreamableHTTPSessionManager):
             m["seconds_since_last_decay"] = int(time.time() - self._last_decay_ts)
         return m
 
+    def health_snapshot(self) -> dict[str, int]:
+        """``metrics()`` for the /health endpoint, with a prune triggered first.
+
+        The request-path prune (:meth:`_maybe_prune`) only runs inside
+        ``_handle_stateful_request`` — i.e. on real MCP traffic. ``/health``
+        is served by the auth middleware and bypasses that path, so on a
+        low-traffic suspend-on-idle deploy the only guaranteed hourly
+        request (the health probe itself) never bounded the very metric it
+        reports. ``oldest_session_age_seconds`` then drifted up past the TTL
+        between real requests overnight, false-tripping check_health.py's
+        soft warn even though the prune was perfectly healthy (it self-heals
+        the instant any real request arrives).
+
+        Reading the snapshot through a prune fixes that structurally: the
+        hourly probe now guarantees a prune-trigger ≤ one interval, bounding
+        ``oldest_session_age_seconds`` at TTL + interval, and the reported
+        value is post-prune — /health never advertises a session the server
+        would already have removed. The prune is the same gated, cheap,
+        error-swallowing DELETE the request path uses (≤ once per
+        ``expire_interval_seconds``), so it is safe to ride on the liveness
+        endpoint. ``metrics()`` itself stays a pure read for every other
+        caller.
+        """
+        self._maybe_prune()
+        return self.metrics()
+
     @contextlib.asynccontextmanager
     async def run(self) -> AsyncIterator[None]:
         """Lifespan wrapper that adds a periodic ``expire_old()`` task.

--- a/src/mnemon/server_remote.py
+++ b/src/mnemon/server_remote.py
@@ -225,6 +225,9 @@ def run_remote() -> None:
         mcp_app,
         config,
         as_config=as_config,
-        metrics_provider=mcp._session_manager.metrics,
+        # health_snapshot (not metrics) so the hourly /health probe
+        # triggers the gated request-path prune and reports a post-prune
+        # oldest_session_age_seconds — see PersistentSessionManager.health_snapshot.
+        metrics_provider=mcp._session_manager.health_snapshot,
     )
     uvicorn.run(wrapped, host="0.0.0.0", port=PORT, log_level="info")

--- a/tests/test_persistent_sessions.py
+++ b/tests/test_persistent_sessions.py
@@ -684,6 +684,51 @@ class TestRequestPathPrune:
 
 
 # ---------------------------------------------------------------------------
+# health_snapshot() — the /health entry point. Triggers the gated
+# request-path prune BEFORE snapshotting so the hourly probe bounds
+# oldest_session_age_seconds even with no real MCP traffic (the false-warn
+# fixed here). metrics() itself stays a pure read.
+# ---------------------------------------------------------------------------
+
+
+class TestHealthSnapshot:
+    @staticmethod
+    def _make_manager(tmp_path, *, ttl_seconds=1, expire_interval_seconds=3600):
+        store = SessionStore(tmp_path / "sessions.sqlite", ttl_seconds=ttl_seconds)
+        return PersistentSessionManager(
+            app=MagicMock(name="mcp_server"),
+            session_store=store,
+            expire_interval_seconds=expire_interval_seconds,
+        )
+
+    def test_health_snapshot_prunes_overdue_row_without_real_traffic(self, tmp_path):
+        """The reported failure: an idle suspend-on-idle deploy where the only
+        hourly request is the /health probe. health_snapshot() must prune the
+        overdue row so oldest_session_age_seconds reads bounded (0 here)."""
+        manager = self._make_manager(tmp_path)
+        manager._session_store.register("overdue")
+        time.sleep(1.1)  # age past the 1s TTL
+        assert manager._session_store.oldest_age_seconds() > 1.0  # not yet pruned
+        snap = manager.health_snapshot()
+        assert snap["oldest_session_age_seconds"] == 0  # pruned during the probe
+
+    def test_metrics_stays_a_pure_read(self, tmp_path):
+        """metrics() must NOT prune — only health_snapshot() does. Guards the
+        separation so non-/health callers keep a side-effect-free snapshot."""
+        manager = self._make_manager(tmp_path)
+        manager._session_store.register("overdue")
+        time.sleep(1.1)
+        assert manager.metrics()["oldest_session_age_seconds"] >= 1  # untouched
+        assert manager._session_store.oldest_age_seconds() > 1.0  # still present
+
+    def test_health_snapshot_returns_same_keys_as_metrics(self, tmp_path):
+        """health_snapshot is metrics-after-prune — identical schema, so
+        check_health.py reads the same fields regardless of which is wired."""
+        manager = self._make_manager(tmp_path)
+        assert set(manager.health_snapshot()) == set(manager.metrics())
+
+
+# ---------------------------------------------------------------------------
 # Periodic memory-decay sweep — wired alongside the prune task in run().
 # Runs apply_confidence_decay() on the vault every decay_interval_seconds
 # in a worker thread. Failures swallowed; counts logged when nonzero.


### PR DESCRIPTION
## What

Fixes the recurring **mnemon health-monitor false positive** (latest: tracker issue #221, run at 12:36 UTC 2026-06-15).

## Diagnosis

The 12:36 failure was a soft WARN (exit 2), not a hard failure — `oldest_session_age_seconds` = 652342 (**7.6d**) vs the 7.5d warn line; `stale_session_misses` was **0** throughout. It already self-healed: by the next manual probe `oldest_session_age` was back to 6.94d after a real MCP request triggered the prune.

Root cause is the same class as the old #208/#117 false positives — a warn threshold too tight for a suspend-on-idle deploy:

- The request-path prune (`_maybe_prune`) only runs inside `_handle_stateful_request`, i.e. on **real MCP traffic**.
- `/health` is served by the auth middleware and **bypasses that path**, so the only guaranteed hourly request (the health probe) never bounded the very metric it reports.
- Overnight, between real requests, `oldest_session_age` drifts up from ~7.0d past the 7.5d warn (TTL + 2×6h). The math checks out: `seconds_since_last_decay`=16.2h ⇒ last prune-triggering request ~16h ago ⇒ 7.0d + 16h ≈ 7.6d.

## Fix

`/health` now reads through a new `PersistentSessionManager.health_snapshot()` that triggers the gated, cheap, error-swallowing prune **before** snapshotting. The hourly probe now guarantees a prune-trigger ≤ one expire interval, bounding `oldest_session_age_seconds` at TTL + interval (~7.25d), and the reported value is post-prune — `/health` never advertises a session the server would already have removed. `metrics()` itself stays a pure read for every other caller. Kills the false-positive class structurally rather than loosening the threshold.

## Tests

- New `TestHealthSnapshot` (3 tests): probe prunes an overdue row with no real traffic; `metrics()` stays a pure read; schema parity with `metrics()`.
- Full suite green locally: **1162 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
