### PR TITLE
ci: optional one-click Fly redeploy workflow (manual path stays primary)

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -1,0 +1,103 @@
+name: Deploy to Fly
+
+# OPTIONAL convenience for the repo owner — NOT a replacement for the
+# manual path. `mnemon upgrade web` (and a plain `flyctl deploy`) remain
+# the supported, fully-capable way to deploy mnemon for self-hosting and
+# for testing; see the "Self-host on Fly.io" section of README.md.
+#
+# This workflow just wraps the same `flyctl deploy` so the owner can roll
+# a merged change to their own Fly app with one click, no laptop/flyctl
+# needed. It is keyed entirely to the OWNER's deployment:
+#   - the target app comes from the `FLY_APP` repo variable (or the
+#     workflow_dispatch `app` input) — nothing is hardcoded, so a fork
+#     points it at its own app;
+#   - it authenticates with the `FLY_API_TOKEN` repo secret.
+# A fork that has set neither simply can't run it (manual dispatch only,
+# and the steps below fail loud if the app/token aren't wired). It never
+# runs on push, so forks' CI is untouched.
+#
+# Safe to run on every release: a redeploy preserves the Fly volume
+# (vault data) and existing Fly secrets — including the OAuth AS
+# passphrase, which is never rotated (the 0.7.3 fail-closed guard). It is
+# a pure image swap, the same as `mnemon upgrade web`'s redeploy path.
+
+on:
+  workflow_dispatch:
+    inputs:
+      app:
+        description: "Fly app name (overrides the FLY_APP repo variable)"
+        required: false
+        type: string
+
+concurrency:
+  group: fly-deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve app name + require token
+        id: cfg
+        env:
+          INPUT_APP: ${{ inputs.app }}
+          VAR_APP: ${{ vars.FLY_APP }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          APP="${INPUT_APP:-$VAR_APP}"
+          if [ -z "$APP" ]; then
+            echo "::error::No Fly app name. Set the FLY_APP repo variable or pass the 'app' input. (Manual 'mnemon upgrade web' remains available — see README.)"
+            exit 1
+          fi
+          if [ -z "$FLY_API_TOKEN" ]; then
+            echo "::error::FLY_API_TOKEN secret is not set. Wire it in repo settings to enable CI deploys; the manual path needs no secret."
+            exit 1
+          fi
+          echo "app=$APP" >> "$GITHUB_OUTPUT"
+
+      - name: Render fly.toml from the committed template
+        env:
+          APP: ${{ steps.cfg.outputs.app }}
+        run: |
+          # fly.toml is .gitignored (per-deploy); render it from the
+          # vendor-neutral fly.toml.example by filling in the app name.
+          sed "s/REPLACE_ME_fly_app_name/${APP}/g" fly.toml.example > fly.toml
+          echo "--- rendered fly.toml ---"
+          cat fly.toml
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          APP: ${{ steps.cfg.outputs.app }}
+        # --remote-only builds on Fly's builders (no Docker-in-CI). The
+        # deploy attaches to the existing volume + secrets; it does not
+        # set or rotate them.
+        run: flyctl deploy --config fly.toml --app "$APP" --remote-only
+
+      - name: Post-deploy health gate
+        env:
+          APP: ${{ steps.cfg.outputs.app }}
+        # Fail the run unless /health reports status=ok after the deploy,
+        # so a broken release surfaces here instead of silently going live.
+        # Generous retries cover the first-request FastEmbed model load.
+        run: |
+          URL="https://${APP}.fly.dev/health"
+          for i in $(seq 1 18); do
+            STATUS=$(curl -sf --max-time 35 -H "User-Agent: mnemon-ci-deploy/1" "$URL" \
+              | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || true)
+            if [ "$STATUS" = "ok" ]; then
+              echo "/health reported status=ok after deploy."
+              exit 0
+            fi
+            echo "waiting for /health (attempt $i/18)..."
+            sleep 10
+          done
+          echo "::error::/health did not report status=ok within the timeout after deploy."
+          exit 1

--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ mnemon upgrade web --app-name my-mnemon
 
 > **Upgrading from a pre-0.7.0rc10 deployment? Re-auth your browser connectors once.** Apps deployed before the OAuth Authorization Server was auto-provisioned only ever had the headless bearer token. The first `upgrade web` on such an app **provisions a brand-new OAuth passphrase** (and enables the AS) — so your existing claude.ai / Desktop / mobile connector login stops working until you re-authenticate. Grab the new passphrase from the deploy summary or `~/.mnemon/as_passphrase` and re-enter it on the connector's login page. This is a **one-time** transition: once the passphrase exists, every later redeploy leaves it untouched (it is never rotated). Headless clients (Claude Code, Cursor) are unaffected — they keep their bearer token.
 
+#### Optional: one-click redeploy from CI
+
+The commands above are the **supported, fully-capable** way to deploy — for self-hosting and for testing a change before trusting automation. If you maintain your own fork and want to roll merged changes without running `flyctl` locally, the repo ships an optional **`Deploy to Fly`** GitHub Actions workflow (`.github/workflows/deploy-fly.yml`). It only wraps the same `flyctl deploy` — it can't do anything you can't do by hand.
+
+It's a manual trigger (`workflow_dispatch`), never runs on push, and is keyed to *your* deployment, so it's inert in a fresh fork until you wire two things:
+
+1. **`FLY_API_TOKEN`** repo secret — `fly tokens create deploy` (Settings → Secrets → Actions).
+2. **`FLY_APP`** repo variable — your Fly app name (Settings → Variables → Actions). Or pass it as the `app` input when you trigger the run.
+
+Then trigger it from the **Actions** tab (or `gh workflow run "Deploy to Fly"`). It renders `fly.toml` from `fly.toml.example` for your app, runs `flyctl deploy --remote-only` (builds on Fly's builders), and fails the run unless `/health` reports `status=ok` afterward. A redeploy preserves your vault volume and secrets (including the OAuth passphrase, never rotated) — same as `upgrade web`'s redeploy path.
+
 ### Downgrade back to local
 
 ```bash
@@ -226,7 +237,7 @@ The extractor and handoff generator use LLM-based extraction when `mnemon[llm]` 
 
 ### Why a warm-keeper if Fly auto-stops?
 
-A self-hosted mnemon Fly app with `auto_stop_machines = "stop"` (the default in `fly.toml.example`) will autostop after a few minutes of idle. The warm-keeper resets Fly's idle timer on every prompt, so the machine stays warm during an active Claude Code session and only autostops once you've been idle for a while. Cost stays the same — Fly bills only running time — but you get reliable mid-session access without paying for an always-on machine. The `|| true` ensures a slow Fly cold-start never blocks your prompt.
+A self-hosted mnemon Fly app with autostop enabled (`fly.toml.example` defaults to `auto_stop_machines = "suspend"` — RAM-snapshot/resume in ~1s, so the OAuth token refresh on wake stays under the connector timeout) will idle the machine after a few minutes. The warm-keeper resets Fly's idle timer on every prompt, so the machine stays warm during an active Claude Code session and only autostops once you've been idle for a while. Cost stays the same — Fly bills only running time — but you get reliable mid-session access without paying for an always-on machine. The `|| true` ensures a slow Fly cold-start never blocks your prompt.
 
 ### What if a cold-stop happens anyway?
 


### PR DESCRIPTION
## What

Adds an **optional** one-click Fly redeploy workflow (`.github/workflows/deploy-fly.yml`, `workflow_dispatch`-only) so the repo owner can roll a merged change to their Fly app without running `flyctl` locally — the gap that made "redeploy Fly" a manual laptop step after each release.

## Strictly additive — manual path stays primary

`mnemon upgrade web` (and a plain `flyctl deploy`) remain the **supported, fully-capable** way to deploy, for self-hosting and for testing a change before trusting CI. They're documented first in the README; this workflow only wraps the same `flyctl deploy` and can't do anything you can't do by hand.

## Vendor-neutral — nothing baked into the public repo

- Target app from the **`FLY_APP` repo variable** (or the `app` dispatch input); `fly.toml` rendered from the committed, generic `fly.toml.example` (`fly.toml` itself stays gitignored).
- Authenticates with the **`FLY_API_TOKEN` repo secret**.
- **Never runs on push**, and fails loud if app/token aren't wired — so a fresh fork's CI is untouched and the workflow is inert until a maintainer opts in (two settings: the secret + the variable, documented in the README).

## Safe on every release

A redeploy attaches to the existing Fly volume (vault data) and existing secrets — including the OAuth AS passphrase, which is **never rotated** (0.7.3 fail-closed guard). It's a pure image swap, the same as `upgrade web`'s redeploy path. `--remote-only` builds on Fly's builders (no Docker-in-CI). A **post-deploy health gate** fails the run unless `/health` reports `status=ok`.

## Also

Fixes a stale README line that called `"stop"` the `fly.toml.example` autostop default — it's `"suspend"`.

## To enable on this repo

`FLY_API_TOKEN` secret already exists; set repo **variable** `FLY_APP=mnemon-memory` (I can set this once merged) and trigger from the Actions tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
