### PR TITLE
ci: install flyctl via retried official script (harden transient-download 503)

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -83,7 +83,26 @@ jobs:
           echo "--- rendered fly.toml ---"
           cat fly.toml
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Install flyctl (retried)
+        # Replaces `superfly/flyctl-actions/setup-flyctl@master`: that action
+        # downloads the flyctl binary from a GitHub/Fly CDN, which 503'd on a
+        # transient hiccup 2026-06-15 — and a `uses:` step can't be retried.
+        # Installing via the official script in a retry loop hardens that
+        # transient-download failure mode (companion to the deploy retry
+        # below). A genuine failure still exhausts the attempts and reds.
+        run: |
+          set +e
+          for i in 1 2 3; do
+            curl -fsSL https://fly.io/install.sh | sh && break
+            echo "flyctl install attempt $i failed; retrying in $((i * 10))s..."
+            sleep $((i * 10))
+          done
+          if [ ! -x "$HOME/.fly/bin/flyctl" ]; then
+            echo "::error::flyctl install failed after 3 attempts."
+            exit 1
+          fi
+          echo "$HOME/.fly/bin" >> "$GITHUB_PATH"
+          "$HOME/.fly/bin/flyctl" version
 
       - name: Deploy
         env:


### PR DESCRIPTION
## What

Hardens the `Deploy to Fly` workflow against the transient **`503` on the flyctl download** that failed the #227 merge auto-deploy at the `setup-flyctl` step.

## Why this, not an org token

The failures this afternoon were transient Fly/GitHub infra (token-verify timeout, then a 503 download) — not a config/token problem (the 14:40 dispatch deployed cleanly with the current token). The institutional fix is **resilience to transient infra + least privilege**, not broader credentials. So this keeps the app-scoped `FLY_API_TOKEN` (least privilege) and makes the workflow robust.

## Change

`superfly/flyctl-actions/setup-flyctl@master` downloads the flyctl binary from a CDN that 503'd — and a `uses:` step can't be retried. Replaced it with the **official install script wrapped in a 3-attempt retry+backoff**, so a transient download hiccup no longer reds `main`. Companion to the deploy-step retry (#226). A genuine failure still exhausts attempts and reds.

After merge (or a dispatch from this branch) the deploy re-tests end-to-end via the post-deploy `/health` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
