### PR TITLE
ci: auto-deploy to Fly on merge to main (fork-safe), keep manual dispatch

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -1,27 +1,34 @@
 name: Deploy to Fly
 
-# OPTIONAL convenience for the repo owner — NOT a replacement for the
-# manual path. `mnemon upgrade web` (and a plain `flyctl deploy`) remain
-# the supported, fully-capable way to deploy mnemon for self-hosting and
-# for testing; see the "Self-host on Fly.io" section of README.md.
+# Deploys mnemon to its Fly app. NOT a replacement for the manual path:
+# `mnemon upgrade web` (and a plain `flyctl deploy`) remain the supported,
+# fully-capable way to deploy for self-hosting and for testing; see the
+# "Self-host on Fly.io" section of README.md.
 #
-# This workflow just wraps the same `flyctl deploy` so the owner can roll
-# a merged change to their own Fly app with one click, no laptop/flyctl
-# needed. It is keyed entirely to the OWNER's deployment:
-#   - the target app comes from the `FLY_APP` repo variable (or the
-#     workflow_dispatch `app` input) — nothing is hardcoded, so a fork
-#     points it at its own app;
-#   - it authenticates with the `FLY_API_TOKEN` repo secret.
-# A fork that has set neither simply can't run it (manual dispatch only,
-# and the steps below fail loud if the app/token aren't wired). It never
-# runs on push, so forks' CI is untouched.
+# Triggers:
+#   - push to main  → AUTO-DEPLOY every merge (the owner wants zero clicks),
+#                     but ONLY on the canonical (non-fork) repo, so a fork's
+#                     CI is never touched by a push.
+#   - workflow_dispatch → manual one-click, available to anyone (incl. forks)
+#                     who has wired their own app + token.
 #
-# Safe to run on every release: a redeploy preserves the Fly volume
-# (vault data) and existing Fly secrets — including the OAuth AS
-# passphrase, which is never rotated (the 0.7.3 fail-closed guard). It is
-# a pure image swap, the same as `mnemon upgrade web`'s redeploy path.
+# Keyed entirely to the OWNER's deployment — nothing hardcoded:
+#   - target app from the `FLY_APP` repo variable (or the dispatch `app`
+#     input), so a fork points it at its own app;
+#   - authenticates with the `FLY_API_TOKEN` repo secret.
+# A fork without those can still dispatch it, and the steps fail loud if the
+# app/token aren't wired. The job is guarded so push-triggered runs skip
+# cleanly on forks (no red CI).
+#
+# Safe to run on every release: a redeploy preserves the Fly volume (vault
+# data) and existing Fly secrets — including the OAuth AS passphrase, which
+# is never rotated (the 0.7.3 fail-closed guard). It is a pure image swap,
+# the same as `mnemon upgrade web`'s redeploy path. The post-deploy /health
+# gate fails the run (red main) if a release comes up unhealthy.
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       app:
@@ -30,6 +37,8 @@ on:
         type: string
 
 concurrency:
+  # Serialize deploys; let an in-flight deploy finish rather than cancel it
+  # mid-`flyctl deploy`. Back-to-back merges queue and each rolls out.
   group: fly-deploy
   cancel-in-progress: false
 
@@ -39,6 +48,10 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Auto-deploy on push only on the canonical repo; a fork's pushes skip
+    # (so forks get no red CI). Manual dispatch is always allowed — that's
+    # how a fork deploys its own app.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.repository.fork == false }}
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -106,16 +106,21 @@ mnemon upgrade web --app-name my-mnemon
 
 > **Upgrading from a pre-0.7.0rc10 deployment? Re-auth your browser connectors once.** Apps deployed before the OAuth Authorization Server was auto-provisioned only ever had the headless bearer token. The first `upgrade web` on such an app **provisions a brand-new OAuth passphrase** (and enables the AS) — so your existing claude.ai / Desktop / mobile connector login stops working until you re-authenticate. Grab the new passphrase from the deploy summary or `~/.mnemon/as_passphrase` and re-enter it on the connector's login page. This is a **one-time** transition: once the passphrase exists, every later redeploy leaves it untouched (it is never rotated). Headless clients (Claude Code, Cursor) are unaffected — they keep their bearer token.
 
