### PR TITLE
chore(hooks): raise context-surfacing SEARCH_LIMIT 8→12

### DIFF
--- a/src/mnemon/hooks/context_surfacing.py
+++ b/src/mnemon/hooks/context_surfacing.py
@@ -44,7 +44,12 @@ CHAR_BUDGET = HOOK_CHAR_BUDGET
 SLOW_THRESHOLD_SEC = HOOK_SLOW_THRESHOLD_SEC
 
 CLIENT_LABEL = "claude-code-context-surfacing"
-SEARCH_LIMIT = 8
+# Situational-recall breadth per prompt. Raised 8→12 (2026-06-22): the Claude
+# Code file-memory index (MEMORY.md) is now deliberately lean (current-state +
+# standing rules only, ~20KB), with the long tail de-indexed to MEMORY_ARCHIVE
+# and left to mnemon recall — so wider per-prompt recall is the intended
+# compensation. Standing-tier breadth is governed separately (capped ~15).
+SEARCH_LIMIT = 12
 
 # Snippet size injected per result — matches the pre-0.5.0 server-side
 # truncation so context block size stays bounded independent of vault

--- a/tests/test_hooks_extended.py
+++ b/tests/test_hooks_extended.py
@@ -593,7 +593,7 @@ class TestSpotlightEnvelope:
 
 class TestContextSurfacingMain:
     def test_full_pipeline_calls_remote_and_emits_context(self):
-        from mnemon.hooks.context_surfacing import main
+        from mnemon.hooks.context_surfacing import SEARCH_LIMIT, main
 
         raw_tool_output = json.dumps([{
             "doc_id": 42, "title": "Pipeline",
@@ -627,7 +627,7 @@ class TestContextSurfacingMain:
         assert call_args[0][0] == "memory_search"
         assert call_args[0][1] == {
             "query": "how does the pipeline work?",
-            "limit": 8,
+            "limit": SEARCH_LIMIT,
         }
         # Client label makes attribution possible in server-side logs.
         assert call_args.kwargs.get("client_label") == "claude-code-context-surfacing"


### PR DESCRIPTION
Widen per-prompt situational recall in the Claude Code context-surfacing hook from **8 → 12** results.

**Why:** the Claude Code file-memory index (`MEMORY.md`) was just curated down to a lean ~20KB always-loaded working set (current-state + standing rules), with the long tail de-indexed to a new `MEMORY_ARCHIVE.md` and left to mnemon recall. Wider per-prompt situational recall is the intended compensation so relevant tail memories still surface even though they are no longer in the always-loaded file index. Standing-tier breadth is governed separately (capped ~15).

**Change:** `SEARCH_LIMIT = 8 → 12` in `hooks/context_surfacing.py`; the one test that pinned the value now references the constant instead of a literal so it cannot drift again.

**Tests:** 196 hook + standing-tier tests pass. (The unrelated `test_oauth_as.py` rate-limit failures are pre-existing on `main` in the local env — CI green there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)