### PR TITLE
docs: correct CLAUDE.md — private/ is the mnemon-ops repo, not local-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,12 @@ open work + the pre-deploy ritual.
    bump "Last verified". Confirmed milestones only, no speculation.
 3. **Memories** — save durable cross-session facts/decisions/feedback.
 
-`private/` is gitignored — these doc edits are local-only (no commit);
-the git history of code + `CHANGELOG.md` is the durable audit trail.
+`private/` is gitignored from THIS repo but is its own nested git repo
+(`private/.git`) pushed to `cipher813/mnemon-ops` (private). So the
+wind-down doc edits above MUST be committed + pushed there — they are
+NOT local-only: `cd private && git add -A && git commit && git push
+origin main` (no PR). The mnemon code repo's git history + `CHANGELOG.md`
+remain the durable audit trail for the package itself.
 
 ## Stack
 


### PR DESCRIPTION
Corrects a stale, load-bearing line in the wind-down section.

It claimed `private/` is "gitignored — these doc edits are local-only (no commit)". That's been false since 2026-06-11: `private/` is its own nested git repo (`private/.git`) pushed to the private `cipher813/mnemon-ops`. The SYSTEM_STATE/ROADMAP edits made at wind-down **must** be committed + pushed there — the old wording risks a future session silently dropping them, the exact data-loss risk `mnemon-ops` was created to close. The loose `~/.claude/CLAUDE.md` was already corrected on 2026-06-11; this brings the per-repo doc in line.

Tracked as a near-term ROADMAP item (P3). Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
