### PR TITLE
docs: fix stale context_surfacing docstring (it emits a warning banner, not silent)

### DIFF
--- a/src/mnemon/hooks/context_surfacing.py
+++ b/src/mnemon/hooks/context_surfacing.py
@@ -12,9 +12,12 @@ Pipeline:
   4. Write the context to stdout for Claude Code to inject
 
 On any network/auth/timeout/config error the hook degrades gracefully:
-logs to stderr and exits 0 without emitting context. It never crashes
-Claude Code — the hook is best-effort augmentation, not a load-bearing
-data path.
+it logs to stderr AND emits a visible ``<mnemon-context>`` warning banner
+(``⚠ mnemon unavailable: …`` / ``⚠ mnemon config error: …``) so the
+unreachable state is surfaced on every affected prompt — never a silent
+empty/missing block indistinguishable from "no relevant memories". It
+always exits 0 and never crashes Claude Code — the hook is best-effort
+augmentation, not a load-bearing data path.
 
 Phase 3 unification: this hook no longer touches the local SQLite vault.
 All memory reads flow to the Fly vault via :mod:`mnemon.hooks._remote_client`.


### PR DESCRIPTION
Corrects the `context_surfacing.py` module docstring, which claimed the hook "logs to stderr and exits 0 **without emitting context**" on error.

That's stale — `main()` actually emits a visible `<mnemon-context>` warning banner (`⚠ mnemon unavailable: …` / `⚠ mnemon config error: …`) when the mnemon server is unreachable, so the down-state is surfaced on every affected prompt instead of looking like "no relevant memories." The behavior is test-covered (`test_hooks_extended.py` asserts the banners are injected). This just makes the docstring match.

Surfaced while answering "can we flag when the Fly server is down?" — turns out we already do. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
