### PR TITLE
ci: retry flyctl deploy with backoff so transient Fly timeouts don't red main

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -92,7 +92,36 @@ jobs:
         # --remote-only builds on Fly's builders (no Docker-in-CI). The
         # deploy attaches to the existing volume + secrets; it does not
         # set or rotate them.
-        run: flyctl deploy --config fly.toml --app "$APP" --remote-only
+        #
+        # Retry with backoff: `flyctl deploy` occasionally fails on a
+        # transient Fly-side hiccup — e.g. a token-verify timeout
+        # ("token validation error: ... context deadline exceeded", seen
+        # on the first auto-deploy 2026-06-15) — unrelated to the image or
+        # config. The deploy is idempotent (reconciles the app to the
+        # target image), so retrying is safe; a genuine failure (bad token,
+        # broken build) just exhausts the attempts and reds the run, as it
+        # should. Without this, a flaky Fly timeout reds `main` on an
+        # otherwise-good merge.
+        run: |
+          set +e
+          attempts=3
+          for i in $(seq 1 "$attempts"); do
+            echo "::group::flyctl deploy (attempt $i/$attempts)"
+            flyctl deploy --config fly.toml --app "$APP" --remote-only
+            code=$?
+            echo "::endgroup::"
+            if [ "$code" -eq 0 ]; then
+              exit 0
+            fi
+            echo "deploy attempt $i failed (exit $code)"
+            if [ "$i" -lt "$attempts" ]; then
+              backoff=$((i * 20))
+              echo "retrying in ${backoff}s..."
+              sleep "$backoff"
+            fi
+          done
+          echo "::error::flyctl deploy failed after ${attempts} attempts."
+          exit 1
 
       - name: Post-deploy health gate
         env:


### PR DESCRIPTION
## What

Hardens the `Deploy to Fly` workflow against transient `flyctl deploy` failures — the P2 follow-up from the first auto-deploy.

## Why

The first auto-deploy-on-merge (2026-06-15) transient-failed on a Fly token-verification timeout:

```
Error: authenticate: token validation error: ... verify: context deadline exceeded
```

Not a token/config issue — a `workflow_dispatch` deploy had succeeded minutes earlier with the same token. It's a flaky Fly auth-service timeout that reds `main` on an otherwise-good merge.

## Fix

Wrap the deploy in a **3-attempt retry with 20s/40s backoff**. `flyctl deploy` is idempotent (it reconciles the app to the target image), so retrying is safe; a genuine failure (bad token, broken build) still exhausts the attempts and reds the run as it should.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