-#### Optional: one-click redeploy from CI
+#### Optional: deploy from CI
 
-The commands above are the **supported, fully-capable** way to deploy — for self-hosting and for testing a change before trusting automation. If you maintain your own fork and want to roll merged changes without running `flyctl` locally, the repo ships an optional **`Deploy to Fly`** GitHub Actions workflow (`.github/workflows/deploy-fly.yml`). It only wraps the same `flyctl deploy` — it can't do anything you can't do by hand.
+The commands above are the **supported, fully-capable** way to deploy — for self-hosting and for testing a change before trusting automation. The repo also ships an optional **`Deploy to Fly`** GitHub Actions workflow (`.github/workflows/deploy-fly.yml`) so you can roll merged changes without running `flyctl` locally. It only wraps the same `flyctl deploy` — it can't do anything you can't do by hand.
 
-It's a manual trigger (`workflow_dispatch`), never runs on push, and is keyed to *your* deployment, so it's inert in a fresh fork until you wire two things:
+It's keyed to *your* deployment, so it's inert in a fresh fork until you wire two things:
 
-1. **`FLY_API_TOKEN`** repo secret — `fly tokens create deploy` (Settings → Secrets → Actions).
-2. **`FLY_APP`** repo variable — your Fly app name (Settings → Variables → Actions). Or pass it as the `app` input when you trigger the run.
+1. **`FLY_API_TOKEN`** repo secret — `fly tokens create deploy -a <your-app>` (Settings → Secrets and variables → Actions → **Secrets**).
+2. **`FLY_APP`** repo variable — your Fly app name (same page → **Variables**). Or pass it as the `app` input on a manual run.
 
-Then trigger it from the **Actions** tab (or `gh workflow run "Deploy to Fly"`). It renders `fly.toml` from `fly.toml.example` for your app, runs `flyctl deploy --remote-only` (builds on Fly's builders), and fails the run unless `/health` reports `status=ok` afterward. A redeploy preserves your vault volume and secrets (including the OAuth passphrase, never rotated) — same as `upgrade web`'s redeploy path.
+Once wired, it runs two ways:
+
+- **Automatically on every push to `main`** (e.g. a merged PR) — zero clicks. This auto-deploy fires **only on the canonical, non-forked repo**, so forking the project never gives you red CI on merges.
+- **Manually** — from the **Actions** tab, or `gh workflow run "Deploy to Fly"` (this path works on forks too).
+
+Either way it renders `fly.toml` from `fly.toml.example` for your app, runs `flyctl deploy --remote-only` (builds on Fly's builders), and fails the run unless `/health` reports `status=ok` afterward. A redeploy preserves your vault volume and secrets (including the OAuth passphrase, never rotated) — same as `upgrade web`'s redeploy path. Don't want auto-deploy? Remove the `push:` trigger from the workflow and it reverts to manual-only.
 
 ### Downgrade back to local
 


### PR DESCRIPTION
## What

Makes the Fly deploy **fully automatic on merge to `main`** — no buttons. Adds a `push: [main]` trigger to the `Deploy to Fly` workflow.

## Fork-safe

Auto-deploy on push is guarded to fire **only on the canonical, non-forked repo** (`github.event.repository.fork == false`), so forking the project never produces red CI on merges. `workflow_dispatch` stays available to anyone — including forks — who has wired their own `FLY_APP` + `FLY_API_TOKEN`. (No repo name is hardcoded; the fork check is generic.)

## Unchanged

- Vendor-neutral: app from the `FLY_APP` repo variable, `fly.toml` rendered from `fly.toml.example`.
- `flyctl deploy --remote-only` + a **post-deploy `/health` gate** (a bad release reds `main`).
- Redeploy preserves the Fly volume + secrets (OAuth passphrase never rotated).
- `mnemon upgrade web` remains the supported manual/OSS path; README updated. Opt out anytime by removing the `push:` trigger.

## Note

Merging this PR will itself trigger the first auto-deploy (rolls current `main` = 0.7.8) — a harmless idempotent redeploy that also validates the auto path live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
